### PR TITLE
Feature/f 01.3 so d policies

### DIFF
--- a/backend/app/Http/Controllers/Api/DocumentController.php
+++ b/backend/app/Http/Controllers/Api/DocumentController.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Document;
+use App\Services\Contracts\DocumentServiceInterface;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class DocumentController extends Controller
+{
+    public function __construct(
+        private readonly DocumentServiceInterface $documentService,
+    ) {}
+
+    /**
+     * Listar documentos.
+     */
+    public function index(Request $request): JsonResponse
+    {
+        // TODO: listar documentos (filtros, paginación)
+
+        return response()->json(['data' => []]);
+    }
+
+    /**
+     * Crear documento.
+     */
+    public function store(Request $request): JsonResponse
+    {
+        // TODO: DocumentService::create(...)
+
+        return response()->json(['message' => 'Not implemented'], 501);
+    }
+
+    /**
+     * Mostrar documento.
+     */
+    public function show(Document $document): JsonResponse
+    {
+        // TODO: DocumentResource
+
+        return response()->json(['data' => $document]);
+    }
+
+    /**
+     * Actualizar documento.
+     */
+    public function update(Request $request, Document $document): JsonResponse
+    {
+        // TODO: DocumentService::update(...)
+
+        return response()->json(['message' => 'Not implemented'], 501);
+    }
+
+    /**
+     * Eliminar documento.
+     */
+    public function destroy(Document $document): JsonResponse
+    {
+        // TODO: borrado lógico / política propia
+
+        return response()->json(['message' => 'Not implemented'], 501);
+    }
+
+    /**
+     * Enviar documento a revisión.
+     */
+    public function submit(Request $request, Document $document): JsonResponse
+    {
+        $this->authorize('submit', $document);
+
+        $actorId = $request->user()->getAuthIdentifier();
+        $updated = $this->documentService->submitToReview($document->id, $actorId);
+
+        return response()->json(['data' => $updated]);
+    }
+
+    /**
+     * Publicar documento.
+     */
+    public function publish(Request $request, Document $document): JsonResponse
+    {
+        $this->authorize('review', $document);
+
+        $actorId = $request->user()->getAuthIdentifier();
+        $updated = $this->documentService->publishDocument($document->id, $actorId);
+
+        return response()->json(['data' => $updated]);
+    }
+
+    /**
+     * Rechazar documento y vuelta a borrador.
+     */
+    public function reject(Request $request, Document $document): JsonResponse
+    {
+        $this->authorize('review', $document);
+
+        $actorId = $request->user()->getAuthIdentifier();
+        $updated = $this->documentService->rejectDocument($document->id, $actorId);
+
+        return response()->json(['data' => $updated]);
+    }
+
+    /**
+     * Delegar documento a otro usuario.
+     */
+    public function delegate(Request $request, Document $document): JsonResponse
+    {
+        $validated = $request->validate([
+            'new_owner_id' => ['required', 'string'],
+        ]);
+
+        $actorId = $request->user()->getAuthIdentifier();
+        $updated = $this->documentService->delegateOwner(
+            $document->id,
+            $validated['new_owner_id'],
+            $actorId,
+        );
+
+        return response()->json(['data' => $updated]);
+    }
+}

--- a/backend/app/Http/Controllers/Api/ReviewController.php
+++ b/backend/app/Http/Controllers/Api/ReviewController.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Document;
+use App\Models\DocumentReview;
+use App\Services\Contracts\DocumentServiceInterface;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class ReviewController extends Controller
+{
+    public function __construct(
+        private readonly DocumentServiceInterface $documentService,
+    ) {}
+
+    /**
+     * Listar revisiones de un documento.
+     */
+    public function index(Request $request, Document $document): JsonResponse
+    {
+        $this->authorize('review', $document);
+
+        $reviews = $this->documentService->listReviews($document->id);
+
+        return response()->json(['data' => $reviews]);
+    }
+
+    /**
+     * Aprobar revisión de un documento.
+     */
+    public function approve(Request $request, Document $document, DocumentReview $review): JsonResponse
+    {
+        $this->authorize('review', $document);
+
+        if ($review->document_id !== $document->id) {
+            abort(404);
+        }
+
+        $actorId = $request->user()->getAuthIdentifier();
+        $updated = $this->documentService->approveReview($document->id, $review->id, $actorId);
+
+        return response()->json(['data' => $updated]);
+    }
+
+    /**
+     * Rechazar revisión de un documento.
+     */
+    public function reject(Request $request, Document $document, DocumentReview $review): JsonResponse
+    {
+        $this->authorize('review', $document);
+
+        if ($review->document_id !== $document->id) {
+            abort(404);
+        }
+
+        $validated = $request->validate([
+            'rejection_reason' => ['nullable', 'string'],
+        ]);
+
+        $actorId = $request->user()->getAuthIdentifier();
+        $updated = $this->documentService->rejectReview(
+            $document->id,
+            $review->id,
+            $actorId,
+            $validated['rejection_reason'] ?? null,
+        );
+
+        return response()->json(['data' => $updated]);
+    }
+}

