### PR TITLE
Feature/f 04.1 creacion documentos

### DIFF
--- a/backend/app/DTOs/Documents/CreateDocumentDto.php
+++ b/backend/app/DTOs/Documents/CreateDocumentDto.php
@@ -14,6 +14,7 @@ readonly class CreateDocumentDto
         public string $createdBy,
         public string $ownerId,
         public ?string $studyId = null,
+        public ?string $moduleId = null,
         public ?string $templateVersionId = null,
     ) {}
 }

--- a/backend/app/Http/Controllers/Api/DocumentController.php
+++ b/backend/app/Http/Controllers/Api/DocumentController.php
@@ -7,8 +7,8 @@ use App\Http\Requests\Documents\StoreDocumentRequest;
 use App\Http\Resources\DocumentResource;
 use App\Services\Contracts\DocumentServiceInterface;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
 
 class DocumentController extends Controller
 {
@@ -19,11 +19,11 @@ class DocumentController extends Controller
     /**
      * Listar documentos.
      */
-    public function index(Request $request): JsonResponse
+    public function index(Request $request): AnonymousResourceCollection
     {
-        // TODO: listar documentos (filtros, paginación)
-
-        return response()->json(['data' => []]);
+        return DocumentResource::collection(
+            $this->documentService->listOrderedByCreatedAtDesc(),
+        );
     }
 
     /**
@@ -31,8 +31,67 @@ class DocumentController extends Controller
      */
     public function store(StoreDocumentRequest $request): JsonResponse
     {
-        $userId = (string) Auth::id();
+        $userId = (string) $request->user()->getAuthIdentifier();
         $document = $this->documentService->create($request->toDto($userId, $userId));
+        $blocks = $this->documentService->blocksForDisplay($document);
+
+        return response()->json([
+            'data' => array_merge(
+                (new DocumentResource($document))->toArray($request),
+                ['blocks' => $blocks],
+            ),
+        ], 201);
+    }
+
+    /**
+     * Opciones para crear una programación desde la vista de módulo.
+     */
+    public function creationOptions(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'module_id' => ['required', 'string'],
+        ]);
+
+        $options = $this->documentService->creationOptionsForModule($validated['module_id']);
+        $count = count($options);
+
+        if ($count === 0) {
+            return response()->json([
+                'data' => [
+                    'can_create' => false,
+                    'mode' => 'none',
+                    'message' => 'No hay plantillas publicadas disponibles para este módulo.',
+                    'options' => [],
+                ],
+            ]);
+        }
+
+        return response()->json([
+            'data' => [
+                'can_create' => true,
+                'mode' => $count === 1 ? 'auto' : 'select',
+                'message' => null,
+                'options' => $options,
+            ],
+        ]);
+    }
+
+    /**
+     * Crear una programación desde módulo con selección opcional de versión de plantilla.
+     */
+    public function createFromModule(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'module_id' => ['required', 'string'],
+            'template_version_id' => ['sometimes', 'nullable', 'uuid'],
+        ]);
+
+        $userId = (string) $request->user()->getAuthIdentifier();
+        $document = $this->documentService->createFromModule(
+            $validated['module_id'],
+            $userId,
+            $validated['template_version_id'] ?? null,
+        );
         $blocks = $this->documentService->blocksForDisplay($document);
 
         return response()->json([

--- a/backend/app/Http/Requests/Documents/StoreDocumentRequest.php
+++ b/backend/app/Http/Requests/Documents/StoreDocumentRequest.php
@@ -35,6 +35,7 @@ class StoreDocumentRequest extends FormRequest
             'title' => ['required', 'string', 'max:255'],
             'organization_id' => ['required', 'string', 'max:255'],
             'study_id' => ['sometimes', 'nullable', 'string', 'max:255'],
+            'module_id' => ['sometimes', 'nullable', 'string', 'max:255'],
             'template_version_id' => [
                 'sometimes',
                 'nullable',
@@ -58,6 +59,7 @@ class StoreDocumentRequest extends FormRequest
             createdBy: $createdBy,
             ownerId: $ownerId,
             studyId: $this->validated('study_id') ?? null,
+            moduleId: $this->validated('module_id') ?? null,
             templateVersionId: $this->validated('template_version_id') ?? null,
         );
     }

--- a/backend/app/Http/Resources/DocumentResource.php
+++ b/backend/app/Http/Resources/DocumentResource.php
@@ -21,6 +21,7 @@ class DocumentResource extends JsonResource
             'title' => $this->title,
             'organization_id' => $this->organization_id,
             'study_id' => $this->study_id,
+            'module_id' => $this->module_id,
             'created_by' => $this->created_by,
             'owner_id' => $this->owner_id,
             'status' => $this->status,

--- a/backend/app/Repositories/Contracts/DocumentRepositoryInterface.php
+++ b/backend/app/Repositories/Contracts/DocumentRepositoryInterface.php
@@ -65,4 +65,11 @@ interface DocumentRepositoryInterface
      * Guarda una revisión del documento.
      */
     public function saveReview(DocumentReview $review): void;
+
+    /**
+     * Lista documentos visibles para el usuario actual ordenados por fecha de creación descendente.
+     *
+     * @return Collection<int, Document>
+     */
+    public function listOrderedByCreatedAtDesc(): Collection;
 }

--- a/backend/app/Repositories/Contracts/TemplateRepositoryInterface.php
+++ b/backend/app/Repositories/Contracts/TemplateRepositoryInterface.php
@@ -48,4 +48,11 @@ interface TemplateRepositoryInterface
      * Replica los bloques de una plantilla origen hacia otra destino.
      */
     public function replicateBlocks(Template $source, Template $target): void;
+
+    /**
+     * Lista plantillas publicadas disponibles para un módulo.
+     *
+     * @return \Illuminate\Support\Collection<int, Template>
+     */
+    public function listPublishedByModule(string $moduleId): \Illuminate\Support\Collection;
 }

--- a/backend/app/Repositories/Eloquent/DocumentRepository.php
+++ b/backend/app/Repositories/Eloquent/DocumentRepository.php
@@ -31,15 +31,20 @@ class DocumentRepository implements DocumentRepositoryInterface
         return DB::transaction(function () use ($documentAttributes, $blockRows) {
             $document = Document::query()->create($documentAttributes);
 
-            foreach ($blockRows as $row) {
-                DocumentBlock::query()->forceCreate([
+            if ($blockRows !== []) {
+                $now = now();
+                $rowsToInsert = array_map(fn (array $row) => [
                     'id' => (string) Str::uuid(),
                     'document_id' => $document->getKey(),
                     'template_block_id' => $row['template_block_id'],
                     'content' => $row['content'],
                     'is_filled' => false,
                     'sort_order' => $row['sort_order'],
-                ]);
+                    'created_at' => $now,
+                    'updated_at' => $now,
+                ], $blockRows);
+
+                DocumentBlock::query()->insert($rowsToInsert);
             }
 
             return $document->fresh(['blocks']);

--- a/backend/app/Repositories/Eloquent/DocumentRepository.php
+++ b/backend/app/Repositories/Eloquent/DocumentRepository.php
@@ -124,6 +124,16 @@ class DocumentRepository implements DocumentRepositoryInterface
     }
 
     /**
+     * Lista documentos visibles para el usuario actual ordenados por fecha de creación descendente.
+     */
+    public function listOrderedByCreatedAtDesc(): Collection
+    {
+        return Document::query()
+            ->orderByDesc('created_at')
+            ->get();
+    }
+
+    /**
      * Indica si el usuario es autor (owner_id / created_by) o revisor asignado
      * del documento. Usado para control de acceso al historial de auditoría.
      */

--- a/backend/app/Repositories/Eloquent/TemplateRepository.php
+++ b/backend/app/Repositories/Eloquent/TemplateRepository.php
@@ -7,6 +7,7 @@ use App\Models\Template;
 use App\Models\TemplateBlock;
 use App\Repositories\Contracts\TemplateRepositoryInterface;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 
@@ -147,5 +148,17 @@ class TemplateRepository implements TemplateRepositoryInterface
                 ]);
             }
         });
+    }
+
+    /**
+     * Lista plantillas publicadas disponibles para un módulo.
+     */
+    public function listPublishedByModule(string $moduleId): Collection
+    {
+        return Template::query()
+            ->where('status', 'published')
+            ->where('module_id', $moduleId)
+            ->orderByDesc('updated_at')
+            ->get();
     }
 }

