### PR TITLE
Features/refactor infra

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ frontend/.env.local
 frontend/.env.*.local
 frontend/node_modules/
 frontend/dist/
+frontend/refresh_token.sh
 dist/
 
 # =============================================================================

--- a/backend/database/seeders/AcademicHierarchySeeder.php
+++ b/backend/database/seeders/AcademicHierarchySeeder.php
@@ -13,10 +13,6 @@ class AcademicHierarchySeeder extends Seeder
 {
     public function run(): void
     {
-        if (! Schema::hasTable('study_types_source')) {
-            return;
-        }
-
         $filePath = database_path('data/academic_hierarchy_mock.php');
         if (! is_file($filePath)) {
             return;
@@ -29,21 +25,24 @@ class AcademicHierarchySeeder extends Seeder
         }
 
         $studyTypes = $loaded['study_types_source'] ?? [];
-        $studies  = $loaded['studies_source'] ?? [];
-        $modules  = $loaded['course_modules_source'] ?? [];
+        $studies    = $loaded['studies_source'] ?? [];
+        $modules    = $loaded['course_modules_source'] ?? [];
 
-        if ($studyTypes !== []) {
-            DB::table('study_types_source')->insertOrIgnore($studyTypes);
-        }
-        if ($studies !== []) {
-            DB::table('studies_source')->insertOrIgnore($studies);
-        }
-        if ($modules !== []) {
-            DB::table('course_modules_source')->insertOrIgnore($modules);
+        // Tablas *_source: presentes en entorno local con FDW (o futura producción).
+        if (Schema::hasTable('study_types_source')) {
+            if ($studyTypes !== []) {
+                DB::table('study_types_source')->insertOrIgnore($studyTypes);
+            }
+            if ($studies !== []) {
+                DB::table('studies_source')->insertOrIgnore($studies);
+            }
+            if ($modules !== []) {
+                DB::table('course_modules_source')->insertOrIgnore($modules);
+            }
         }
 
-        // En entorno local la migración crea tablas directas (no FDW).
-        // Hay que poblarlas también para que la app pueda leer los datos.
+        // Tablas directas: presentes en entorno local/testing sin FDW.
+        // La migración las crea vacías; hay que poblarlas aquí.
         if (Schema::hasTable('study_types') && DB::table('study_types')->count() === 0) {
             if ($studyTypes !== []) {
                 DB::table('study_types')->insertOrIgnore($studyTypes);

--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -6,9 +6,11 @@ echo "[entrypoint] Clearing bootstrap cache..."
 rm -f /var/www/html/bootstrap/cache/packages.php
 rm -f /var/www/html/bootstrap/cache/services.php
 
-# Install dependencies if vendor is missing (handles fresh anonymous volumes)
-if [ ! -f /var/www/html/vendor/autoload.php ]; then
-    echo "[entrypoint] vendor/autoload.php not found. Running composer install..."
+# Install dependencies if vendor is missing OR if path packages are not linked
+# (handles fresh anonymous volumes AND the case where autoload.php exists but
+# path packages like maya/shared-auth-laravel were dropped from the volume)
+if [ ! -f /var/www/html/vendor/autoload.php ] || [ ! -d /var/www/html/vendor/maya/shared-auth-laravel ]; then
+    echo "[entrypoint] vendor incomplete. Running composer install..."
     composer install --optimize-autoloader --no-interaction --ignore-platform-reqs
 fi
 


### PR DESCRIPTION
  # Cambios
  ## Qué resuelve: 

JwtMiddleware no encontrado tras recrear el contenedor — docker compose up --build frontend dejaba vendor/maya/ vacío mientras autoload.php existía, saltando el composer install 

  ## ¿Rompe algo?
No. Añade una condición al if; si el paquete ya estaba no hace nada  