--- a/backend/app/Http/Controllers/Api/TemplateController.php
+++ b/backend/app/Http/Controllers/Api/TemplateController.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Template;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class TemplateController extends Controller
+{
+    /**
+     * Listar plantillas.
+     */
+    public function index(Request $request): JsonResponse
+    {
+        // TODO: filtros, paginación, TemplateService
+
+        return response()->json(['data' => []]);
+    }
+
+    /**
+     * Crear plantilla.
+     */
+    public function store(Request $request): JsonResponse
+    {
+        // TODO: TemplateService::create(...)
+
+        return response()->json(['message' => 'Not implemented'], 501);
+    }
+
+    /**
+     * Mostrar plantilla.
+     */
+    public function show(Template $template): JsonResponse
+    {
+        // TODO: TemplateResource
+
+        return response()->json(['data' => $template]);
+    }
+
+    /**
+     * Actualizar plantilla.
+     * La publicación de una plantilla no puede hacerlo el creador; exige otro actor autorizado vía {@see TemplatePolicy::review}.
+     */
+    public function update(Request $request, Template $template): JsonResponse
+    {
+        $validated = $request->validate([
+            'name'            => ['sometimes', 'string', 'max:255'],
+            'description'     => ['sometimes', 'nullable', 'string'],
+            'study_id'        => ['sometimes', 'nullable', 'string'],
+            'organization_id' => ['sometimes', 'nullable', 'string'],
+            'status'          => ['sometimes', 'string', 'in:draft,published,archived'],
+            'review_stages'   => ['sometimes', 'integer', 'min:0'],
+            'review_mode'     => ['sometimes', 'string', 'in:sequential,parallel'],
+        ]);
+
+        $targetStatus = $validated['status'] ?? $template->status;
+
+        if ($targetStatus === 'published' && $template->status !== 'published') {
+            $this->authorize('review', $template);
+        }
+
+        // TODO: TemplateService::update(...)
+
+        return response()->json(['message' => 'Not implemented'], 501);
+    }
+
+    /**
+     * Eliminar plantilla.
+     */
+    public function destroy(Template $template): JsonResponse
+    {
+        // TODO: borrado lógico / política propia
+
+        return response()->json(['message' => 'Not implemented'], 501);
+    }
+}

--- a/backend/app/Http/Controllers/Controller.php
+++ b/backend/app/Http/Controllers/Controller.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Controllers;
 
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+
 abstract class Controller
 {
-    //
+    use AuthorizesRequests;
 }

--- a/backend/app/Listeners/RecordSegregationOfDutiesDenial.php
+++ b/backend/app/Listeners/RecordSegregationOfDutiesDenial.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Models\Document;
+use App\Models\Template;
+use App\Services\Contracts\AuditLogServiceInterface;
+use Illuminate\Auth\Access\Events\GateEvaluated;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Registra en audit_log (y deja traza en log de aplicación) cuando una política SoD
+ * deniega explícitamente {@see DocumentPolicy} / {@see TemplatePolicy}.
+ */
+class RecordSegregationOfDutiesDenial
+{
+    private const ABILITIES = ['review', 'submit'];
+
+    public function __construct(
+        private readonly AuditLogServiceInterface $auditLogService,
+    ) {}
+
+    public function handle(GateEvaluated $event): void
+    {
+        if ($event->result !== false) {
+            return;
+        }
+
+        if (! in_array($event->ability, self::ABILITIES, true)) {
+            return;
+        }
+
+        $user = $event->user;
+        if (! $user instanceof Authenticatable) {
+            return;
+        }
+
+        $subject = $event->arguments[0] ?? null;
+
+        $entityType = match (true) {
+            $subject instanceof Document => 'document',
+            $subject instanceof Template   => 'template',
+            default                        => null,
+        };
+
+        if ($entityType === null || ! $subject->getKey()) {
+            return;
+        }
+
+        $userId = $user->getAuthIdentifier();
+        if ($userId === null || $userId === '') {
+            return;
+        }
+
+        $request = request();
+
+        Log::warning('SoD policy denied', [
+            'ability'      => $event->ability,
+            'entity_type'  => $entityType,
+            'entity_id'    => (string) $subject->getKey(),
+            'user_id'      => $userId,
+        ]);
+
+        try {
+            $this->auditLogService->record(
+                entityType:    $entityType,
+                entityId:      (string) $subject->getKey(),
+                action:        'sod_violation',
+                userId:        (string) $userId,
+                blockUuid:     null,
+                previousValue: null,
+                newValue:      [
+                    'ability' => $event->ability,
+                    'level'   => 'WARNING',
+                    'reason'  => 'segregation_of_duties',
+                ],
+                ipAddress:     $request?->ip(),
+                userAgent:     $request?->userAgent(),
+            );
+        } catch (\Throwable $e) {
+            Log::error('Failed to persist SoD audit entry', [
+                'exception' => $e->getMessage(),
+            ]);
+        }
+    }
+}

--- a/backend/app/Policies/DocumentPolicy.php
+++ b/backend/app/Policies/DocumentPolicy.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Document;
+use App\Models\JwtUser;
+
+/**
+ * Segregación de funciones (SoD) en documentos.
+ *
+ * Creador y titular actual (owner tras delegación) no pueden revisar ni aprobar
+ * el mismo artefacto. Solo comparación de IDs en memoria — sin consultas extra.
+ */
+class DocumentPolicy
+{
+    /**
+     * Revisión / aprobación / rechazo del documento en flujo de revisión.
+     */
+    public function review(JwtUser $user, Document $document): bool
+    {
+        return ! $this->violatesSegregation($user, $document);
+    }
+
+    /**
+     * Envío a revisión (p. ej. transición draft → in_review).
+     */
+    public function submit(JwtUser $user, Document $document): bool
+    {
+        return ! $this->violatesSegregation($user, $document);
+    }
+
+    private function violatesSegregation(JwtUser $user, Document $document): bool
+    {
+        $id = $user->getAuthIdentifier();
+
+        return $id === $document->created_by || $id === $document->owner_id;
+    }
+}

--- a/backend/app/Policies/TemplatePolicy.php
+++ b/backend/app/Policies/TemplatePolicy.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\JwtUser;
+use App\Models\Template;
+
+/**
+ * Segregación de funciones (SoD) en plantillas.
+ *
+ * El creador de la plantilla no puede actuar como revisor/aprobador del mismo artefacto.
+ */
+class TemplatePolicy
+{
+    /**
+     * Revisión / aprobación en el flujo de plantilla.
+     */
+    public function review(JwtUser $user, Template $template): bool
+    {
+        return $user->getAuthIdentifier() !== $template->created_by;
+    }
+}