--- a/backend/app/Services/Contracts/DocumentServiceInterface.php
+++ b/backend/app/Services/Contracts/DocumentServiceInterface.php
@@ -69,4 +69,23 @@ interface DocumentServiceInterface
      * Rechaza una revisión del documento.
      */
     public function rejectReview(string $documentId, string $reviewId, string $actorId, ?string $reason = null): Document;
+
+    /**
+     * Lista documentos visibles para el usuario actual ordenados por fecha de creación descendente.
+     *
+     * @return Collection<int, Document>
+     */
+    public function listOrderedByCreatedAtDesc(): Collection;
+
+    /**
+     * Opciones de creación de documento disponibles para un módulo.
+     *
+     * @return list<array{template_id: string, template_version_id: string, name: string, description: ?string}>
+     */
+    public function creationOptionsForModule(string $moduleId): array;
+
+    /**
+     * Crea documento desde la vista de módulo resolviendo plantilla/version disponibles.
+     */
+    public function createFromModule(string $moduleId, string $creatorId, ?string $templateVersionId = null): Document;
 }

--- a/backend/app/Services/DocumentService.php
+++ b/backend/app/Services/DocumentService.php
@@ -4,13 +4,16 @@ namespace App\Services;
 
 use App\DTOs\Documents\CreateDocumentDto;
 use App\Events\DocumentStateChanged;
+use App\Models\CourseModule;
 use App\Models\Document;
 use App\Models\DocumentReview;
+use App\Models\JwtUser;
 use App\Repositories\Contracts\DocumentRepositoryInterface;
 use App\Repositories\Contracts\TemplateRepositoryInterface;
 use App\Repositories\Contracts\TemplateVersionRepositoryInterface;
 use App\Services\Contracts\DocumentServiceInterface;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\ValidationException;
 
@@ -76,6 +79,7 @@ class DocumentService implements DocumentServiceInterface
             'title' => $dto->title,
             'organization_id' => $dto->organizationId,
             'study_id' => $dto->studyId,
+            'module_id' => $dto->moduleId,
             'created_by' => $dto->createdBy,
             'owner_id' => $dto->ownerId,
             'status' => 'draft',
@@ -85,6 +89,109 @@ class DocumentService implements DocumentServiceInterface
         ], $blockRows);
     }
 
