### PR TITLE
fix: read RabbitMQ and WebSocket health targets via config instead of env

### DIFF
--- a/backend/app/Services/HealthCheckService.php
+++ b/backend/app/Services/HealthCheckService.php
@@ -25,12 +25,12 @@ class HealthCheckService implements HealthCheckServiceInterface
             'redis'     => $this->checkRedis(),
             'fdw'       => $this->checkFdw(),
             'rabbitmq'  => $this->checkTcp(
-                (string) env('RABBITMQ_HOST', 'localhost'),
-                (int) env('RABBITMQ_PORT', 5672),
+                (string) config('services.rabbitmq.host'),
+                (int) config('services.rabbitmq.port'),
             ),
             'websocket' => $this->checkTcp(
-                (string) env('REVERB_HOST', 'localhost'),
-                (int) env('REVERB_PORT', 8082),
+                (string) config('services.health.websocket_host'),
+                (int) config('services.health.websocket_port'),
             ),
         ];
 

--- a/backend/config/services.php
+++ b/backend/config/services.php
@@ -35,4 +35,14 @@ return [
         ],
     ],
 
+    'rabbitmq' => [
+        'host' => env('RABBITMQ_HOST', 'localhost'),
+        'port' => (int) env('RABBITMQ_PORT', 5672),
+    ],
+    
+    'health' => [
+        'websocket_host' => env('REVERB_HOST', 'localhost'),
+        'websocket_port' => (int) env('REVERB_PORT', 8082),
+    ],
+
 ];


### PR DESCRIPTION
- Se añaden en config/services.php las claves services.rabbitmq (host, port) y services.health (websocket_host, websocket_port), leyendo RABBITMQ_*, REVERB_HOST y REVERB_PORT con los mismos valores por defecto.
- Se sustituyen las llamadas a env() en HealthCheckService::checkAll() por config('services.rabbitmq.*') y config('services.health.*') para que, tras php artisan config:cache, los checks TCP sigan resolviendo host y puerto correctamente.