--- a/backend/app/Providers/AppServiceProvider.php
+++ b/backend/app/Providers/AppServiceProvider.php
@@ -12,7 +12,11 @@ use App\Repositories\Eloquent\CommentRepository;
 use App\Repositories\Eloquent\DocumentRepository;
 use App\Repositories\Eloquent\TemplateRepository;
 use App\Repositories\Eloquent\UserProfileRepository;
+use App\Models\Document;
 use App\Models\JwtUser;
+use App\Models\Template;
+use App\Policies\DocumentPolicy;
+use App\Policies\TemplatePolicy;
 use App\Services\Contracts\AuditLogServiceInterface;
 use App\Services\Contracts\DocumentServiceInterface;
 use App\Services\Contracts\HealthCheckServiceInterface;
@@ -26,6 +30,7 @@ use App\Services\JwksService;
 use App\Services\TemplateService;
 use App\Services\UserProfileService;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\ServiceProvider;
 
 
@@ -58,5 +63,9 @@ class AppServiceProvider extends ServiceProvider
             $profile = $request->attributes->get('jwt_user');
             return $profile ? new JwtUser($profile) : null;
         });
+
+        // Registro de políticas
+        Gate::policy(Document::class, DocumentPolicy::class);
+        Gate::policy(Template::class, TemplatePolicy::class);
     }
 }

--- a/backend/app/Repositories/Contracts/DocumentRepositoryInterface.php
+++ b/backend/app/Repositories/Contracts/DocumentRepositoryInterface.php
@@ -3,6 +3,8 @@
 namespace App\Repositories\Contracts;
 
 use App\Models\Document;
+use App\Models\DocumentReview;
+use Illuminate\Support\Collection;
 
 interface DocumentRepositoryInterface
 {
@@ -16,4 +18,27 @@ interface DocumentRepositoryInterface
      * del documento. Usado para control de acceso al historial de auditoría.
      */
     public function isAuthorOrReviewer(string $documentId, string $userId): bool;
+
+    /**
+     * Revisiones del documento ordenadas por etapa.
+     *
+     * @return Collection<int, DocumentReview>
+     */
+    public function listReviewsForDocument(string $documentId): Collection;
+
+    /**
+     * Busca una revisión por ID si pertenece al documento indicado.
+     */
+    public function findReviewInDocument(string $reviewId, string $documentId): ?DocumentReview;
+
+    public function deleteReviewsForDocument(string $documentId): void;
+
+    /**
+     * @param  list<array{reviewer_id: string, stage: int}>  $rows
+     */
+    public function createPendingReviews(string $documentId, array $rows): void;
+
+    public function countPendingReviewsForDocument(string $documentId): int;
+
+    public function saveReview(DocumentReview $review): void;
 }

--- a/backend/app/Repositories/Eloquent/DocumentRepository.php
+++ b/backend/app/Repositories/Eloquent/DocumentRepository.php
@@ -3,14 +3,84 @@
 namespace App\Repositories\Eloquent;
 
 use App\Models\Document;