+    /**
+     * Opciones de creación de documento disponibles para un módulo.
+     * 
+     * @return list<array{template_id: string, template_version_id: string, name: string, description: ?string}>
+     */
+    public function creationOptionsForModule(string $moduleId): array
+    {
+        $templates = $this->templateRepository->listPublishedByModule($moduleId);
+
+        $options = [];
+        foreach ($templates as $template) {
+            $version = $this->templateVersionRepository->findLatestPublishedForTemplate($template->id);
+            if ($version === null) {
+                continue;
+            }
+
+            $options[] = [
+                'template_id' => $template->id,
+                'template_version_id' => $version->id,
+                'name' => (string) $template->name,
+                'description' => $template->description,
+            ];
+        }
+
+        return $options;
+    }
+
+    /**
+     * Crea un documento desde la vista de módulo resolviendo plantilla/version disponibles.
+     */
+    public function createFromModule(string $moduleId, string $creatorId, ?string $templateVersionId = null): Document
+    {
+        $options = $this->creationOptionsForModule($moduleId);
+        if ($options === []) {
+            throw ValidationException::withMessages([
+                'module_id' => ['El módulo no tiene plantillas publicadas disponibles.'],
+            ]);
+        }
+
+        $selected = null;
+        if ($templateVersionId !== null) {
+            foreach ($options as $option) {
+                if ($option['template_version_id'] === $templateVersionId) {
+                    $selected = $option;
+                    break;
+                }
+            }
+
+            if ($selected === null) {
+                throw ValidationException::withMessages([
+                    'template_version_id' => ['La versión seleccionada no está disponible para el módulo.'],
+                ]);
+            }
+        } elseif (count($options) === 1) {
+            $selected = $options[0];
+        } else {
+            throw ValidationException::withMessages([
+                'template_version_id' => ['Debe seleccionar una plantilla cuando existen varias opciones.'],
+            ]);
+        }
+
+        $module = CourseModule::query()->find($moduleId);
+        if ($module === null) {
+            throw ValidationException::withMessages([
+                'module_id' => ['El módulo no existe.'],
+            ]);
+        }
+
+        $user = Auth::user();
+        $organizationId = $user instanceof JwtUser ? $user->organizationId : null;
+        if ($organizationId === null || $organizationId === '') {
+            throw ValidationException::withMessages([
+                'organization_id' => ['No se pudo resolver la organización del usuario autenticado.'],
+            ]);
+        }
+
+        return $this->create(new CreateDocumentDto(
+            templateId: $selected['template_id'],
+            templateVersionId: $selected['template_version_id'],
+            title: 'Nueva Programación Didáctica',
+            organizationId: $organizationId,
+            studyId: (string) $module->study_id,
+            moduleId: $moduleId,
+            createdBy: $creatorId,
+            ownerId: $creatorId,
+        ));
+    }
+
+    /**
+     * Lista documentos visibles para el usuario actual ordenados por fecha de creación descendente.
+     * 
+     * @return Collection<int, Document>
+     */
+    public function listOrderedByCreatedAtDesc(): Collection
+    {
+        return $this->documentRepository->listOrderedByCreatedAtDesc();
+    }
+
+    /**
+     * Bloques para mostrar/editar: definición según {@see Document::$template_version_id} y contenido en document_blocks.
+     *
+     * @return list<array<string, mixed>>
+     */
     public function blocksForDisplay(Document $document): array
     {
         $document->loadMissing(['blocks', 'templateVersion']);

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -67,6 +67,8 @@ Route::prefix('v1')->group(function () {
 
         // Sprint 3 — Documentos
         Route::apiResource('documents', DocumentController::class);
+        Route::get('documents/creation-options', [DocumentController::class, 'creationOptions']);
+        Route::post('documents/create-from-module', [DocumentController::class, 'createFromModule']);
         Route::post('documents/{document}/submit', [DocumentController::class, 'submit']);
         Route::post('documents/{document}/publish', [DocumentController::class, 'publish']);
         Route::post('documents/{document}/reject', [DocumentController::class, 'reject']);

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -48,55 +48,97 @@ Route::prefix('v1')->group(function () {
         Route::get('/hierarchy', [AcademicHierarchyController::class, 'index']);
 
         // Sprint 1 — Grupos
-        Route::apiResource('groups', GroupController::class);
-        Route::post('groups/{group}/members', [GroupController::class, 'addMember']);
-        Route::delete('groups/{group}/members/{userId}', [GroupController::class, 'removeMember']);
+        Route::apiResource('groups', GroupController::class)
+            ->whereUuid('group');
+        Route::post('groups/{group}/members', [GroupController::class, 'addMember'])
+            ->whereUuid('group');
+        Route::delete('groups/{group}/members/{userId}', [GroupController::class, 'removeMember'])
+            ->whereUuid('group');
 
         // Sprint 2 — Plantillas
-        Route::apiResource('templates', TemplateController::class);
+        Route::apiResource('templates', TemplateController::class)
+            ->whereUuid('template');
         Route::apiResource('templates.blocks', TemplateBlockController::class)
-            ->shallow();
-        Route::post('templates/{template}/clone', [TemplateController::class, 'clone']);
-        Route::post('templates/{template}/submit-review', [TemplateController::class, 'submitForReview']);
-        Route::post('templates/{template}/reject-review', [TemplateController::class, 'rejectReview']);
-        Route::post('templates/{template}/publish', [TemplateController::class, 'publish']);
-        Route::post('templates/{template}/reopen-draft', [TemplateController::class, 'reopenDraft']);
-        Route::get('templates/{template}/versions', [TemplateController::class, 'versions']);
-        Route::get('template-versions/{template_version}', [TemplateController::class, 'showVersion']);
-        Route::match(['put', 'patch', 'delete'], 'template-versions/{template_version}', fn () => abort(403, 'Los snapshots de plantilla son de solo inserción (append-only).'));
+            ->shallow()
+            ->whereUuid('template')
+            ->whereUuid('block');
+        Route::post('templates/{template}/clone', [TemplateController::class, 'clone'])
+            ->whereUuid('template');
+        Route::post('templates/{template}/submit-review', [TemplateController::class, 'submitForReview'])
+            ->whereUuid('template');
+        Route::post('templates/{template}/reject-review', [TemplateController::class, 'rejectReview'])
+            ->whereUuid('template');
+        Route::post('templates/{template}/publish', [TemplateController::class, 'publish'])
+            ->whereUuid('template');
+        Route::post('templates/{template}/reopen-draft', [TemplateController::class, 'reopenDraft'])
+            ->whereUuid('template');
+        Route::get('templates/{template}/versions', [TemplateController::class, 'versions'])
+            ->whereUuid('template');
+        Route::get('template-versions/{template_version}', [TemplateController::class, 'showVersion'])
+            ->whereUuid('template_version');
+        Route::match(['put', 'patch', 'delete'], 'template-versions/{template_version}', fn () => abort(403, 'Los snapshots de plantilla son de solo inserción (append-only).'))
+            ->whereUuid('template_version');
 
         // Sprint 3 — Documentos
-        Route::apiResource('documents', DocumentController::class);
         Route::get('documents/creation-options', [DocumentController::class, 'creationOptions']);
         Route::post('documents/create-from-module', [DocumentController::class, 'createFromModule']);
-        Route::post('documents/{document}/submit', [DocumentController::class, 'submit']);
-        Route::post('documents/{document}/publish', [DocumentController::class, 'publish']);
-        Route::post('documents/{document}/reject', [DocumentController::class, 'reject']);
-        Route::post('documents/{document}/delegate', [DocumentController::class, 'delegate']);
+        Route::get('documents', [DocumentController::class, 'index']);
+        Route::post('documents', [DocumentController::class, 'store']);
+        Route::get('documents/{document}', [DocumentController::class, 'show'])
+            ->whereUuid('document');
+        Route::match(['put', 'patch'], 'documents/{document}', [DocumentController::class, 'update'])
+            ->whereUuid('document');
+        Route::delete('documents/{document}', [DocumentController::class, 'destroy'])
+            ->whereUuid('document');
+        Route::post('documents/{document}/submit', [DocumentController::class, 'submit'])
+            ->whereUuid('document');
+        Route::post('documents/{document}/publish', [DocumentController::class, 'publish'])
+            ->whereUuid('document');
+        Route::post('documents/{document}/reject', [DocumentController::class, 'reject'])
+            ->whereUuid('document');
+        Route::post('documents/{document}/delegate', [DocumentController::class, 'delegate'])
+            ->whereUuid('document');
 
-        Route::get('documents/{document}/blocks', [DocumentBlockController::class, 'index']);
-        Route::put('documents/{document}/blocks/{block}', [DocumentBlockController::class, 'update']);
+        Route::get('documents/{document}/blocks', [DocumentBlockController::class, 'index'])
+            ->whereUuid('document');
+        Route::put('documents/{document}/blocks/{block}', [DocumentBlockController::class, 'update'])
+            ->whereUuid('document')
+            ->whereUuid('block');
 
-        Route::get('documents/{document}/versions', [DocumentVersionController::class, 'index']);
+        Route::get('documents/{document}/versions', [DocumentVersionController::class, 'index'])
+            ->whereUuid('document');
 
         // Auditoría
-        Route::get('documents/{document}/audit', [AuditLogController::class, 'indexForDocument']);
-        Route::get('templates/{template}/audit', [AuditLogController::class, 'indexForTemplate']);
-        Route::get('comments/{comment}/audit', [AuditLogController::class, 'indexForComment']);
+        Route::get('documents/{document}/audit', [AuditLogController::class, 'indexForDocument'])
+            ->whereUuid('document');
+        Route::get('templates/{template}/audit', [AuditLogController::class, 'indexForTemplate'])
+            ->whereUuid('template');
+        Route::get('comments/{comment}/audit', [AuditLogController::class, 'indexForComment'])
+            ->whereUuid('comment');
 
         // Sprint 3 — Compartición
-        Route::post('documents/{document}/shares', [DocumentShareController::class, 'store']);
-        Route::delete('documents/{document}/shares/{userId}', [DocumentShareController::class, 'destroy']);
+        Route::post('documents/{document}/shares', [DocumentShareController::class, 'store'])
+            ->whereUuid('document');
+        Route::delete('documents/{document}/shares/{userId}', [DocumentShareController::class, 'destroy'])
+            ->whereUuid('document');
 
         // Sprint 4 — Revisión
-        Route::get('documents/{document}/reviews', [ReviewController::class, 'index']);
-        Route::post('documents/{document}/reviews/{review}/approve', [ReviewController::class, 'approve']);
-        Route::post('documents/{document}/reviews/{review}/reject', [ReviewController::class, 'reject']);
+        Route::get('documents/{document}/reviews', [ReviewController::class, 'index'])
+            ->whereUuid('document');
+        Route::post('documents/{document}/reviews/{review}/approve', [ReviewController::class, 'approve'])
+            ->whereUuid('document')
+            ->whereUuid('review');
+        Route::post('documents/{document}/reviews/{review}/reject', [ReviewController::class, 'reject'])
+            ->whereUuid('document')
+            ->whereUuid('review');
 
         // Sprint 5 — Comentarios
         Route::apiResource('documents.comments', CommentController::class)
-            ->shallow();
-        Route::patch('comments/{comment}/resolve', [CommentController::class, 'resolve']);
+            ->shallow()
+            ->whereUuid('document')
+            ->whereUuid('comment');
+        Route::patch('comments/{comment}/resolve', [CommentController::class, 'resolve'])
+            ->whereUuid('comment');
 
         // Sprint 6 — Dashboard BFF
         Route::get('/dashboard', [DashboardController::class, 'index']);

--- a/backend/tests/Feature/DocumentsModuleCreationApiTest.php
+++ b/backend/tests/Feature/DocumentsModuleCreationApiTest.php
@@ -1,0 +1,316 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\TemplateVisibilityLevel;
+use App\Models\Template;
+use App\Models\TemplateVersion;
+use App\Services\Contracts\JwksServiceInterface;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Lcobucci\JWT\Signer\Key\InMemory;
+use Tests\Concerns\BuildsTestJwt;
+use Tests\TestCase;
+
+class DocumentsModuleCreationApiTest extends TestCase
+{
+    use BuildsTestJwt;
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config([
+            'auth.jwt_issuer' => 'test-issuer',
+            'auth.jwt_audience' => 'test-audience',
+            'auth.template_shared_visibility_roles' => ['department-head', 'director'],
+        ]);
+
+        Cache::flush();
+    }
+
+    /**
+     * @param  array<string, mixed>  $extraClaims
+     * @return array<string, string>
+     */
+    private function authHeaders(string $sub, array $extraClaims = []): array
+    {
+        auth()->forgetUser();
+
+        [$privatePem, $publicPem] = $this->generateRsaKeyPairForTests();
+
+        $this->mock(JwksServiceInterface::class)
+            ->shouldReceive('getPublicKey')
+            ->andReturn(InMemory::plainText($publicPem));
+
+        $token = $this->buildJwtForSub(
+            $privatePem,
+            $publicPem,
+            'kid-'.substr($sub, 0, 8),
+            $sub,
+            'test-issuer',
+            'test-audience',
+            [],
+            $extraClaims,
+        );
+
+        return ['Authorization' => 'Bearer '.$token];
+    }
+
+    private function seedAcademicHierarchy(string $moduleId = 'MOD-1', string $studyId = 'STUDY-1'): void
+    {
+        DB::table('study_types')->insert([
+            'id' => 'TYPE-1',
+            'name' => 'Bachillerato',
+        ]);
+
+        DB::table('studies')->insert([
+            'id' => $studyId,
+            'study_type_id' => 'TYPE-1',
+            'name' => '1º Bachillerato',
+        ]);
+
+        DB::table('course_modules')->insert([
+            'id' => $moduleId,
+            'study_id' => $studyId,
+            'name' => 'Matemáticas I',
+        ]);
+    }
+
+    private function createPublishedTemplateWithVersion(
+        string $templateId,
+        string $creatorId,
+        string $moduleId,
+        string $name,
+        ?string $description = null,
+    ): TemplateVersion {
+        $templateBlockId = (string) Str::uuid();
+
+        Template::query()->forceCreate([
+            'id' => $templateId,
+            'name' => $name,
+            'description' => $description,
+            'visibility_level' => TemplateVisibilityLevel::Module->value,
+            'delivery_deadline' => null,
+            'study_type_id' => 'TYPE-1',
+            'study_id' => 'STUDY-1',
+            'module_id' => $moduleId,
+            'group_id' => null,
+            'organization_id' => 'org-test',
+            'created_by' => $creatorId,
+            'status' => 'published',
+            'version' => 1,
+            'review_stages' => 0,
+            'review_mode' => 'sequential',
+        ]);
+
+        DB::table('template_blocks')->insert([
+            'id' => $templateBlockId,
+            'template_id' => $templateId,
+            'type' => 'paragraph',
+            'title' => 'Objetivos',
+            'default_content' => null,
+            'block_state' => 'editable',
+            'mandatory' => 0,
+            'sort_order' => 1,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return TemplateVersion::query()->forceCreate([
+            'id' => (string) Str::uuid(),
+            'template_id' => $templateId,
+            'version_number' => 1,
+            'blocks_snapshot' => [[
+                'id' => $templateBlockId,
+                'type' => 'paragraph',
+                'title' => 'Objetivos',
+                'default_content' => null,
+                'block_state' => 'editable',
+                'mandatory' => false,
+                'sort_order' => 1,
+            ]],
+            'changelog' => 'Versión inicial',
+            'published_by' => $creatorId,
+            'published_at' => now(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    public function test_creation_options_returns_none_when_module_has_no_published_templates(): void
+    {
+        $userId = (string) Str::uuid();
+        $headers = $this->authHeaders($userId, [
+            'organization_id' => 'org-test',
+        ]);
+        $this->seedAcademicHierarchy();
+
+        $this->getJson('/api/v1/documents/creation-options?module_id=MOD-1', $headers)
+            ->assertOk()
+            ->assertJsonPath('data.can_create', false)
+            ->assertJsonPath('data.mode', 'none')
+            ->assertJsonCount(0, 'data.options');
+    }
+
+    public function test_creation_options_returns_auto_when_only_one_template_is_available(): void
+    {
+        $userId = (string) Str::uuid();
+        $headers = $this->authHeaders($userId, [
+            'organization_id' => 'org-test',
+        ]);
+        $this->seedAcademicHierarchy();
+
+        $version = $this->createPublishedTemplateWithVersion(
+            templateId: (string) Str::uuid(),
+            creatorId: $userId,
+            moduleId: 'MOD-1',
+            name: 'Plantilla Única',
+            description: 'Descripción breve',
+        );
+
+        $this->getJson('/api/v1/documents/creation-options?module_id=MOD-1', $headers)
+            ->assertOk()
+            ->assertJsonPath('data.can_create', true)
+            ->assertJsonPath('data.mode', 'auto')
+            ->assertJsonPath('data.options.0.template_version_id', $version->id)
+            ->assertJsonPath('data.options.0.name', 'Plantilla Única');
+    }
+
+    public function test_creation_options_returns_select_when_multiple_templates_are_available(): void
+    {
+        $userId = (string) Str::uuid();
+        $headers = $this->authHeaders($userId, [
+            'organization_id' => 'org-test',
+        ]);
+        $this->seedAcademicHierarchy();
+
+        $this->createPublishedTemplateWithVersion(
+            templateId: (string) Str::uuid(),
+            creatorId: $userId,
+            moduleId: 'MOD-1',
+            name: 'Plantilla A',
+        );
+
+        $this->createPublishedTemplateWithVersion(
+            templateId: (string) Str::uuid(),
+            creatorId: $userId,
+            moduleId: 'MOD-1',
+            name: 'Plantilla B',
+        );
+
+        $this->getJson('/api/v1/documents/creation-options?module_id=MOD-1', $headers)
+            ->assertOk()
+            ->assertJsonPath('data.can_create', true)
+            ->assertJsonPath('data.mode', 'select')
+            ->assertJsonCount(2, 'data.options');
+    }
+
+    public function test_create_from_module_uses_sub_claim_as_creator_and_owner(): void
+    {
+        $userId = (string) Str::uuid();
+        $headers = $this->authHeaders($userId, [
+            'organization_id' => 'org-test',
+        ]);
+        $this->seedAcademicHierarchy();
+
+        $version = $this->createPublishedTemplateWithVersion(
+            templateId: (string) Str::uuid(),
+            creatorId: $userId,
+            moduleId: 'MOD-1',
+            name: 'Plantilla Única',
+        );
+
+        $response = $this->postJson('/api/v1/documents/create-from-module', [
+            'module_id' => 'MOD-1',
+            'template_version_id' => $version->id,
+        ], $headers);
+
+        $response->assertCreated()
+            ->assertJsonPath('data.status', 'draft')
+            ->assertJsonPath('data.created_by', $userId)
+            ->assertJsonPath('data.owner_id', $userId)
+            ->assertJsonPath('data.module_id', 'MOD-1')
+            ->assertJsonPath('data.study_id', 'STUDY-1');
+
+        $this->assertDatabaseHas('documents', [
+            'id' => $response->json('data.id'),
+            'created_by' => $userId,
+            'owner_id' => $userId,
+            'template_version_id' => $version->id,
+            'module_id' => 'MOD-1',
+            'status' => 'draft',
+        ]);
+    }
+
+    public function test_create_from_module_requires_template_version_when_multiple_options_exist(): void
+    {
+        $userId = (string) Str::uuid();
+        $headers = $this->authHeaders($userId, [
+            'organization_id' => 'org-test',
+        ]);
+        $this->seedAcademicHierarchy();
+
+        $this->createPublishedTemplateWithVersion(
+            templateId: (string) Str::uuid(),
+            creatorId: $userId,
+            moduleId: 'MOD-1',
+            name: 'Plantilla A',
+        );
+
+        $this->createPublishedTemplateWithVersion(
+            templateId: (string) Str::uuid(),
+            creatorId: $userId,
+            moduleId: 'MOD-1',
+            name: 'Plantilla B',
+        );
+
+        $this->postJson('/api/v1/documents/create-from-module', [
+            'module_id' => 'MOD-1',
+        ], $headers)
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors(['template_version_id']);
+    }
+
+    public function test_new_document_appears_first_in_documents_list(): void
+    {
+        $userId = (string) Str::uuid();
+        $headers = $this->authHeaders($userId, [
+            'organization_id' => 'org-test',
+        ]);
+        $this->seedAcademicHierarchy();
+
+        $version = $this->createPublishedTemplateWithVersion(
+            templateId: (string) Str::uuid(),
+            creatorId: $userId,
+            moduleId: 'MOD-1',
+            name: 'Plantilla Única',
+        );
+
+        $first = $this->postJson('/api/v1/documents/create-from-module', [
+            'module_id' => 'MOD-1',
+            'template_version_id' => $version->id,
+        ], $headers)->assertCreated();
+
+        // Forzamos antigüedad para validar orden sin depender del reloj del sistema.
+        DB::table('documents')
+            ->where('id', $first->json('data.id'))
+            ->update(['created_at' => now()->subMinute()]);
+
+        $second = $this->postJson('/api/v1/documents/create-from-module', [
+            'module_id' => 'MOD-1',
+            'template_version_id' => $version->id,
+        ], $headers)->assertCreated();
+
+        $list = $this->getJson('/api/v1/documents', $headers)
+            ->assertOk()
+            ->json('data');
+
+        $this->assertNotEmpty($list);
+        $this->assertSame($second->json('data.id'), $list[0]['id']);
+    }
+}
+

--- a/backend/tests/Unit/Services/DocumentServiceCreationOptionsTest.php
+++ b/backend/tests/Unit/Services/DocumentServiceCreationOptionsTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Models\Template;
+use App\Models\TemplateVersion;
+use App\Repositories\Contracts\DocumentRepositoryInterface;
+use App\Repositories\Contracts\TemplateRepositoryInterface;
+use App\Repositories\Contracts\TemplateVersionRepositoryInterface;
+use App\Services\DocumentService;
+use Illuminate\Validation\ValidationException;
+use Mockery;
+use Tests\TestCase;
+
+class DocumentServiceCreationOptionsTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    public function test_creation_options_for_module_returns_only_templates_with_published_version(): void
+    {
+        $docRepo = Mockery::mock(DocumentRepositoryInterface::class);
+        $tplRepo = Mockery::mock(TemplateRepositoryInterface::class);
+        $verRepo = Mockery::mock(TemplateVersionRepositoryInterface::class);
+
+        $templateWithVersion = new Template;
+        $templateWithVersion->forceFill([
+            'id' => 'tpl-1',
+            'name' => 'Plantilla 1',
+            'description' => 'Desc 1',
+        ]);
+
+        $templateWithoutVersion = new Template;
+        $templateWithoutVersion->forceFill([
+            'id' => 'tpl-2',
+            'name' => 'Plantilla 2',
+            'description' => 'Desc 2',
+        ]);
+
+        $tplRepo->shouldReceive('listPublishedByModule')
+            ->once()
+            ->with('MOD-1')
+            ->andReturn(collect([$templateWithVersion, $templateWithoutVersion]));
+
+        $version = new TemplateVersion;
+        $version->forceFill(['id' => 'ver-1', 'template_id' => 'tpl-1']);
+
+        $verRepo->shouldReceive('findLatestPublishedForTemplate')
+            ->once()
+            ->with('tpl-1')
+            ->andReturn($version);
+
+        $verRepo->shouldReceive('findLatestPublishedForTemplate')
+            ->once()
+            ->with('tpl-2')
+            ->andReturn(null);
+
+        $service = new DocumentService($docRepo, $tplRepo, $verRepo);
+
+        $out = $service->creationOptionsForModule('MOD-1');
+
+        $this->assertCount(1, $out);
+        $this->assertSame('tpl-1', $out[0]['template_id']);
+        $this->assertSame('ver-1', $out[0]['template_version_id']);
+    }
+
+    public function test_create_from_module_throws_validation_when_no_template_options_exist(): void
+    {
+        $docRepo = Mockery::mock(DocumentRepositoryInterface::class);
+        $tplRepo = Mockery::mock(TemplateRepositoryInterface::class);
+        $verRepo = Mockery::mock(TemplateVersionRepositoryInterface::class);
+
+        $tplRepo->shouldReceive('listPublishedByModule')
+            ->once()
+            ->with('MOD-1')
+            ->andReturn(collect());
+
+        $service = new DocumentService($docRepo, $tplRepo, $verRepo);
+
+        $this->expectException(ValidationException::class);
+
+        $service->createFromModule('MOD-1', 'user-sub-1');
+    }
+}
+

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@tailwindcss/vite": "^4.2.2",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
+        "react-router-dom": "^7.14.1",
         "tailwindcss": "^4.2.2"
       },
       "devDependencies": {
@@ -2615,6 +2616,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3853,6 +3867,44 @@
         "react": "^19.2.4"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.14.1.tgz",
+      "integrity": "sha512-5BCvFskyAAVumqhEKh/iPhLOIkfxcEUz8WqFIARCkMg8hZZzDYX9CtwxXA0e+qT8zAxmMC0x3Ckb9iMONwc5jg==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.14.1.tgz",
+      "integrity": "sha512-ZkrQuwwhGibjQLqH1eCdyiZyLWglPxzxdl5tgwgKEyCSGC76vmAjleGocRe3J/MLfzMUIKwaFJWpFVJhK3d2xA==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.14.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -3962,6 +4014,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,8 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/node": "^24.12.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -24,11 +26,51 @@
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.4.0",
+        "jsdom": "^29.0.2",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.57.0",
         "vite": "^8.0.1",
         "vitest": "^3.2.4"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.10",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.10.tgz",
+      "integrity": "sha512-02OhhkKtgNRuicQ/nF3TRnGsxL9wp0r3Y7VlKWyOHHGmGyvXv03y+PnymU8FKFJMTjIr1Bk8U2g1HWSLrpAHww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.1.1",
+        "@csstools/css-color-parser": "^4.0.2",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.0.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.0.9.tgz",
+      "integrity": "sha512-r3ElRr7y8ucyN2KdICwGsmj19RoN13CLCa/pvGydghWK6ZzeKQ+TcDjVdtEZz2ElpndM5jXw//B9CEee0mWnVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -222,6 +264,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -268,6 +320,159 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -898,6 +1103,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@humanfs/core": {
@@ -1878,6 +2101,69 @@
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -1887,6 +2173,14 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -2399,6 +2693,17 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -2421,6 +2726,17 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -2450,6 +2766,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/brace-expansion": {
@@ -2644,12 +2970,40 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -2669,6 +3023,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deep-eql": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
@@ -2686,6 +3047,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -2694,6 +3066,14 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.331",
@@ -2713,6 +3093,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-module-lexer": {
@@ -3163,6 +3556,19 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3223,6 +3629,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -3257,6 +3670,57 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.0.2",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.2.tgz",
+      "integrity": "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.5",
+        "@asamuzakjp/dom-selector": "^7.0.6",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.24.5",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/jsesc": {
@@ -3619,6 +4083,17 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -3627,6 +4102,13 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/minimatch": {
       "version": "3.1.5",
@@ -3743,6 +4225,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -3836,6 +4331,36 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3866,6 +4391,14 @@
       "peerDependencies": {
         "react": "^19.2.4"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-router": {
       "version": "7.14.1",
@@ -3903,6 +4436,16 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve-from": {
@@ -3997,6 +4540,19 @@
         "@rollup/rollup-win32-x64-gnu": "4.60.1",
         "@rollup/rollup-win32-x64-msvc": "4.60.1",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -4120,6 +4676,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tailwindcss": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
@@ -4199,6 +4762,52 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
+      "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.28"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
+      "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -4268,6 +4877,16 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -4668,6 +5287,54 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4710,6 +5377,23 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,8 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^24.12.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
@@ -28,6 +30,7 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.4.0",
+    "jsdom": "^29.0.2",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.57.0",
     "vite": "^8.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "@tailwindcss/vite": "^4.2.2",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "react-router-dom": "^7.14.1",
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,10 +1,10 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
+import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
 import './index.css';
 import { NAV_ITEMS, Sidebar, Topbar } from './components/layout';
-import { ActiveSection } from './pages';
+import { DashboardPage, DocumentsPage, GroupsPage, PlaceholderPage, TemplatesPage } from './pages';
 
 function App() {
-  const [activeSection, setActiveSection] = useState('dashboard');
   const [isDark, setIsDark] = useState(() => {
     return (
       localStorage.getItem('theme') === 'dark' ||
@@ -21,18 +21,31 @@ function App() {
 
   if (isDark) document.documentElement.classList.add('dark');
 
-  const currentNav = NAV_ITEMS.find((n) => n.id === activeSection);
+  const location = useLocation();
+  const currentNav = useMemo(
+    () => NAV_ITEMS.find((n) => location.pathname === n.path || location.pathname.startsWith(`${n.path}/`)),
+    [location.pathname],
+  );
   const pageTitle = currentNav?.label ?? 'Maya DMS';
 
   return (
     <div className="min-h-screen bg-ui-body dark:bg-ui-dark-bg">
-      <Sidebar active={activeSection} onNav={setActiveSection} />
+      <Sidebar />
 
       <div className="ml-64 flex flex-col min-h-screen">
         <Topbar title={pageTitle} isDark={isDark} onToggleDark={handleToggleDark} />
 
         <main className="flex-1 overflow-auto">
-          <ActiveSection section={activeSection} />
+          <Routes>
+            <Route path="/" element={<Navigate to="/dashboard" replace />} />
+            <Route path="/dashboard" element={<DashboardPage />} />
+            <Route path="/documents" element={<DocumentsPage />} />
+            <Route path="/templates" element={<TemplatesPage />} />
+            <Route path="/groups" element={<GroupsPage />} />
+            <Route path="/upload" element={<PlaceholderPage />} />
+            <Route path="/search" element={<PlaceholderPage />} />
+            <Route path="*" element={<PlaceholderPage />} />
+          </Routes>
         </main>
       </div>
     </div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,7 +2,14 @@ import { useMemo, useState } from 'react';
 import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
 import './index.css';
 import { NAV_ITEMS, Sidebar, Topbar } from './components/layout';
-import { DashboardPage, DocumentsPage, GroupsPage, PlaceholderPage, TemplatesPage } from './pages';
+import {
+  DashboardPage,
+  DocumentEditorPage,
+  DocumentsPage,
+  GroupsPage,
+  PlaceholderPage,
+  TemplatesPage,
+} from './pages';
 
 function App() {
   const [isDark, setIsDark] = useState(() => {
@@ -22,11 +29,12 @@ function App() {
   if (isDark) document.documentElement.classList.add('dark');
 
   const location = useLocation();
+  const isEditorRoute = location.pathname.startsWith('/documents/') && location.pathname.endsWith('/editor');
   const currentNav = useMemo(
     () => NAV_ITEMS.find((n) => location.pathname === n.path || location.pathname.startsWith(`${n.path}/`)),
     [location.pathname],
   );
-  const pageTitle = currentNav?.label ?? 'Maya DMS';
+  const pageTitle = isEditorRoute ? 'Editor de Programación' : currentNav?.label ?? 'Maya DMS';
 
   return (
     <div className="min-h-screen bg-ui-body dark:bg-ui-dark-bg">
@@ -40,6 +48,7 @@ function App() {
             <Route path="/" element={<Navigate to="/dashboard" replace />} />
             <Route path="/dashboard" element={<DashboardPage />} />
             <Route path="/documents" element={<DocumentsPage />} />
+            <Route path="/documents/:documentId/editor" element={<DocumentEditorPage />} />
             <Route path="/templates" element={<TemplatesPage />} />
             <Route path="/groups" element={<GroupsPage />} />
             <Route path="/upload" element={<PlaceholderPage />} />

--- a/frontend/src/api/documents.ts
+++ b/frontend/src/api/documents.ts
@@ -1,12 +1,57 @@
 import type { Document } from '../types/documents';
-import { apiGetJson } from './http';
+import { apiFetchJson, apiGetJson } from './http';
 
 type DocumentsApiResponse = { data: Document[] };
+type CreationMode = 'none' | 'auto' | 'select';
+
+export type DocumentCreationOption = {
+  template_id: string;
+  template_version_id: string;
+  name: string;
+  description: string | null;
+};
+
+export type DocumentCreationOptionsResponse = {
+  data: {
+    can_create: boolean;
+    mode: CreationMode;
+    message: string | null;
+    options: DocumentCreationOption[];
+  };
+};
+
+type CreateFromModuleResponse = { data: Document };
 
 /**
  * GET /api/v1/documents — listado de documentos del usuario autenticado.
  */
 export async function fetchDocuments(): Promise<Document[]> {
   const body = await apiGetJson<DocumentsApiResponse>('documents');
+  return body.data;
+}
+
+/**
+ * GET /api/v1/documents/creation-options?module_id={id}
+ */
+export async function fetchDocumentCreationOptions(
+  moduleId: string,
+): Promise<DocumentCreationOptionsResponse['data']> {
+  const body = await apiGetJson<DocumentCreationOptionsResponse>(
+    `documents/creation-options?module_id=${encodeURIComponent(moduleId)}`,
+  );
+  return body.data;
+}
+
+/**
+ * POST /api/v1/documents/create-from-module
+ */
+export async function createDocumentFromModule(payload: {
+  module_id: string;
+  template_version_id?: string;
+}): Promise<Document> {
+  const body = await apiFetchJson<CreateFromModuleResponse>('documents/create-from-module', {
+    method: 'POST',
+    body: payload,
+  });
   return body.data;
 }

--- a/frontend/src/components/DocumentsContent.test.tsx
+++ b/frontend/src/components/DocumentsContent.test.tsx
@@ -1,0 +1,200 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DocumentsContent } from './DocumentsContent';
+
+const mockUseDocuments = vi.fn();
+const mockUseFilteredDocuments = vi.fn();
+const mockUseHierarchy = vi.fn();
+const mockFetchDocumentCreationOptions = vi.fn();
+const mockCreateDocumentFromModule = vi.fn();
+const mockNavigate = vi.fn();
+
+vi.mock('./CascadeFilters', () => ({
+  CascadeFilters: ({ onFilterChange }: { onFilterChange: (filters: { studyTypeId: string; studyId: string; moduleId: string }) => void }) => (
+    <button onClick={() => onFilterChange({ studyTypeId: 'st1', studyId: 's1', moduleId: 'm1' })}>
+      seleccionar-modulo
+    </button>
+  ),
+}));
+
+vi.mock('../features/documents', () => ({
+  useDocuments: () => mockUseDocuments(),
+  useFilteredDocuments: (...args: unknown[]) => mockUseFilteredDocuments(...args),
+}));
+
+vi.mock('../features/hierarchy', () => ({
+  useHierarchy: () => mockUseHierarchy(),
+}));
+
+vi.mock('../api/documents', () => ({
+  fetchDocumentCreationOptions: (...args: unknown[]) => mockFetchDocumentCreationOptions(...args),
+  createDocumentFromModule: (...args: unknown[]) => mockCreateDocumentFromModule(...args),
+}));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+const baseDocument = {
+  id: 'd-1',
+  template_id: 't-1',
+  title: 'Doc',
+  organization_id: 'org',
+  study_id: 's1',
+  module_id: 'm1',
+  created_by: 'u1',
+  owner_id: 'u1',
+  status: 'draft' as const,
+  current_version: 1,
+  submitted_at: null,
+  published_at: null,
+};
+
+describe('DocumentsContent creation flow', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseDocuments.mockReturnValue({
+      documents: [baseDocument],
+      loading: false,
+      error: null,
+      reload: vi.fn().mockResolvedValue(undefined),
+    });
+    mockUseFilteredDocuments.mockImplementation((docs: unknown[]) => docs);
+    mockUseHierarchy.mockReturnValue({ hierarchy: [], loading: false, error: null });
+  });
+
+  it('deshabilita nueva programación sin módulo seleccionado', () => {
+    render(<DocumentsContent />);
+
+    const button = screen.getByRole('button', { name: 'Nueva Programación' });
+    expect(button).toHaveProperty('disabled', true);
+    expect(
+      screen.getByText('Selecciona un módulo para crear una nueva programación.'),
+    ).toBeTruthy();
+  });
+
+  it('muestra estado none cuando no hay plantillas disponibles', async () => {
+    mockFetchDocumentCreationOptions.mockResolvedValue({
+      can_create: false,
+      mode: 'none',
+      message: 'No hay plantillas publicadas disponibles para este módulo.',
+      options: [],
+    });
+
+    render(<DocumentsContent />);
+    fireEvent.click(screen.getByRole('button', { name: 'seleccionar-modulo' }));
+
+    await waitFor(() =>
+      expect(mockFetchDocumentCreationOptions).toHaveBeenCalledWith('m1'),
+    );
+    expect(screen.getByRole('button', { name: 'Nueva Programación' })).toHaveProperty('disabled', true);
+    expect(
+      screen.getByText('No hay plantillas publicadas disponibles para este módulo.'),
+    ).toBeTruthy();
+  });
+
+  it('crea automáticamente y navega al editor con modo auto', async () => {
+    const reload = vi.fn().mockResolvedValue(undefined);
+    mockUseDocuments.mockReturnValue({
+      documents: [baseDocument],
+      loading: false,
+      error: null,
+      reload,
+    });
+    mockFetchDocumentCreationOptions.mockResolvedValue({
+      can_create: true,
+      mode: 'auto',
+      message: null,
+      options: [
+        {
+          template_id: 'tpl-1',
+          template_version_id: 'ver-1',
+          name: 'Plantilla única',
+          description: 'Desc',
+        },
+      ],
+    });
+    mockCreateDocumentFromModule.mockResolvedValue({ ...baseDocument, id: 'doc-new' });
+
+    render(<DocumentsContent />);
+    fireEvent.click(screen.getByRole('button', { name: 'seleccionar-modulo' }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Nueva Programación' })).toHaveProperty('disabled', false),
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Nueva Programación' }));
+
+    await waitFor(() =>
+      expect(mockCreateDocumentFromModule).toHaveBeenCalledWith({
+        module_id: 'm1',
+        template_version_id: 'ver-1',
+      }),
+    );
+    expect(reload).toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith('/documents/doc-new/editor');
+  });
+
+  it('muestra selector y crea con la plantilla elegida en modo select', async () => {
+    const reload = vi.fn().mockResolvedValue(undefined);
+    mockUseDocuments.mockReturnValue({
+      documents: [baseDocument],
+      loading: false,
+      error: null,
+      reload,
+    });
+    mockFetchDocumentCreationOptions.mockResolvedValue({
+      can_create: true,
+      mode: 'select',
+      message: null,
+      options: [
+        {
+          template_id: 'tpl-1',
+          template_version_id: 'ver-1',
+          name: 'Plantilla A',
+          description: 'Desc A',
+        },
+        {
+          template_id: 'tpl-2',
+          template_version_id: 'ver-2',
+          name: 'Plantilla B',
+          description: 'Desc B',
+        },
+      ],
+    });
+    mockCreateDocumentFromModule.mockResolvedValue({ ...baseDocument, id: 'doc-sel' });
+
+    render(<DocumentsContent />);
+    fireEvent.click(screen.getByRole('button', { name: 'seleccionar-modulo' }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Nueva Programación' })).toHaveProperty('disabled', false),
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Nueva Programación' }));
+
+    expect(
+      screen.getByText('Selecciona una plantilla para esta programación'),
+    ).toBeTruthy();
+
+    const select = screen.getByRole('combobox');
+    fireEvent.change(select, { target: { value: 'ver-2' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Crear' }));
+
+    await waitFor(() =>
+      expect(mockCreateDocumentFromModule).toHaveBeenCalledWith({
+        module_id: 'm1',
+        template_version_id: 'ver-2',
+      }),
+    );
+    expect(reload).toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith('/documents/doc-sel/editor');
+  });
+});
+

--- a/frontend/src/components/DocumentsContent.tsx
+++ b/frontend/src/components/DocumentsContent.tsx
@@ -1,4 +1,5 @@
-import { useState, useTransition } from 'react';
+import { useEffect, useMemo, useState, useTransition } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { CascadeFilters } from './CascadeFilters';
 import {
   useDocuments,
@@ -6,7 +7,13 @@ import {
   type CascadeDocumentFilters,
 } from '../features/documents';
 import { useHierarchy } from '../features/hierarchy';
+import {
+  createDocumentFromModule,
+  fetchDocumentCreationOptions,
+  type DocumentCreationOption,
+} from '../api/documents';
 import type { DocumentStatus } from '../types/documents';
+import { Button, Select } from '../ui';
 
 const STATUS_LABELS: Record<DocumentStatus, string> = {
   draft: 'Borrador',
@@ -27,16 +34,80 @@ const STATUS_CLASS: Record<DocumentStatus, string> = {
  * Componente para mostrar el contenido de los documentos.
  */
 export function DocumentsContent() {
+  const navigate = useNavigate();
   const [activeFilters, setActiveFilters] = useState<CascadeDocumentFilters>({
     studyTypeId: '',
     studyId: '',
     moduleId: '',
   });
+  const [creationOptions, setCreationOptions] = useState<DocumentCreationOption[]>([]);
+  const [creationMode, setCreationMode] = useState<'none' | 'auto' | 'select' | null>(null);
+  const [creationMessage, setCreationMessage] = useState<string | null>(null);
+  const [loadingCreationOptions, setLoadingCreationOptions] = useState(false);
+  const [creatingDocument, setCreatingDocument] = useState(false);
+  const [creationError, setCreationError] = useState<string | null>(null);
+  const [showSelector, setShowSelector] = useState(false);
+  const [selectedTemplateVersionId, setSelectedTemplateVersionId] = useState('');
   const [, startTransition] = useTransition();
 
-  const { documents, loading, error } = useDocuments();
+  const { documents, loading, error, reload } = useDocuments();
   const { hierarchy } = useHierarchy();
   const filtered = useFilteredDocuments(documents, activeFilters, hierarchy);
+  const selectedModuleId = activeFilters.moduleId;
+
+  const newProgrammingDisabledReason = useMemo(() => {
+    if (!selectedModuleId) {
+      return 'Selecciona un módulo para crear una nueva programación.';
+    }
+    if (loadingCreationOptions) {
+      return 'Cargando plantillas disponibles...';
+    }
+    if (creationMode === 'none') {
+      return creationMessage ?? 'No hay plantillas publicadas disponibles para este módulo.';
+    }
+    return null;
+  }, [selectedModuleId, loadingCreationOptions, creationMode, creationMessage]);
+
+  useEffect(() => {
+    if (!selectedModuleId) {
+      setCreationOptions([]);
+      setCreationMode(null);
+      setCreationMessage(null);
+      setSelectedTemplateVersionId('');
+      setShowSelector(false);
+      setCreationError(null);
+      return;
+    }
+
+    let cancelled = false;
+    const loadOptions = async () => {
+      try {
+        setLoadingCreationOptions(true);
+        setCreationError(null);
+        const data = await fetchDocumentCreationOptions(selectedModuleId);
+        if (cancelled) return;
+        setCreationOptions(data.options);
+        setCreationMode(data.mode);
+        setCreationMessage(data.message);
+        setSelectedTemplateVersionId(data.options[0]?.template_version_id ?? '');
+      } catch (err) {
+        if (!cancelled) {
+          setCreationError(err instanceof Error ? err.message : 'No se pudieron cargar las plantillas.');
+          setCreationOptions([]);
+          setCreationMode('none');
+          setCreationMessage('No se pudieron cargar las plantillas disponibles.');
+        }
+      } finally {
+        if (!cancelled) setLoadingCreationOptions(false);
+      }
+    };
+
+    void loadOptions();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedModuleId]);
 
   const handleClear = () =>
     startTransition(() =>
@@ -45,6 +116,35 @@ export function DocumentsContent() {
 
   const handleChange = (filters: CascadeDocumentFilters) =>
     startTransition(() => setActiveFilters(filters));
+
+  const handleCreateFromModule = async (templateVersionId?: string) => {
+    if (!selectedModuleId) return;
+    setCreatingDocument(true);
+    setCreationError(null);
+    try {
+      const created = await createDocumentFromModule({
+        module_id: selectedModuleId,
+        ...(templateVersionId ? { template_version_id: templateVersionId } : {}),
+      });
+      await reload();
+      navigate(`/documents/${created.id}/editor`);
+    } catch (err) {
+      setCreationError(err instanceof Error ? err.message : 'No se pudo crear la programación.');
+    } finally {
+      setCreatingDocument(false);
+    }
+  };
+
+  const handleNewProgrammingClick = async () => {
+    if (!selectedModuleId || loadingCreationOptions || creatingDocument) return;
+    if (creationMode === 'none') return;
+    if (creationMode === 'auto') {
+      const versionId = creationOptions[0]?.template_version_id;
+      await handleCreateFromModule(versionId);
+      return;
+    }
+    setShowSelector(true);
+  };
 
   return (
     <div className="p-6">
@@ -55,12 +155,71 @@ export function DocumentsContent() {
           <h2 className="text-sm font-semibold text-text-primary dark:text-text-dark-primary">
             Programaciones Didácticas
           </h2>
-          {!loading && (
-            <span className="text-xs text-text-muted dark:text-text-dark-muted">
-              {filtered.length} {filtered.length === 1 ? 'documento' : 'documentos'}
-            </span>
-          )}
+          <div className="flex items-center gap-3">
+            {!loading && (
+              <span className="text-xs text-text-muted dark:text-text-dark-muted">
+                {filtered.length} {filtered.length === 1 ? 'documento' : 'documentos'}
+              </span>
+            )}
+            <Button
+              type="button"
+              size="sm"
+              loading={creatingDocument}
+              disabled={newProgrammingDisabledReason !== null}
+              onClick={() => void handleNewProgrammingClick()}
+              title={newProgrammingDisabledReason ?? undefined}
+            >
+              Nueva Programación
+            </Button>
+          </div>
         </div>
+
+        {newProgrammingDisabledReason && (
+          <p className="px-5 py-2 text-xs text-text-muted dark:text-text-dark-muted border-b border-ui-border-l dark:border-ui-dark-border-l">
+            {newProgrammingDisabledReason}
+          </p>
+        )}
+        {creationError && (
+          <p className="px-5 py-2 text-xs text-warning-dark dark:text-warning-light border-b border-ui-border-l dark:border-ui-dark-border-l">
+            {creationError}
+          </p>
+        )}
+        {showSelector && creationMode === 'select' && (
+          <div className="px-5 py-3 border-b border-ui-border-l dark:border-ui-dark-border-l bg-ui-body dark:bg-ui-dark-bg flex flex-col gap-2">
+            <p className="text-xs font-semibold text-text-primary dark:text-text-dark-primary">
+              Selecciona una plantilla para esta programación
+            </p>
+            <Select
+              value={selectedTemplateVersionId}
+              onChange={(e) => setSelectedTemplateVersionId(e.target.value)}
+            >
+              {creationOptions.map((option) => (
+                <option key={option.template_version_id} value={option.template_version_id}>
+                  {option.name}
+                  {option.description ? ` — ${option.description}` : ''}
+                </option>
+              ))}
+            </Select>
+            <div className="flex items-center justify-end gap-2">
+              <Button
+                type="button"
+                variant="secondary"
+                onClick={() => setShowSelector(false)}
+                disabled={creatingDocument}
+              >
+                Cancelar
+              </Button>
+              <Button
+                type="button"
+                loading={creatingDocument}
+                disabled={!selectedTemplateVersionId}
+                onClick={() => void handleCreateFromModule(selectedTemplateVersionId)}
+              >
+                Crear
+              </Button>
+            </div>
+          </div>
+        )}
 
         <div className="divide-y divide-ui-border-l dark:divide-ui-dark-border-l">
           {loading && (

--- a/frontend/src/components/DocumentsContent.tsx
+++ b/frontend/src/components/DocumentsContent.tsx
@@ -126,8 +126,8 @@ export function DocumentsContent() {
         module_id: selectedModuleId,
         ...(templateVersionId ? { template_version_id: templateVersionId } : {}),
       });
-      await reload();
       navigate(`/documents/${created.id}/editor`);
+      void reload();
     } catch (err) {
       setCreationError(err instanceof Error ? err.message : 'No se pudo crear la programación.');
     } finally {

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,12 +1,7 @@
-import { Button } from '../../ui';
+import { NavLink } from 'react-router-dom';
 import { NAV_ITEMS } from './navItems';
 
-type Props = {
-  active: string;
-  onNav: (id: string) => void;
-};
-
-export function Sidebar({ active, onNav }: Props) {
+export function Sidebar() {
   return (
     <aside className="fixed inset-y-0 left-0 w-64 bg-ui-sidebar flex flex-col z-[100]">
       <div className="h-14 flex items-center px-5 border-b border-white/10">
@@ -14,25 +9,22 @@ export function Sidebar({ active, onNav }: Props) {
       </div>
 
       <nav className="flex-1 py-3 px-2 space-y-0.5 overflow-y-auto">
-        {NAV_ITEMS.map((item) => {
-          const isActive = active === item.id;
-          return (
-            <Button
-              key={item.id}
-              type="button"
-              variant="unstyled"
-              onClick={() => onNav(item.id)}
-              className={`w-full flex items-center gap-3 rounded px-3 py-2 text-left text-sm font-medium transition-colors focus-visible:ring-white/35 ${
+        {NAV_ITEMS.map((item) => (
+          <NavLink
+            key={item.id}
+            to={item.path}
+            className={({ isActive }) =>
+              `w-full flex items-center gap-3 rounded px-3 py-2 text-left text-sm font-medium transition-colors focus-visible:ring-white/35 ${
                 isActive
                   ? 'bg-ui-sidebar-active text-white'
                   : 'text-white/70 hover:bg-ui-sidebar-hover hover:text-white'
-              }`}
-            >
-              <item.icon />
-              {item.label}
-            </Button>
-          );
-        })}
+              }`
+            }
+          >
+            <item.icon />
+            {item.label}
+          </NavLink>
+        ))}
       </nav>
 
       <div className="border-t border-white/10 px-4 py-3">

--- a/frontend/src/components/layout/navItems.tsx
+++ b/frontend/src/components/layout/navItems.tsx
@@ -12,13 +12,14 @@ export type NavItem = {
   id: string;
   label: string;
   icon: FC;
+  path: string;
 };
 
 export const NAV_ITEMS: NavItem[] = [
-  { id: 'dashboard', label: 'Dashboard', icon: HomeIcon },
-  { id: 'documents', label: 'Documentos', icon: FolderIcon },
-  { id: 'templates', label: 'Plantillas', icon: TemplateIcon },
-  { id: 'groups', label: 'Grupos', icon: UsersIcon },
-  { id: 'upload', label: 'Subir archivo', icon: UploadIcon },
-  { id: 'search', label: 'Búsqueda', icon: SearchIcon },
+  { id: 'dashboard', label: 'Dashboard', icon: HomeIcon, path: '/dashboard' },
+  { id: 'documents', label: 'Documentos', icon: FolderIcon, path: '/documents' },
+  { id: 'templates', label: 'Plantillas', icon: TemplateIcon, path: '/templates' },
+  { id: 'groups', label: 'Grupos', icon: UsersIcon, path: '/groups' },
+  { id: 'upload', label: 'Subir archivo', icon: UploadIcon, path: '/upload' },
+  { id: 'search', label: 'Búsqueda', icon: SearchIcon, path: '/search' },
 ];

--- a/frontend/src/features/documents/hooks/useDocuments.ts
+++ b/frontend/src/features/documents/hooks/useDocuments.ts
@@ -10,15 +10,28 @@ export function useDocuments(): {
   documents: Document[];
   loading: boolean;
   error: Error | null;
+  reload: () => Promise<void>;
 } {
   const [documents, setDocuments] = useState<Document[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
 
+  const load = async () => {
+    try {
+      setLoading(true);
+      const data = await fetchDocuments();
+      setDocuments(data);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error('Unknown error'));
+    } finally {
+      setLoading(false);
+    }
+  };
+
   useEffect(() => {
     let cancelled = false;
-
-    const load = async () => {
+    const loadOnMount = async () => {
       try {
         setLoading(true);
         const data = await fetchDocuments();
@@ -34,13 +47,17 @@ export function useDocuments(): {
         if (!cancelled) setLoading(false);
       }
     };
-
-    void load();
+    void loadOnMount();
 
     return () => {
       cancelled = true;
     };
   }, []);
 
-  return { documents, loading, error };
+  return {
+    documents,
+    loading,
+    error,
+    reload: load,
+  };
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,5 +1,6 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
 import './index.css'
 import App from './App.tsx'
 import { HierarchyProvider } from './features/hierarchy'
@@ -9,8 +10,10 @@ bootstrapSessionToken()
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <HierarchyProvider>
-      <App />
-    </HierarchyProvider>
+    <BrowserRouter>
+      <HierarchyProvider>
+        <App />
+      </HierarchyProvider>
+    </BrowserRouter>
   </StrictMode>,
 )

--- a/frontend/src/pages/DocumentEditorPage.tsx
+++ b/frontend/src/pages/DocumentEditorPage.tsx
@@ -1,0 +1,30 @@
+import { Link, useParams } from 'react-router-dom';
+import { Button } from '../ui';
+
+/**
+ * Pantalla mínima de editor para soportar redirección tras crear documento.
+ * Se sustituirá por el editor completo en iteraciones siguientes.
+ */
+export function DocumentEditorPage() {
+  const { documentId } = useParams<{ documentId: string }>();
+
+  return (
+    <div className="p-6">
+      <div className="bg-ui-card dark:bg-ui-dark-card rounded-lg border border-ui-border dark:border-ui-dark-border shadow-card p-6 space-y-4">
+        <h2 className="text-lg font-semibold text-text-primary dark:text-text-dark-primary">
+          Editor de Programación
+        </h2>
+        <p className="text-sm text-text-secondary dark:text-text-dark-secondary">
+          Documento: <span className="font-mono">{documentId}</span>
+        </p>
+        <p className="text-sm text-text-muted dark:text-text-dark-muted">
+          Pantalla mínima de destino tras crear. El editor completo se implementará en otra tarea.
+        </p>
+        <Link to="/documents">
+          <Button variant="secondary">Volver al listado</Button>
+        </Link>
+      </div>
+    </div>
+  );
+}
+

--- a/frontend/src/pages/index.ts
+++ b/frontend/src/pages/index.ts
@@ -1,5 +1,6 @@
 export { ActiveSection } from './ActiveSection';
 export { DashboardPage } from './DashboardPage';
+export { DocumentEditorPage } from './DocumentEditorPage';
 export { DocumentsPage } from './DocumentsPage';
 export { GroupsPage } from './GroupsPage';
 export { PlaceholderPage } from './PlaceholderPage';

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    environment: 'node',
-    include: ['src/**/*.test.ts'],
+    environment: 'jsdom',
+    include: ['src/**/*.test.{ts,tsx}'],
   },
 });


### PR DESCRIPTION
- Se implementó en backend la creación de documentos desde módulo con tres comportamientos:
     - sin plantillas publicadas: no se permite crear,
     - una plantilla publicada: creación automática,
     - múltiples plantillas publicadas: selector simple.
- Se reforzó que created_by/owner_id se obtengan desde el sub del JWT autenticado.
- Se ajustó el listado para devolver documentos ordenados por created_at DESC y facilitar aparición inmediata del nuevo.

- En frontend se migró navegación a rutas y se añadió el flujo Nueva Programación con estados none/auto/select, incluyendo redirección a pantalla mínima de editor.

- Se añadieron tests backend y frontend para cubrir escenarios principales del flujo.