+use App\Models\DocumentReview;
 use App\Repositories\Contracts\DocumentRepositoryInterface;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
 
 class DocumentRepository implements DocumentRepositoryInterface
 {
+    /**
+     * Busca un documento por su ID o lanza ModelNotFoundException.
+     */
     public function findOrFail(string $id): Document
     {
         return Document::findOrFail($id);
+    }
+
+    /**
+     * Listado de revisiones del documento ordenadas por etapa.
+     */
+    public function listReviewsForDocument(string $documentId): Collection
+    {
+        return DocumentReview::query()
+            ->where('document_id', $documentId)
+            ->orderBy('stage')
+            ->get();
+    }
+
+    /**
+     * Busca una revisión por ID si pertenece al documento indicado.
+     */
+    public function findReviewInDocument(string $reviewId, string $documentId): ?DocumentReview
+    {
+        return DocumentReview::query()
+            ->where('id', $reviewId)
+            ->where('document_id', $documentId)
+            ->first();
+    }
+
+    /**
+     * Elimina todas las revisiones de un documento.
+     */
+    public function deleteReviewsForDocument(string $documentId): void
+    {
+        DocumentReview::query()->where('document_id', $documentId)->delete();
+    }
+
+    /**
+     * Crea revisiones pendientes para un documento.
+     *
+     * @param  list<array{reviewer_id: string, stage: int}>  $rows
+     */
+    public function createPendingReviews(string $documentId, array $rows): void
+    {
+        foreach ($rows as $row) {
+            DocumentReview::forceCreate([
+                'id'            => (string) Str::uuid(),
+                'document_id'   => $documentId,
+                'reviewer_id'   => $row['reviewer_id'],
+                'stage'         => $row['stage'],
+                'status'        => 'pending',
+            ]);
+        }
+    }
+
+    /**
+     * Cuenta las revisiones pendientes de un documento.
+     */
+    public function countPendingReviewsForDocument(string $documentId): int
+    {
+        return DocumentReview::query()
+            ->where('document_id', $documentId)
+            ->where('status', 'pending')
+            ->count();
+    }
+
+    public function saveReview(DocumentReview $review): void
+    {
+        $review->save();
     }
 
     public function isAuthorOrReviewer(string $documentId, string $userId): bool

--- a/backend/app/Services/Contracts/DocumentServiceInterface.php
+++ b/backend/app/Services/Contracts/DocumentServiceInterface.php
@@ -3,11 +3,32 @@
 namespace App\Services\Contracts;
 
 use App\Models\Document;
+use App\Models\DocumentReview;
+use Illuminate\Support\Collection;
 
 interface DocumentServiceInterface
 {
     /**
      * Transiciona el documento a un nuevo estado y emite el evento de dominio DocumentStateChanged.
+     *
+     * @param  array<string, mixed>  $extraAttributes
      */
-    public function transition(string $documentId, string $newStatus, string $actorId): Document;
+    public function transition(string $documentId, string $newStatus, string $actorId, array $extraAttributes = []): Document;
+
+    public function submitToReview(string $documentId, string $actorId): Document;
+
+    public function publishDocument(string $documentId, string $actorId): Document;
+
+    public function rejectDocument(string $documentId, string $actorId): Document;
+
+    public function delegateOwner(string $documentId, string $newOwnerId, string $actorId): Document;
+
+    /**
+     * @return Collection<int, DocumentReview>
+     */
+    public function listReviews(string $documentId): Collection;
+
+    public function approveReview(string $documentId, string $reviewId, string $actorId): Document;
+
+    public function rejectReview(string $documentId, string $reviewId, string $actorId, ?string $reason = null): Document;
 }

--- a/backend/app/Services/DocumentService.php
+++ b/backend/app/Services/DocumentService.php
@@ -6,6 +6,9 @@ use App\Events\DocumentStateChanged;
 use App\Models\Document;
 use App\Repositories\Contracts\DocumentRepositoryInterface;
 use App\Services\Contracts\DocumentServiceInterface;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
 
 class DocumentService implements DocumentServiceInterface
 {
@@ -14,22 +17,209 @@ class DocumentService implements DocumentServiceInterface
     ) {}
 
     /**
-     * Transiciona el documento a un nuevo estado y emite DocumentStateChanged.
+     * @param  array<string, mixed>  $extraAttributes
      */
-    public function transition(string $documentId, string $newStatus, string $actorId): Document
+    public function transition(string $documentId, string $newStatus, string $actorId, array $extraAttributes = []): Document
     {
         $document  = $this->documentRepository->findOrFail($documentId);
         $oldStatus = $document->status;
 
-        $document->update(['status' => $newStatus]);
+        $document->update(array_merge(['status' => $newStatus], $extraAttributes));
 
         event(new DocumentStateChanged(
-            document:  $document,
+            document:  $document->fresh(),
             oldStatus: $oldStatus,
             newStatus: $newStatus,
             actorId:   $actorId,
         ));
 
-        return $document;
+        return $document->fresh();
+    }
+
+    public function submitToReview(string $documentId, string $actorId): Document
+    {
+        $document = $this->documentRepository->findOrFail($documentId);
+
+        if ($document->status !== 'draft') {
+            throw ValidationException::withMessages([
+                'status' => ['Solo los documentos en borrador pueden enviarse a revisión.'],
+            ]);
+        }
+
+        return DB::transaction(function () use ($documentId, $actorId, $document) {
+            $this->documentRepository->deleteReviewsForDocument($documentId);
+
+            $document->loadMissing('template.reviewers');
+
+            $document = $this->transition($documentId, 'in_review', $actorId, [
+                'submitted_at' => now(),
+            ]);
+
+            $rows = $document->template?->reviewers
+                ?->sortBy('stage')
+                ->map(fn ($r) => [
+                    'reviewer_id' => $r->user_id,
+                    'stage'       => $r->stage,
+                ])
+                ->values()
+                ->all() ?? [];
+
+            if ($rows !== []) {
+                $this->documentRepository->createPendingReviews($documentId, $rows);
+            }
+
+            return $document;
+        });
+    }
+
+    public function publishDocument(string $documentId, string $actorId): Document
+    {
+        $document = $this->documentRepository->findOrFail($documentId);
+
+        if ($document->status !== 'in_review') {
+            throw ValidationException::withMessages([
+                'status' => ['Solo se puede publicar un documento en revisión.'],
+            ]);
+        }
+
+        if ($this->documentRepository->countPendingReviewsForDocument($documentId) > 0) {
+            throw ValidationException::withMessages([
+                'reviews' => ['Quedan revisiones pendientes.'],
+            ]);
+        }
+
+        return $this->transition($documentId, 'published', $actorId, [
+            'published_at' => now(),
+        ]);
+    }
+
+    public function rejectDocument(string $documentId, string $actorId): Document
+    {
+        $document = $this->documentRepository->findOrFail($documentId);
+
+        if (! in_array($document->status, ['in_review', 'published'], true)) {
+            throw ValidationException::withMessages([
+                'status' => ['Solo se puede rechazar un documento en revisión o publicado.'],
+            ]);
+        }
+
+        return DB::transaction(function () use ($documentId, $actorId) {
+            $this->documentRepository->deleteReviewsForDocument($documentId);
+
+            return $this->transition($documentId, 'draft', $actorId, [
+                'submitted_at' => null,
+                'published_at' => null,
+            ]);
+        });
+    }
+
+    public function delegateOwner(string $documentId, string $newOwnerId, string $actorId): Document
+    {
+        $document = $this->documentRepository->findOrFail($documentId);
+
+        if ($document->owner_id !== $actorId) {
+            throw ValidationException::withMessages([
+                'owner' => ['Solo el titular actual puede delegar el documento.'],
+            ]);
+        }
+
+        if ($newOwnerId === $document->owner_id) {
+            throw ValidationException::withMessages([
+                'new_owner_id' => ['El nuevo titular debe ser distinto del actual.'],
+            ]);
+        }
+
+        $document->update(['owner_id' => $newOwnerId]);
+
+        return $document->fresh();
+    }
+
+    public function listReviews(string $documentId): Collection
+    {
+        $this->documentRepository->findOrFail($documentId);
+
+        return $this->documentRepository->listReviewsForDocument($documentId);
+    }
+
+    public function approveReview(string $documentId, string $reviewId, string $actorId): Document
+    {
+        return DB::transaction(function () use ($documentId, $reviewId, $actorId) {
+            $document = $this->documentRepository->findOrFail($documentId);
+
+            if ($document->status !== 'in_review') {
+                throw ValidationException::withMessages([
+                    'status' => ['Las revisiones solo aplican a documentos en revisión.'],
+                ]);
+            }
+
+            $review = $this->documentRepository->findReviewInDocument($reviewId, $documentId);
+
+            if ($review === null) {
+                abort(404);
+            }
+
+            if ($review->reviewer_id !== $actorId) {
+                abort(403, 'No eres el revisor asignado a esta etapa.');
+            }
+
+            if ($review->status !== 'pending') {
+                throw ValidationException::withMessages([
+                    'review' => ['Esta revisión ya fue procesada.'],
+                ]);
+            }
+
+            $review->status       = 'approved';
+            $review->reviewed_at  = now();
+            $this->documentRepository->saveReview($review);
+
+            if ($this->documentRepository->countPendingReviewsForDocument($documentId) === 0) {
+                return $this->transition($documentId, 'published', $actorId, [
+                    'published_at' => now(),
+                ]);
+            }
+
+            return $this->documentRepository->findOrFail($documentId);
+        });
+    }
+
+    public function rejectReview(string $documentId, string $reviewId, string $actorId, ?string $reason = null): Document
+    {
+        return DB::transaction(function () use ($documentId, $reviewId, $actorId, $reason) {
+            $document = $this->documentRepository->findOrFail($documentId);
+
+            if ($document->status !== 'in_review') {
+                throw ValidationException::withMessages([
+                    'status' => ['Las revisiones solo aplican a documentos en revisión.'],
+                ]);
+            }
+
+            $review = $this->documentRepository->findReviewInDocument($reviewId, $documentId);
+
+            if ($review === null) {
+                abort(404);
+            }
+
+            if ($review->reviewer_id !== $actorId) {
+                abort(403, 'No eres el revisor asignado a esta etapa.');
+            }
+
+            if ($review->status !== 'pending') {
+                throw ValidationException::withMessages([
+                    'review' => ['Esta revisión ya fue procesada.'],
+                ]);
+            }
+
+            $review->status            = 'rejected';
+            $review->rejection_reason  = $reason;
+            $review->reviewed_at       = now();
+            $this->documentRepository->saveReview($review);
+
+            $this->documentRepository->deleteReviewsForDocument($documentId);
+
+            return $this->transition($documentId, 'draft', $actorId, [
+                'submitted_at' => null,
+                'published_at' => null,
+            ]);
+        });
     }
 }

--- a/backend/tests/Concerns/BuildsTestJwt.php
+++ b/backend/tests/Concerns/BuildsTestJwt.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests\Concerns;
+
+use DateTimeImmutable;
+use Lcobucci\JWT\Configuration;
+use Lcobucci\JWT\Signer\Key\InMemory;
+use Lcobucci\JWT\Signer\Rsa\Sha256;
+
+trait BuildsTestJwt
+{
+    /**
+     * @return array{0: string, 1: string} [privatePem, publicPem]
+     */
+    protected function generateRsaKeyPairForTests(): array
+    {
+        $resource = openssl_pkey_new([
+            'private_key_bits' => 2048,
+            'private_key_type' => OPENSSL_KEYTYPE_RSA,
+        ]);
+        openssl_pkey_export($resource, $privatePem);
+        $details = openssl_pkey_get_details($resource);
+
+        return [$privatePem, $details['key']];
+    }
+
+    protected function buildJwtForSub(
+        string $privatePem,
+        string $publicPem,
+        string $kid,
+        string $sub,
+        string $issuer = 'test-issuer',
+        string $audience = 'test-audience',
+    ): string {
+        $config = Configuration::forAsymmetricSigner(
+            new Sha256(),
+            InMemory::plainText($privatePem),
+            InMemory::plainText($publicPem),
+        );
+
+        $now = new DateTimeImmutable;
+
+        return $config->builder()
+            ->issuedBy($issuer)
+            ->permittedFor($audience)
+            ->issuedAt($now->modify('-2 hours'))
+            ->canOnlyBeUsedAfter($now->modify('-2 hours'))
+            ->expiresAt($now->modify('+1 hour'))
+            ->relatedTo($sub)
+            ->withClaim('email', 'test@example.com')
+            ->withHeader('kid', $kid)
+            ->getToken(new Sha256(), InMemory::plainText($privatePem))
+            ->toString();
+    }
+}

--- a/backend/tests/Feature/DocumentSoDHttpAcceptanceTest.php
+++ b/backend/tests/Feature/DocumentSoDHttpAcceptanceTest.php
@@ -1,0 +1,192 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Document;
+use App\Models\Template;
+use App\Services\Contracts\JwksServiceInterface;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Lcobucci\JWT\Signer\Key\InMemory;
+use Tests\Concerns\BuildsTestJwt;
+use Tests\TestCase;
+
+/**
+ * Requiere PostgreSQL (o motor compatible con gen_random_uuid() en migraciones).
+ * Con SQLite en phpunit.xml las migraciones fallan igual que en AuditLogInsertLatencyTest.
+ */
+class DocumentSoDHttpAcceptanceTest extends TestCase
+{
+    use BuildsTestJwt;
+    use RefreshDatabase;
+
+    private function seedTemplateAndDocument(string $creatorId): array
+    {
+        $templateId = (string) \Illuminate\Support\Str::uuid();
+        $documentId = (string) \Illuminate\Support\Str::uuid();
+
+        Template::query()->forceCreate([
+            'id'              => $templateId,
+            'name'            => 'Plantilla SoD',
+            'description'     => null,
+            'study_id'        => null,
+            'organization_id' => 'org-test',
+            'created_by'      => $creatorId,
+            'status'          => 'draft',
+            'version'         => 1,
+            'review_stages'   => 0,
+            'review_mode'     => 'sequential',
+        ]);
+
+        Document::query()->forceCreate([
+            'id'               => $documentId,
+            'template_id'      => $templateId,
+            'title'            => 'Documento SoD',
+            'organization_id'  => 'org-test',
+            'study_id'         => null,
+            'created_by'       => $creatorId,
+            'owner_id'         => $creatorId,
+            'status'           => 'draft',
+            'current_version'  => 1,
+            'submitted_at'     => null,
+            'published_at'     => null,
+        ]);
+
+        return [$templateId, $documentId];
+    }
+
+    /**
+     * Escenario 5: creador envía a revisión su documento → HTTP 403.
+     * Escenario 4: queda registro en audit_log (nivel WARNING en new_value).
+     */
+    public function test_creator_submit_own_document_returns_403_and_writes_audit_log(): void
+    {
+        [$templateId, $documentId] = $this->seedTemplateAndDocument('creator-doc-uuid-01');
+
+        [$privatePem, $publicPem] = $this->generateRsaKeyPairForTests();
+        $token = $this->buildJwtForSub($privatePem, $publicPem, 'kid-sod-doc', 'creator-doc-uuid-01');
+
+        config([
+            'auth.jwt_issuer'   => 'test-issuer',
+            'auth.jwt_audience' => 'test-audience',
+        ]);
+
+        $this->mock(JwksServiceInterface::class)
+            ->shouldReceive('getPublicKey')
+            ->andReturn(InMemory::plainText($publicPem));
+
+        $response = $this->postJson(
+            "/api/v1/documents/{$documentId}/submit",
+            [],
+            ['Authorization' => 'Bearer '.$token],
+        );
+
+        $response->assertForbidden();
+
+        $this->assertDatabaseHas('audit_log', [
+            'entity_type' => 'document',
+            'entity_id'   => $documentId,
+            'action'      => 'sod_violation',
+            'user_id'     => 'creator-doc-uuid-01',
+        ]);
+
+        $row = DB::table('audit_log')
+            ->where('entity_id', $documentId)
+            ->where('action', 'sod_violation')
+            ->first();
+
+        $this->assertNotNull($row);
+        $newValue = is_string($row->new_value) ? json_decode($row->new_value, true) : $row->new_value;
+        $this->assertIsArray($newValue);
+        $this->assertSame('WARNING', $newValue['level'] ?? null);
+        $this->assertArrayHasKey('ability', $newValue);
+        $this->assertNotEmpty($row->timestamp);
+    }
+
+    /**
+     * Escenario 2: creador publica plantilla (revisión/aprobación) → HTTP 403.
+     */
+    public function test_creator_publish_template_returns_403(): void
+    {
+        $creatorId = 'creator-tpl-uuid-02';
+        [$templateId, ] = $this->seedTemplateAndDocument($creatorId);
+        // Crea también un documento; no interfiere con la plantilla bajo prueba
+
+        [$privatePem, $publicPem] = $this->generateRsaKeyPairForTests();
+        $token = $this->buildJwtForSub($privatePem, $publicPem, 'kid-sod-tpl', $creatorId);
+
+        config([
+            'auth.jwt_issuer'   => 'test-issuer',
+            'auth.jwt_audience' => 'test-audience',
+        ]);
+
+        $this->mock(JwksServiceInterface::class)
+            ->shouldReceive('getPublicKey')
+            ->andReturn(InMemory::plainText($publicPem));
+
+        $response = $this->patchJson(
+            "/api/v1/templates/{$templateId}",
+            ['status' => 'published'],
+            ['Authorization' => 'Bearer '.$token],
+        );
+
+        $response->assertForbidden();
+    }
+
+    /**
+     * Escenario 3: titular delegado (owner) no puede enviar a revisión.
+     */
+    public function test_delegate_owner_cannot_submit_document(): void
+    {
+        $creatorId = 'creator-deleg-uuid-03';
+        $ownerId   = 'owner-deleg-uuid-04';
+
+        $templateId = (string) \Illuminate\Support\Str::uuid();
+        $documentId = (string) \Illuminate\Support\Str::uuid();
+
+        Template::query()->forceCreate([
+            'id'              => $templateId,
+            'name'            => 'T',
+            'description'     => null,
+            'study_id'        => null,
+            'organization_id' => 'org-test',
+            'created_by'      => $creatorId,
+            'status'          => 'draft',
+            'version'         => 1,
+            'review_stages'   => 0,
+            'review_mode'     => 'sequential',
+        ]);
+
+        Document::query()->forceCreate([
+            'id'               => $documentId,
+            'template_id'      => $templateId,
+            'title'            => 'Doc delegado',
+            'organization_id'  => 'org-test',
+            'study_id'         => null,
+            'created_by'       => $creatorId,
+            'owner_id'         => $ownerId,
+            'status'           => 'draft',
+            'current_version'  => 1,
+            'submitted_at'     => null,
+            'published_at'     => null,
+        ]);
+
+        [$privatePem, $publicPem] = $this->generateRsaKeyPairForTests();
+        $token = $this->buildJwtForSub($privatePem, $publicPem, 'kid-sod-del', $ownerId);
+
+        config([
+            'auth.jwt_issuer'   => 'test-issuer',
+            'auth.jwt_audience' => 'test-audience',
+        ]);
+
+        $this->mock(JwksServiceInterface::class)
+            ->shouldReceive('getPublicKey')
+            ->andReturn(InMemory::plainText($publicPem));
+
+        $this->postJson(
+            "/api/v1/documents/{$documentId}/submit",
+            [],
+            ['Authorization' => 'Bearer '.$token],
+        )->assertForbidden();
+    }
+}

--- a/backend/tests/Unit/Listeners/RecordSegregationOfDutiesDenialTest.php
+++ b/backend/tests/Unit/Listeners/RecordSegregationOfDutiesDenialTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Tests\Unit\Listeners;
+
+use App\Listeners\RecordSegregationOfDutiesDenial;
+use App\Models\AuditLog;
+use App\Models\Document;
+use App\Models\JwtUser;
+use App\Services\Contracts\AuditLogServiceInterface;
+use Illuminate\Auth\Access\Events\GateEvaluated;
+use Tests\TestCase;
+
+class RecordSegregationOfDutiesDenialTest extends TestCase
+{
+    public function test_persists_audit_when_document_submit_is_denied(): void
+    {
+        $user = new JwtUser([
+            'id'              => 'user-1',
+            'email'           => null,
+            'name'            => null,
+            'department'      => null,
+            'organization_id' => null,
+            'roles'           => [],
+            'scope'           => '',
+        ]);
+
+        $document = new Document;
+        $document->forceFill([
+            'id'         => 'doc-uuid-1',
+            'created_by' => 'user-1',
+            'owner_id'   => 'user-1',
+            'status'     => 'draft',
+        ]);
+
+        $audit = $this->createMock(AuditLogServiceInterface::class);
+        $audit->expects($this->once())
+            ->method('record')
+            ->with(
+                'document',
+                'doc-uuid-1',
+                'sod_violation',
+                'user-1',
+                null,
+                null,
+                $this->callback(fn (array $v) => ($v['ability'] ?? null) === 'submit'
+                    && ($v['reason'] ?? null) === 'segregation_of_duties'),
+                $this->anything(),
+                $this->anything(),
+            )
+            ->willReturn(new AuditLog);
+
+        $listener = new RecordSegregationOfDutiesDenial($audit);
+        $listener->handle(new GateEvaluated($user, 'submit', false, [$document]));
+    }
+
+    public function test_skips_when_gate_allows(): void
+    {
+        $audit = $this->createMock(AuditLogServiceInterface::class);
+        $audit->expects($this->never())->method('record');
+
+        $user = new JwtUser([
+            'id'              => 'reviewer',
+            'email'           => null,
+            'name'            => null,
+            'department'      => null,
+            'organization_id' => null,
+            'roles'           => [],
+            'scope'           => '',
+        ]);
+
+        $document = new Document;
+        $document->forceFill([
+            'id'         => 'doc-1',
+            'created_by' => 'other',
+            'owner_id'   => 'other',
+            'status'     => 'draft',
+        ]);
+
+        $listener = new RecordSegregationOfDutiesDenial($audit);
+        $listener->handle(new GateEvaluated($user, 'submit', true, [$document]));
+    }
+}

--- a/backend/tests/Unit/Policies/DocumentPolicyPerformanceTest.php
+++ b/backend/tests/Unit/Policies/DocumentPolicyPerformanceTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Unit\Policies;
+
+use App\Models\Document;
+use App\Models\JwtUser;
+use App\Policies\DocumentPolicy;
+use Tests\TestCase;
+
+/**
+ * Requisito técnico F-01.3: verificación SoD sin consultas a BD (comparación de IDs en memoria).
+ */
+class DocumentPolicyPerformanceTest extends TestCase
+{
+    public function test_review_check_is_fast_enough_for_in_memory_id_comparison(): void
+    {
+        $policy = new DocumentPolicy;
+        $user   = new JwtUser([
+            'id'              => 'user-perf-1',
+            'email'           => null,
+            'name'            => null,
+            'department'      => null,
+            'organization_id' => null,
+            'roles'           => [],
+            'scope'           => '',
+        ]);
+        $doc = new Document;
+        $doc->forceFill([
+            'created_by' => 'other-user',
+            'owner_id'   => 'other-user',
+            'status'     => 'draft',
+        ]);
+
+        $iterations = 2_000;
+        $start      = hrtime(true);
+        for ($i = 0; $i < $iterations; $i++) {
+            $policy->review($user, $doc);
+        }
+        $avgMs = ((hrtime(true) - $start) / 1_000_000) / $iterations;
+
+        $this->assertLessThan(
+            1.0,
+            $avgMs,
+            "La media por llamada fue {$avgMs} ms (límite: 1 ms)."
+        );
+    }
+}

--- a/backend/tests/Unit/Policies/DocumentPolicyTest.php
+++ b/backend/tests/Unit/Policies/DocumentPolicyTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Tests\Unit\Policies;
+
+use App\Models\Document;
+use App\Models\JwtUser;
+use App\Policies\DocumentPolicy;
+use Tests\TestCase;
+
+class DocumentPolicyTest extends TestCase
+{
+    private DocumentPolicy $policy;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->policy = new DocumentPolicy;
+    }
+
+    /**
+     * SoD (F-01.3): creador no puede enviar a revisión ni actuar como revisor del mismo documento.
+     */
+    public function test_creator_cannot_submit_or_review(): void
+    {
+        $userId = '11111111-1111-1111-1111-111111111111';
+        $user   = $this->makeJwtUser($userId);
+        $doc    = $this->makeDocument(createdBy: $userId, ownerId: $userId);
+
+        $this->assertFalse($this->policy->submit($user, $doc));
+        $this->assertFalse($this->policy->review($user, $doc));
+    }
+
+    /**
+     * Titular delegado sigue sin poder revisar/aprobar (misma segregación que el creador).
+     */
+    public function test_delegate_owner_cannot_review_when_not_creator(): void
+    {
+        $creatorId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+        $ownerId   = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+        $user      = $this->makeJwtUser($ownerId);
+        $doc       = $this->makeDocument(createdBy: $creatorId, ownerId: $ownerId);
+
+        $this->assertFalse($this->policy->review($user, $doc));
+        $this->assertFalse($this->policy->submit($user, $doc));
+    }
+
+    /**
+     * Usuario que no es creador ni titular puede revisar y enviar (autorización de negocio aparte).
+     */
+    public function test_unrelated_user_can_submit_and_review_from_sod_perspective(): void
+    {
+        $creatorId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+        $ownerId   = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+        $reviewerId = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+        $user      = $this->makeJwtUser($reviewerId);
+        $doc       = $this->makeDocument(createdBy: $creatorId, ownerId: $ownerId);
+
+        $this->assertTrue($this->policy->submit($user, $doc));
+        $this->assertTrue($this->policy->review($user, $doc));
+    }
+
+    /**
+     * Tras delegar el titular, el creador sigue considerado "conflictivo" para revisión/aprobación y envío.
+     */
+    public function test_creator_still_cannot_submit_or_review_after_delegating_ownership(): void
+    {
+        $creatorId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+        $newOwner  = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+        $user      = $this->makeJwtUser($creatorId);
+        $doc       = $this->makeDocument(createdBy: $creatorId, ownerId: $newOwner);
+
+        $this->assertFalse($this->policy->review($user, $doc));
+        $this->assertFalse($this->policy->submit($user, $doc));
+    }
+
+    private function makeJwtUser(string $id): JwtUser
+    {
+        return new JwtUser([
+            'id'              => $id,
+            'email'           => null,
+            'name'            => null,
+            'department'      => null,
+            'organization_id' => null,
+            'roles'           => [],
+            'scope'           => '',
+        ]);
+    }
+
+    private function makeDocument(string $createdBy, string $ownerId): Document
+    {
+        $doc = new Document;
+        $doc->forceFill([
+            'created_by' => $createdBy,
+            'owner_id'   => $ownerId,
+            'status'     => 'draft',
+        ]);
+
+        return $doc;
+    }
+}

--- a/backend/tests/Unit/Policies/TemplatePolicyTest.php
+++ b/backend/tests/Unit/Policies/TemplatePolicyTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Tests\Unit\Policies;
+
+use App\Models\JwtUser;
+use App\Models\Template;
+use App\Policies\TemplatePolicy;
+use Tests\TestCase;
+
+class TemplatePolicyTest extends TestCase
+{
+    private TemplatePolicy $policy;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->policy = new TemplatePolicy;
+    }
+
+    public function test_creator_cannot_review_template(): void
+    {
+        $creatorId = '11111111-1111-1111-1111-111111111111';
+        $user      = $this->makeJwtUser($creatorId);
+        $template  = $this->makeTemplate(createdBy: $creatorId);
+
+        $this->assertFalse($this->policy->review($user, $template));
+    }
+
+    public function test_non_creator_can_review_template(): void
+    {
+        $creatorId  = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+        $reviewerId = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+        $user       = $this->makeJwtUser($reviewerId);
+        $template   = $this->makeTemplate(createdBy: $creatorId);
+
+        $this->assertTrue($this->policy->review($user, $template));
+    }
+
+    private function makeJwtUser(string $id): JwtUser
+    {
+        return new JwtUser([
+            'id'              => $id,
+            'email'           => null,
+            'name'            => null,
+            'department'      => null,
+            'organization_id' => null,
+            'roles'           => [],
+            'scope'           => '',
+        ]);
+    }
+
+    private function makeTemplate(string $createdBy): Template
+    {
+        $t = new Template;
+        $t->forceFill([
+            'created_by' => $createdBy,
+            'status'     => 'draft',
+        ]);
+
+        return $t;
+    }
+}

--- a/backend/tests/Unit/Services/DocumentServiceSubmitTest.php
+++ b/backend/tests/Unit/Services/DocumentServiceSubmitTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Models\Document;
+use App\Repositories\Contracts\DocumentRepositoryInterface;
+use App\Services\DocumentService;
+use Illuminate\Validation\ValidationException;
+use Mockery;
+use Tests\TestCase;
+
+class DocumentServiceSubmitTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    public function test_submit_to_review_throws_when_document_is_not_draft(): void
+    {
+        $repo = Mockery::mock(DocumentRepositoryInterface::class);
+        $doc  = new Document;
+        $doc->forceFill([
+            'id'     => 'doc-uuid',
+            'status' => 'in_review',
+        ]);
+
+        $repo->shouldReceive('findOrFail')
+            ->once()
+            ->with('doc-uuid')
+            ->andReturn($doc);
+
+        $service = new DocumentService($repo);
+
+        $this->expectException(ValidationException::class);
+
+        $service->submitToReview('doc-uuid', 'actor-uuid');
+    }
+}


### PR DESCRIPTION
- Segregación de funciones (SoD) mediante DocumentPolicy y TemplatePolicy, registradas con Gate::policy, con comprobación en memoria por IDs (creador y titular en documentos; creador en plantillas).
- Integración en la API: authorize('submit'|'review', …) en flujo de documentos (envío a revisión, publicación, rechazo, revisiones) y en plantillas al intentar pasar a published vía update.
- Servicio de flujo de revisión de documentos (transiciones, document_reviews, delegación) enlazado desde los controladores; el CRUD estándar (index / store / show / update / destroy) permanece sin implementar de forma deliberada.
- Auditoría de intentos denegados: listener sobre GateEvaluated que registra sod_violation en audit_log (nivel WARNING en new_value) y traza en log de aplicación.
- Tests: unitarios (policies, listener, validación de envío, rendimiento de policy) y feature de aceptación ISO (403 HTTP, audit_log, delegación, plantilla) donde aplica.