### PR TITLE
Feature/backend plantillas

### DIFF
--- a/backend/app/Http/Controllers/Api/TemplateController.php
+++ b/backend/app/Http/Controllers/Api/TemplateController.php
@@ -211,20 +211,38 @@ class TemplateController extends Controller
     }
 
     /**
-     * Sincroniza los validadores de la plantilla.
+     * Sincroniza los revisores de la plantilla normativa.
      */
-    public function syncValidators(Request $request, string $template): JsonResponse
+    public function syncReviewers(Request $request, string $template): JsonResponse
     {
         $model = $this->templateService->findOrFail($template);
         $this->authorize('update', $model);
 
         $request->validate([
-            'user_ids' => ['present', 'array'],
+            'user_ids'   => ['present', 'array'],
             'user_ids.*' => ['required', 'string', 'exists:users,id'],
         ]);
 
-        $this->templateService->syncValidators($model->id, $request->input('user_ids'));
+        $this->templateService->syncReviewers($model->id, $request->input('user_ids'));
 
-        return response()->json(['message' => 'Validadores sincronizados correctamente.']);
+        return response()->json(['message' => 'Revisores de plantilla sincronizados correctamente.']);
+    }
+
+    /**
+     * Sincroniza el pool de posibles revisores de documentos generados desde la plantilla.
+     */
+    public function syncDocumentReviewers(Request $request, string $template): JsonResponse
+    {
+        $model = $this->templateService->findOrFail($template);
+        $this->authorize('update', $model);
+
+        $request->validate([
+            'user_ids'   => ['present', 'array'],
+            'user_ids.*' => ['required', 'string', 'exists:users,id'],
+        ]);
+
+        $this->templateService->syncDocumentReviewers($model->id, $request->input('user_ids'));
+
+        return response()->json(['message' => 'Validadores de documento sincronizados correctamente.']);
     }
 }

--- a/backend/app/Http/Controllers/Api/TemplateController.php
+++ b/backend/app/Http/Controllers/Api/TemplateController.php
@@ -190,19 +190,6 @@ class TemplateController extends Controller
     }
 
     /**
-     * Publicado → borrador para preparar otra versión publicable.
-     */
-    public function reopenDraft(string $template): TemplateResource
-    {
-        $model = $this->templateService->findOrFail($template);
-        $this->authorize('reopenDraft', $model);
-
-        $updated = $this->templateService->reopenDraft($model->id, (string) Auth::id());
-
-        return new TemplateResource($updated);
-    }
-
-    /**
      * Historial de versiones publicadas (metadatos).
      */
     public function versions(string $template): ResourceCollection

--- a/backend/app/Http/Controllers/Api/TemplateController.php
+++ b/backend/app/Http/Controllers/Api/TemplateController.php
@@ -157,11 +157,28 @@ class TemplateController extends Controller
     }
 
     /**
+     * En revisión → aprobación del revisor activo.
+     *
+     * Si todos los revisores han aprobado, la plantilla se publica automáticamente.
+     * En modo secuencial verifica que los stages anteriores estén aprobados.
+     */
+    public function approveReview(string $template): TemplateResource
+    {
+        $model = $this->templateService->findOrFail($template);
+        $this->authorize('review', $model);
+
+        $updated = $this->templateService->approveReview($model->id, (string) Auth::id());
+
+        return new TemplateResource($updated);
+    }
+
+    /**
      * En revisión → publicado + snapshot (revisor; changelog obligatorio).
      */
     public function publish(PublishTemplateRequest $request, string $template): TemplateResource
     {
         $model = $this->templateService->findOrFail($template);
+        $this->authorize('review', $model);
 
         $updated = $this->templateService->publishWithSnapshot(
             $model->id,

--- a/backend/app/Http/Controllers/Api/UserController.php
+++ b/backend/app/Http/Controllers/Api/UserController.php
@@ -13,9 +13,6 @@ class UserController extends Controller
     /**
      * GET /api/v1/users?search={term}&per_page={n}
      *
-     * F-05.1 describe colaboradores/revisores pero no el endpoint `/users`; el acceso
-     * con `users.search` es decisión de producto hasta que el backlog lo cierre.
-     *
      * Búsqueda case-insensitive por nombre, email y departamento.
      * Devuelve { data: [...] } con el campo `role` mapeado desde `department`.
      *
@@ -37,7 +34,6 @@ class UserController extends Controller
 
         $term = '%' . mb_strtolower($search) . '%';
 
-        // DB::table evita que Eloquent castee el id (string) a int.
         $users = DB::table('users')
             ->where(function ($query) use ($term) {
                 $query->whereRaw('LOWER(name) LIKE ?', [$term])
@@ -51,7 +47,53 @@ class UserController extends Controller
                 'id'    => $u->id,
                 'name'  => $u->name,
                 'email' => $u->email,
-                'role'  => $u->department, // department → role para el frontend
+                'role'  => $u->department,
+            ]);
+
+        return response()->json(['data' => $users]);
+    }
+
+    /**
+     * GET /api/v1/users/reviewer-candidates?search={term}&per_page={n}
+     *
+     * Devuelve los usuarios que tienen el permiso `templates.review` y, por tanto,
+     * pueden ser seleccionados como revisores de una plantilla normativa.
+     * El front no necesita conocer el código de permiso interno.
+     *
+     * `search` es opcional; si se omite devuelve todos los candidatos (hasta per_page).
+     */
+    public function reviewerCandidates(Request $request): JsonResponse
+    {
+        $user = $request->user();
+        if (! $user instanceof JwtUser || ! $user->hasPermission('users.search')) {
+            abort(403, 'No tienes permiso para buscar usuarios.');
+        }
+
+        $search  = trim((string) $request->get('search', ''));
+        $perPage = min((int) $request->get('per_page', 20), 50);
+
+        $query = DB::table('users')
+            ->join('user_permissions', 'users.id', '=', 'user_permissions.user_id')
+            ->where('user_permissions.permission_code', 'templates.review');
+
+        if (mb_strlen($search) >= 2) {
+            $term = '%' . mb_strtolower($search) . '%';
+            $query->where(function ($q) use ($term) {
+                $q->whereRaw('LOWER(users.name) LIKE ?', [$term])
+                  ->orWhereRaw('LOWER(users.email) LIKE ?', [$term])
+                  ->orWhereRaw('LOWER(users.department) LIKE ?', [$term]);
+            });
+        }
+
+        $users = $query
+            ->select('users.id', 'users.name', 'users.email', 'users.department')
+            ->limit($perPage)
+            ->get()
+            ->map(static fn (object $u): array => [
+                'id'    => $u->id,
+                'name'  => $u->name,
+                'email' => $u->email,
+                'role'  => $u->department,
             ]);
 
         return response()->json(['data' => $users]);

--- a/backend/app/Http/Requests/Documents/StoreDocumentRequest.php
+++ b/backend/app/Http/Requests/Documents/StoreDocumentRequest.php
@@ -5,8 +5,8 @@ namespace App\Http\Requests\Documents;
 use App\DTOs\Documents\CreateDocumentDto;
 use App\Models\JwtUser;
 use App\Models\Template;
+use App\Models\TemplateVersion;
 use Illuminate\Foundation\Http\FormRequest;
-use Illuminate\Validation\Rule;
 
 class StoreDocumentRequest extends FormRequest
 {
@@ -20,11 +20,21 @@ class StoreDocumentRequest extends FormRequest
             return false;
         }
 
-        if (! $this->filled('template_id')) {
+        if (! $this->filled('template_id') && ! $this->filled('template_version_id')) {
             return true;
         }
 
-        $template = Template::query()->find($this->input('template_id'));
+        $template = null;
+        if ($this->filled('template_id')) {
+            $template = Template::query()->find($this->input('template_id'));
+        } elseif ($this->filled('template_version_id')) {
+            $templateId = TemplateVersion::query()
+                ->whereKey($this->input('template_version_id'))
+                ->value('template_id');
+            if (is_string($templateId)) {
+                $template = Template::query()->find($templateId);
+            }
+        }
 
         return $template !== null && $user->can('view', $template);
     }
@@ -37,18 +47,15 @@ class StoreDocumentRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'template_id' => ['required', 'uuid', 'exists:templates,id'],
+            'template_id' => ['sometimes', 'nullable', 'uuid', 'exists:templates,id'],
             'title' => ['required', 'string', 'max:255'],
             'study_type_id' => ['sometimes', 'nullable', 'string', 'max:255'],
             'study_id' => ['sometimes', 'nullable', 'string', 'max:255'],
             'module_id' => ['sometimes', 'nullable', 'string', 'max:255'],
             'template_version_id' => [
-                'sometimes',
-                'nullable',
+                'required_without:template_id',
                 'uuid',
-                Rule::exists('template_versions', 'id')->where(
-                    fn ($q) => $q->where('template_id', $this->input('template_id')),
-                ),
+                'exists:template_versions,id',
             ],
         ];
     }
@@ -58,15 +65,24 @@ class StoreDocumentRequest extends FormRequest
      */
     public function toDto(string $createdBy, string $ownerId): CreateDocumentDto
     {
+        $templateVersionId = $this->validated('template_version_id');
+        $templateId = $this->validated('template_id');
+
+        if (! is_string($templateId) && is_string($templateVersionId)) {
+            $templateId = (string) TemplateVersion::query()
+                ->whereKey($templateVersionId)
+                ->value('template_id');
+        }
+
         return new CreateDocumentDto(
-            templateId: $this->validated('template_id'),
+            templateId: (string) $templateId,
             title: $this->validated('title'),
             createdBy: $createdBy,
             ownerId: $ownerId,
             studyTypeId: $this->validated('study_type_id') ?? null,
             studyId: $this->validated('study_id') ?? null,
             moduleId: $this->validated('module_id') ?? null,
-            templateVersionId: $this->validated('template_version_id') ?? null,
+            templateVersionId: $templateVersionId ?? null,
         );
     }
 }

--- a/backend/app/Http/Requests/Templates/IndexTemplateRequest.php
+++ b/backend/app/Http/Requests/Templates/IndexTemplateRequest.php
@@ -30,7 +30,7 @@ class IndexTemplateRequest extends FormRequest
     {
         return [
             'visibility_level' => ['sometimes', 'nullable', Rule::enum(TemplateVisibilityLevel::class)],
-            'status'           => ['sometimes', 'nullable', 'string', 'in:draft,published,archived'],
+            'status'           => ['sometimes', 'nullable', 'string', 'in:draft,in_review,published,archived'],
             'study_type_id'    => ['sometimes', 'nullable', 'string', 'max:255'],
             'study_id'         => ['sometimes', 'nullable', 'string', 'max:255'],
             'module_id'        => ['sometimes', 'nullable', 'string', 'max:255'],

--- a/backend/app/Http/Resources/TemplateResource.php
+++ b/backend/app/Http/Resources/TemplateResource.php
@@ -31,10 +31,14 @@ class TemplateResource extends JsonResource
             'version'            => $this->version,
             'review_stages'      => $this->review_stages,
             'review_mode'        => $this->review_mode,
-            'reviewers'          => $this->whenLoaded('reviewers', fn () => $this->reviewers
+            'reviewers'           => $this->whenLoaded('reviewers', fn () => $this->reviewers
                 ->sortBy('stage')
                 ->values()
                 ->map(fn ($r) => ['user_id' => $r->user_id, 'stage' => $r->stage])
+                ->all()),
+            'document_reviewers' => $this->whenLoaded('documentReviewers', fn () => $this->documentReviewers
+                ->map(fn ($v) => $v->user_id)
+                ->values()
                 ->all()),
             'created_at'         => $this->created_at?->toIso8601String(),
             'updated_at'         => $this->updated_at?->toIso8601String(),

--- a/backend/app/Models/Template.php
+++ b/backend/app/Models/Template.php
@@ -139,6 +139,11 @@ class Template extends Model
         return $this->hasMany(TemplateReviewer::class);
     }
 
+    public function documentReviewers(): HasMany
+    {
+        return $this->hasMany(TemplateDocumentReviewer::class);
+    }
+
     public function documents(): HasMany
     {
         return $this->hasMany(Document::class);

--- a/backend/app/Models/TemplateDocumentReviewer.php
+++ b/backend/app/Models/TemplateDocumentReviewer.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Pool de posibles revisores de documento para una plantilla.
+ *
+ * PK compuesta (template_id, user_id) — no hay identidad propia por fila.
+ * Esta tabla define quiénes pueden ser elegidos como revisores al crear un
+ * documento desde la plantilla. El stage y el estado se asignan en `document_reviews`.
+ */
+class TemplateDocumentReviewer extends Model
+{
+    public $incrementing = false;
+
+    protected $primaryKey = ['template_id', 'user_id'];
+
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'template_id',
+        'user_id',
+    ];
+
+    public function template(): BelongsTo
+    {
+        return $this->belongsTo(Template::class);
+    }
+}

--- a/backend/app/Models/TemplateDocumentReviewer.php
+++ b/backend/app/Models/TemplateDocumentReviewer.php
@@ -10,8 +10,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  *
  * PK compuesta (template_id, user_id) — no hay identidad propia por fila.
  * Esta tabla define quiénes pueden ser elegidos como revisores al crear un
- * documento desde la plantilla. Se conserva `template_version_id` para trazabilidad
- * de la configuración usada en cada publicación.
+ * documento desde la plantilla.
  */
 class TemplateDocumentReviewer extends Model
 {
@@ -23,7 +22,6 @@ class TemplateDocumentReviewer extends Model
 
     protected $fillable = [
         'template_id',
-        'template_version_id',
         'user_id',
     ];
 
@@ -32,8 +30,4 @@ class TemplateDocumentReviewer extends Model
         return $this->belongsTo(Template::class);
     }
 
-    public function templateVersion(): BelongsTo
-    {
-        return $this->belongsTo(TemplateVersion::class);
-    }
 }

--- a/backend/app/Models/TemplateDocumentReviewer.php
+++ b/backend/app/Models/TemplateDocumentReviewer.php
@@ -10,7 +10,8 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  *
  * PK compuesta (template_id, user_id) — no hay identidad propia por fila.
  * Esta tabla define quiénes pueden ser elegidos como revisores al crear un
- * documento desde la plantilla. El stage y el estado se asignan en `document_reviews`.
+ * documento desde la plantilla. Se conserva `template_version_id` para trazabilidad
+ * de la configuración usada en cada publicación.
  */
 class TemplateDocumentReviewer extends Model
 {
@@ -22,11 +23,17 @@ class TemplateDocumentReviewer extends Model
 
     protected $fillable = [
         'template_id',
+        'template_version_id',
         'user_id',
     ];
 
     public function template(): BelongsTo
     {
         return $this->belongsTo(Template::class);
+    }
+
+    public function templateVersion(): BelongsTo
+    {
+        return $this->belongsTo(TemplateVersion::class);
     }
 }

--- a/backend/app/Models/TemplateReviewer.php
+++ b/backend/app/Models/TemplateReviewer.php
@@ -17,6 +17,7 @@ class TemplateReviewer extends Model
 
     protected $fillable = [
         'template_id',
+        'template_version_id',
         'user_id',
         'stage',
         'status',
@@ -32,5 +33,10 @@ class TemplateReviewer extends Model
     public function template(): BelongsTo
     {
         return $this->belongsTo(Template::class);
+    }
+
+    public function templateVersion(): BelongsTo
+    {
+        return $this->belongsTo(TemplateVersion::class);
     }
 }

--- a/backend/app/Models/TemplateReviewer.php
+++ b/backend/app/Models/TemplateReviewer.php
@@ -5,10 +5,11 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class TemplateReviewer extends Model
 {
-    use HasUuids;
+    use HasUuids, SoftDeletes;
 
     protected $keyType = 'string';
 
@@ -18,6 +19,7 @@ class TemplateReviewer extends Model
         'template_id',
         'user_id',
         'stage',
+        'status',
     ];
 
     protected function casts(): array

--- a/backend/app/Models/TemplateReviewer.php
+++ b/backend/app/Models/TemplateReviewer.php
@@ -17,7 +17,6 @@ class TemplateReviewer extends Model
 
     protected $fillable = [
         'template_id',
-        'template_version_id',
         'user_id',
         'stage',
         'status',
@@ -35,8 +34,4 @@ class TemplateReviewer extends Model
         return $this->belongsTo(Template::class);
     }
 
-    public function templateVersion(): BelongsTo
-    {
-        return $this->belongsTo(TemplateVersion::class);
-    }
 }

--- a/backend/app/Policies/TemplatePolicy.php
+++ b/backend/app/Policies/TemplatePolicy.php
@@ -7,24 +7,28 @@ use App\Models\JwtUser;
 use App\Models\Template;
 
 /**
- * Autorización sobre plantillas normativas y segregación de funciones (SoD).
+ * Autorización sobre plantillas normativas y Segregación de Funciones (SoD).
  *
- * Listado y detalle exigen {@see self::viewAny} / {@see self::view} con permiso
- * `templates.read`; el global scope de {@see Template} acota qué filas existen.
+ * REGLAS DE EDICIÓN:
+ * - Solo el creador puede editar una plantilla, y únicamente cuando está en borrador (`draft`).
+ * - La visibilidad no personal (compartida) exige además `templates.create`.
  *
- * - Alta con visibilidad no personal: {@see self::create} exige `templates.create`.
- * - Editar contenido ajeno (o propio con cambios que no sean solo visibilidad): `templates.update`.
- * - Borrar / archivar ajena: `templates.delete`.
- * - Subir visibilidad a no personal en PATCH: además de poder editar, {@see self::create} con el nivel objetivo.
+ * REGLAS DE BORRADO:
+ * - El creador puede borrar su propia plantilla.
+ * - Cualquier usuario con `templates.delete` puede borrar cualquier plantilla.
  *
- * En controladores:
+ * REGLAS DE REVISIÓN:
+ * - Solo los revisores explícitamente asignados en `template_reviewers` pueden aprobar/rechazar.
+ * - El creador nunca puede ser revisor de su propia plantilla.
+ *
+ * Uso en controladores:
  *   $this->authorize('create', [Template::class, $visibilityLevelString]);
- *   $this->authorize('update', [$template, $targetVisibilityLevelString]); // opcional 2.º arg si se envía visibility_level
+ *   $this->authorize('update', [$template, $targetVisibilityLevelString]);
  */
 class TemplatePolicy
 {
     /**
-     * Listar plantillas: requiere `templates.read`; el alcance acota filas visibles.
+     * Listar plantillas: requiere `templates.read`; el global scope acota filas visibles.
      */
     public function viewAny(JwtUser $user): bool
     {
@@ -32,7 +36,7 @@ class TemplatePolicy
     }
 
     /**
-     * Ver una plantilla: requiere `templates.read`; el alcance impide cargar filas ajenas.
+     * Ver una plantilla: requiere `templates.read`; el scope impide cargar filas ajenas.
      */
     public function view(JwtUser $user, Template $template): bool
     {
@@ -40,9 +44,12 @@ class TemplatePolicy
     }
 
     /**
-     * Crear plantilla. Si el segundo argumento se omite (solo clase), se asume visibilidad personal.
+     * Crear plantilla.
      *
-     * @param  string|null  $visibilityLevel  Valor de {@see TemplateVisibilityLevel} (p. ej. tras array_shift del FQCN).
+     * Visibilidad personal: cualquier usuario autenticado.
+     * Visibilidad compartida: requiere `templates.create`.
+     *
+     * @param  string|null  $visibilityLevel  Valor de {@see TemplateVisibilityLevel}.
      */
     public function create(JwtUser $user, ?string $visibilityLevel = null): bool
     {
@@ -56,13 +63,20 @@ class TemplatePolicy
     }
 
     /**
-     * Actualizar plantilla. Si se pasa el nivel de visibilidad objetivo, aplica la misma regla que en {@see create}.
+     * Editar una plantilla.
      *
-     * @param  string|null  $targetVisibilityLevel  Valor pretendido de visibility_level en el body, si viene en la petición.
+     * Solo el creador puede editar, y únicamente cuando la plantilla está en borrador.
+     * Si se cambia la visibilidad a no personal, aplica además la regla de {@see self::create}.
+     *
+     * @param  string|null  $targetVisibilityLevel  Nivel de visibilidad pretendido, si viene en el body.
      */
     public function update(JwtUser $user, Template $template, ?string $targetVisibilityLevel = null): bool
     {
-        if (! $this->userCanEditTemplate($user, $template)) {
+        if ($user->getAuthIdentifier() !== $template->created_by) {
+            return false;
+        }
+
+        if ($template->status !== 'draft') {
             return false;
         }
 
@@ -75,14 +89,21 @@ class TemplatePolicy
 
     /**
      * Eliminar o archivar plantilla.
+     *
+     * El creador puede borrar su propia plantilla.
+     * Cualquier usuario con `templates.delete` puede borrar cualquier plantilla.
      */
     public function delete(JwtUser $user, Template $template): bool
     {
-        return $this->userCanDeleteTemplate($user, $template);
+        if ($user->getAuthIdentifier() === $template->created_by) {
+            return true;
+        }
+
+        return $user->hasPermission('templates.delete');
     }
 
     /**
-     * Generar copia en borrador; quien puede ver la plantilla puede clonarla.
+     * Clonar plantilla: cualquier usuario que pueda verla puede clonarla.
      */
     public function clone(JwtUser $user, Template $template): bool
     {
@@ -90,38 +111,30 @@ class TemplatePolicy
     }
 
     /**
-     * Revisión / aprobación en el flujo de plantilla.
+     * Revisión / aprobación (SoD — F-01.3).
      *
-     * Solo los usuarios explícitamente asignados como revisores en `template_reviewers`
-     * pueden aprobar o rechazar la plantilla. La segregación de funciones (el creador
-     * no puede ser revisor de la suya) se garantiza en {@see self::syncReviewers} o
-     * en la validación del wizard, no aquí.
+     * Requiere estar asignado en `template_reviewers` Y no ser el creador de la plantilla.
+     * El creador nunca puede aprobar o rechazar su propia plantilla.
      */
     public function review(JwtUser $user, Template $template): bool
     {
+        $userId = $user->getAuthIdentifier();
+
+        if ($userId === $template->created_by) {
+            return false;
+        }
+
         return $template->reviewers()
-            ->where('user_id', $user->getAuthIdentifier())
+            ->where('user_id', $userId)
             ->exists();
     }
 
     /**
-     * Enviar borrador a revisión (autor o quien puede editar la plantilla).
+     * Enviar borrador a revisión: solo el creador.
      */
     public function submitForReview(JwtUser $user, Template $template): bool
     {
-        return $this->userCanEditTemplate($user, $template);
-    }
-
-    /**
-     * Volver a borrador una plantilla publicada para preparar una nueva versión.
-     */
-    public function reopenDraft(JwtUser $user, Template $template): bool
-    {
-        if ($template->status !== 'published') {
-            return false;
-        }
-
-        return $this->userCanEditTemplate($user, $template);
+        return $user->getAuthIdentifier() === $template->created_by;
     }
 
     /**
@@ -135,29 +148,5 @@ class TemplatePolicy
 
         return TemplateVisibilityLevel::tryFrom($visibilityLevel)
             ?? TemplateVisibilityLevel::Personal;
-    }
-
-    /**
-     * Verifica si el usuario puede editar la plantilla (contenido, metadatos, flujo salvo borrado).
-     */
-    private function userCanEditTemplate(JwtUser $user, Template $template): bool
-    {
-        if ($user->getAuthIdentifier() === $template->created_by) {
-            return true;
-        }
-
-        return $user->hasPermission('templates.update');
-    }
-
-    /**
-     * Creador siempre puede borrar; terceros solo con permiso explícito de borrado.
-     */
-    private function userCanDeleteTemplate(JwtUser $user, Template $template): bool
-    {
-        if ($user->getAuthIdentifier() === $template->created_by) {
-            return true;
-        }
-
-        return $user->hasPermission('templates.delete');
     }
 }

--- a/backend/app/Policies/TemplatePolicy.php
+++ b/backend/app/Policies/TemplatePolicy.php
@@ -90,11 +90,18 @@ class TemplatePolicy
     }
 
     /**
-     * Revisión / aprobación en el flujo de plantilla (SoD: el creador no aprueba la suya).
+     * Revisión / aprobación en el flujo de plantilla.
+     *
+     * Solo los usuarios explícitamente asignados como revisores en `template_reviewers`
+     * pueden aprobar o rechazar la plantilla. La segregación de funciones (el creador
+     * no puede ser revisor de la suya) se garantiza en {@see self::syncReviewers} o
+     * en la validación del wizard, no aquí.
      */
     public function review(JwtUser $user, Template $template): bool
     {
-        return $user->getAuthIdentifier() !== $template->created_by;
+        return $template->reviewers()
+            ->where('user_id', $user->getAuthIdentifier())
+            ->exists();
     }
 
     /**

--- a/backend/app/Repositories/Eloquent/TemplateRepository.php
+++ b/backend/app/Repositories/Eloquent/TemplateRepository.php
@@ -140,6 +140,7 @@ class TemplateRepository implements TemplateRepositoryInterface
                     'template_id' => $target->getKey(),
                     'type' => $block->type,
                     'title' => $block->title,
+                    'description' => $block->description,
                     'default_content' => $block->default_content,
                     'block_state' => $block->block_state,
                     'mandatory' => $block->mandatory,

--- a/backend/app/Services/Contracts/TemplateServiceInterface.php
+++ b/backend/app/Services/Contracts/TemplateServiceInterface.php
@@ -80,6 +80,15 @@ interface TemplateServiceInterface
     public function clone(string $sourceTemplateId, string $actorId): Template;
 
     /**
+     * Registra la aprobación del revisor activo. Si todos los revisores han aprobado,
+     * publica la plantilla automáticamente con un snapshot.
+     *
+     * En modo secuencial verifica que los stages anteriores estén aprobados antes
+     * de permitir que el actor apruebe.
+     */
+    public function approveReview(string $templateId, string $actorId): Template;
+
+    /**
      * Sincroniza los revisores de la plantilla normativa.
      * @param array<int, string> $userIds Lista ordenada de IDs de usuario.
      */

--- a/backend/app/Services/Contracts/TemplateServiceInterface.php
+++ b/backend/app/Services/Contracts/TemplateServiceInterface.php
@@ -80,8 +80,14 @@ interface TemplateServiceInterface
     public function clone(string $sourceTemplateId, string $actorId): Template;
 
     /**
-     * Sincroniza los validadores de la plantilla.
+     * Sincroniza los revisores de la plantilla normativa.
      * @param array<int, string> $userIds Lista ordenada de IDs de usuario.
      */
-    public function syncValidators(string $templateId, array $userIds): void;
+    public function syncReviewers(string $templateId, array $userIds): void;
+
+    /**
+     * Sincroniza el pool de posibles revisores de documentos generados desde la plantilla.
+     * @param array<int, string> $userIds IDs de usuario elegibles como revisores de documentos.
+     */
+    public function syncDocumentReviewers(string $templateId, array $userIds): void;
 }

--- a/backend/app/Services/Contracts/TemplateServiceInterface.php
+++ b/backend/app/Services/Contracts/TemplateServiceInterface.php
@@ -43,11 +43,6 @@ interface TemplateServiceInterface
     public function publishWithSnapshot(string $templateId, string $changelog, string $actorId): Template;
 
     /**
-     * Reabre el borrador de la plantilla (autor o quien puede editar la plantilla).
-     */
-    public function reopenDraft(string $templateId, string $actorId): Template;
-
-    /**
      * @return Collection<int, TemplateVersion>
      */
     public function listPublishedVersions(string $templateId): Collection;

--- a/backend/app/Services/TemplateService.php
+++ b/backend/app/Services/TemplateService.php
@@ -54,6 +54,11 @@ class TemplateService implements TemplateServiceInterface
 
     /**
      * Envia el borrador a revisión (autor o quien puede editar la plantilla).
+     *
+     * - Sin revisores asignados → publica automáticamente.
+     * - Con revisores → resetea sus estados a `pending` (necesario para rondas
+     *   sucesivas: en draft post-rechazo los estados quedan visibles para el autor,
+     *   y solo se limpian al reenviar) y transiciona a `in_review`.
      */
     public function submitForReview(string $templateId, string $actorId): Template
     {
@@ -65,11 +70,21 @@ class TemplateService implements TemplateServiceInterface
             ]);
         }
 
+        if ($template->reviewers()->doesntExist()) {
+            return $this->publishWithSnapshot($templateId, null, $actorId);
+        }
+
+        $template->reviewers()->update(['status' => 'pending']);
+
         return $this->updateTemplateStatusWithEvent($template, 'in_review', $actorId);
     }
 
     /**
-     * Rechaza la revisión de la plantilla (autor o quien puede editar la plantilla).
+     * Rechaza la revisión de la plantilla.
+     *
+     * Registra el rechazo del actor en `template_reviewers` (auditoría de quién rechazó)
+     * y transiciona la plantilla a borrador. Los estados quedan visibles en draft
+     * para que el autor sepa quién rechazó; se limpian al reenviar.
      */
     public function rejectReview(string $templateId, string $actorId): Template
     {
@@ -81,7 +96,74 @@ class TemplateService implements TemplateServiceInterface
             ]);
         }
 
+        $template->reviewers()
+            ->where('user_id', $actorId)
+            ->update(['status' => 'rejected']);
+
         return $this->updateTemplateStatusWithEvent($template, 'draft', $actorId);
+    }
+
+    /**
+     * Registra la aprobación del revisor activo.
+     *
+     * En modo secuencial exige que todos los stages anteriores estén aprobados.
+     * Si tras esta aprobación todos los revisores están en `approved`, publica
+     * la plantilla automáticamente con un snapshot.
+     */
+    public function approveReview(string $templateId, string $actorId): Template
+    {
+        return DB::transaction(function () use ($templateId, $actorId) {
+            $template = Template::query()->whereKey($templateId)->lockForUpdate()->firstOrFail();
+
+            if ($template->status !== 'in_review') {
+                throw ValidationException::withMessages([
+                    'status' => ['Solo se puede aprobar una plantilla en revisión.'],
+                ]);
+            }
+
+            $reviewer = $template->reviewers()
+                ->where('user_id', $actorId)
+                ->first();
+
+            if (! $reviewer) {
+                throw ValidationException::withMessages([
+                    'user' => ['No estás asignado como revisor de esta plantilla.'],
+                ]);
+            }
+
+            if ($reviewer->status === 'approved') {
+                throw ValidationException::withMessages([
+                    'status' => ['Ya has aprobado esta plantilla.'],
+                ]);
+            }
+
+            if ($template->review_mode === 'sequential') {
+                $pendingPreviousStage = $template->reviewers()
+                    ->where('stage', '<', $reviewer->stage)
+                    ->where('status', '!=', 'approved')
+                    ->exists();
+
+                if ($pendingPreviousStage) {
+                    throw ValidationException::withMessages([
+                        'stage' => ['Debes esperar a que los revisores de etapas anteriores aprueben primero.'],
+                    ]);
+                }
+            }
+
+            $template->reviewers()
+                ->where('user_id', $actorId)
+                ->update(['status' => 'approved']);
+
+            $allApproved = $template->reviewers()
+                ->where('status', '!=', 'approved')
+                ->doesntExist();
+
+            if ($allApproved) {
+                return $this->publishWithSnapshot($templateId, 'Aprobado por todos los revisores.', $actorId);
+            }
+
+            return $template->fresh();
+        });
     }
 
     /**

--- a/backend/app/Services/TemplateService.php
+++ b/backend/app/Services/TemplateService.php
@@ -222,22 +222,6 @@ class TemplateService implements TemplateServiceInterface
     }
 
     /**
-     * Reabre el borrador de la plantilla (autor o quien puede editar la plantilla).
-     */
-    public function reopenDraft(string $templateId, string $actorId): Template
-    {
-        $template = $this->templateRepository->findOrFail($templateId);
-
-        if ($template->status !== 'published') {
-            throw ValidationException::withMessages([
-                'status' => ['Solo las plantillas publicadas pueden reabrirse a borrador para una nueva versión.'],
-            ]);
-        }
-
-        return $this->updateTemplateStatusWithEvent($template, 'draft', $actorId);
-    }
-
-    /**
      * Lista todas las versiones publicadas de una plantilla ordenadas por número de versión.
      *
      * @return Collection<int, TemplateVersion>

--- a/backend/app/Services/TemplateService.php
+++ b/backend/app/Services/TemplateService.php
@@ -187,6 +187,7 @@ class TemplateService implements TemplateServiceInterface
                 'id' => $b->id,
                 'type' => $b->type,
                 'title' => $b->title,
+                'description' => $b->description,
                 'default_content' => $b->default_content,
                 'block_state' => $b->block_state,
                 'mandatory' => $b->mandatory,

--- a/backend/app/Services/TemplateService.php
+++ b/backend/app/Services/TemplateService.php
@@ -320,21 +320,37 @@ class TemplateService implements TemplateServiceInterface
     }
 
     /**
-     * Sincroniza los validadores de la plantilla.
+     * Sincroniza los revisores de la plantilla normativa.
      */
-    public function syncValidators(string $templateId, array $userIds): void
+    public function syncReviewers(string $templateId, array $userIds): void
     {
         DB::transaction(function () use ($templateId, $userIds) {
             $template = $this->templateRepository->findOrFail($templateId);
 
-            // Eliminar revisores actuales
             $template->reviewers()->delete();
 
-            // Insertar nuevos con orden (stage)
             foreach ($userIds as $index => $userId) {
                 $template->reviewers()->create([
                     'user_id' => $userId,
-                    'stage' => $index + 1,
+                    'stage'   => $index + 1,
+                ]);
+            }
+        });
+    }
+
+    /**
+     * Sincroniza el pool de posibles revisores de documentos generados desde la plantilla.
+     */
+    public function syncDocumentReviewers(string $templateId, array $userIds): void
+    {
+        DB::transaction(function () use ($templateId, $userIds) {
+            $template = $this->templateRepository->findOrFail($templateId);
+
+            $template->documentReviewers()->delete();
+
+            foreach ($userIds as $userId) {
+                $template->documentReviewers()->create([
+                    'user_id' => $userId,
                 ]);
             }
         });

--- a/backend/app/Services/TemplateService.php
+++ b/backend/app/Services/TemplateService.php
@@ -196,16 +196,13 @@ class TemplateService implements TemplateServiceInterface
 
             $next = $this->templateVersionRepository->nextVersionNumber($templateId);
 
-            $snapshot = $this->templateVersionRepository->createSnapshot(
+            $this->templateVersionRepository->createSnapshot(
                 $templateId,
                 $next,
                 $blocksSnapshot,
                 $changelog ?? '',
                 $actorId,
             );
-
-            $template->reviewers()->update(['template_version_id' => $snapshot->id]);
-            $template->documentReviewers()->update(['template_version_id' => $snapshot->id]);
 
             $oldStatus = $template->status;
             $updated = $this->templateRepository->update($template, [
@@ -398,15 +395,12 @@ class TemplateService implements TemplateServiceInterface
     {
         DB::transaction(function () use ($templateId, $userIds) {
             $template = $this->templateRepository->findOrFail($templateId);
-            $latestVersionId = $this->templateVersionRepository
-                ->findLatestPublishedForTemplate($templateId)?->id;
 
             $template->reviewers()->delete();
 
             foreach ($userIds as $index => $userId) {
                 $template->reviewers()->create([
                     'user_id' => $userId,
-                    'template_version_id' => $latestVersionId,
                     'stage'   => $index + 1,
                 ]);
             }
@@ -420,15 +414,12 @@ class TemplateService implements TemplateServiceInterface
     {
         DB::transaction(function () use ($templateId, $userIds) {
             $template = $this->templateRepository->findOrFail($templateId);
-            $latestVersionId = $this->templateVersionRepository
-                ->findLatestPublishedForTemplate($templateId)?->id;
 
             $template->documentReviewers()->delete();
 
             foreach ($userIds as $userId) {
                 $template->documentReviewers()->create([
                     'user_id' => $userId,
-                    'template_version_id' => $latestVersionId,
                 ]);
             }
         });

--- a/backend/app/Services/TemplateService.php
+++ b/backend/app/Services/TemplateService.php
@@ -196,13 +196,16 @@ class TemplateService implements TemplateServiceInterface
 
             $next = $this->templateVersionRepository->nextVersionNumber($templateId);
 
-            $this->templateVersionRepository->createSnapshot(
+            $snapshot = $this->templateVersionRepository->createSnapshot(
                 $templateId,
                 $next,
                 $blocksSnapshot,
                 $changelog ?? '',
                 $actorId,
             );
+
+            $template->reviewers()->update(['template_version_id' => $snapshot->id]);
+            $template->documentReviewers()->update(['template_version_id' => $snapshot->id]);
 
             $oldStatus = $template->status;
             $updated = $this->templateRepository->update($template, [
@@ -351,15 +354,17 @@ class TemplateService implements TemplateServiceInterface
         $target = $this->templateRepository->create([
             'name' => $source->name.' (copia)',
             'description' => $source->description,
-            'visibility_level' => TemplateVisibilityLevel::Personal->value,
-            'delivery_deadline' => null,
-            'study_type_id' => null,
-            'study_id' => null,
-            'module_id' => null,
-            'team_id' => null,
+            'visibility_level' => $source->visibility_level instanceof TemplateVisibilityLevel
+                ? $source->visibility_level->value
+                : $source->visibility_level,
+            'delivery_deadline' => $source->delivery_deadline,
+            'study_type_id' => $source->study_type_id,
+            'study_id' => $source->study_id,
+            'module_id' => $source->module_id,
+            'team_id' => $source->team_id,
             'created_by' => $actorId,
             'status' => 'draft',
-            'version' => 1,
+            'version' => ((int) $source->version) + 1,
             'review_stages' => $source->review_stages,
             'review_mode' => $source->review_mode,
         ]);
@@ -393,12 +398,15 @@ class TemplateService implements TemplateServiceInterface
     {
         DB::transaction(function () use ($templateId, $userIds) {
             $template = $this->templateRepository->findOrFail($templateId);
+            $latestVersionId = $this->templateVersionRepository
+                ->findLatestPublishedForTemplate($templateId)?->id;
 
             $template->reviewers()->delete();
 
             foreach ($userIds as $index => $userId) {
                 $template->reviewers()->create([
                     'user_id' => $userId,
+                    'template_version_id' => $latestVersionId,
                     'stage'   => $index + 1,
                 ]);
             }
@@ -412,12 +420,15 @@ class TemplateService implements TemplateServiceInterface
     {
         DB::transaction(function () use ($templateId, $userIds) {
             $template = $this->templateRepository->findOrFail($templateId);
+            $latestVersionId = $this->templateVersionRepository
+                ->findLatestPublishedForTemplate($templateId)?->id;
 
             $template->documentReviewers()->delete();
 
             foreach ($userIds as $userId) {
                 $template->documentReviewers()->create([
                     'user_id' => $userId,
+                    'template_version_id' => $latestVersionId,
                 ]);
             }
         });

--- a/backend/database/data/permissions_mock.php
+++ b/backend/database/data/permissions_mock.php
@@ -10,6 +10,7 @@ return [
     ['code' => 'templates.read', 'name' => 'Plantillas — leer', 'description' => 'Listar y ver plantillas visibles.'],
     ['code' => 'templates.update', 'name' => 'Plantillas — actualizar', 'description' => 'Editar plantillas permitidas.'],
     ['code' => 'templates.delete', 'name' => 'Plantillas — eliminar', 'description' => 'Eliminar o archivar plantillas permitidas.'],
+    ['code' => 'templates.review', 'name' => 'Plantillas — revisar', 'description' => 'Puede ser seleccionado como revisor de una plantilla normativa y aprobar o rechazar su publicación.'],
 
     ['code' => 'documents.create', 'name' => 'Documentos — crear', 'description' => 'Crear documentos.'],
     ['code' => 'documents.read', 'name' => 'Documentos — leer', 'description' => 'Ver documentos visibles.'],

--- a/backend/database/data/templates_mock.php
+++ b/backend/database/data/templates_mock.php
@@ -289,6 +289,29 @@ return [
             'review_mode' => 'sequential',
         ],
     ],
+    /**
+     * Pool de posibles validadores de documentos generados desde cada plantilla.
+     * Son usuarios distintos de los revisores de la plantilla normativa (template_reviewers).
+     * PK compuesta (template_id, user_id) → sin campo id.
+     */
+    'template_document_reviewers' => [
+        // Plantilla global 01 — doc reviewers: secretaria + docentes
+        ['template_id' => '33333333-3333-3333-3333-333333333301', 'user_id' => '2ead4bf3-574c-41b4-95ca-cac7daed0664'],
+        ['template_id' => '33333333-3333-3333-3333-333333333301', 'user_id' => 'cf8bb92a-0417-4a4c-918a-08dd3fd69165'],
+        ['template_id' => '33333333-3333-3333-3333-333333333301', 'user_id' => '53bc5feb-cf5a-4e0b-ba08-f7f21fe9ea8f'],
+        // Plantilla equipo académico 02 — doc reviewers: dirección + secretaria
+        ['template_id' => '33333333-3333-3333-3333-333333333302', 'user_id' => 'ed568442-ece5-4c90-97ca-12c8969bb3a2'],
+        ['template_id' => '33333333-3333-3333-3333-333333333302', 'user_id' => '2ead4bf3-574c-41b4-95ca-cac7daed0664'],
+        // Plantilla tipo BACH 08 — doc reviewers: dirección
+        ['template_id' => '33333333-3333-3333-3333-333333333308', 'user_id' => 'ed568442-ece5-4c90-97ca-12c8969bb3a2'],
+        // Plantilla tipo FP 09 — doc reviewers: dirección + secretaria
+        ['template_id' => '33333333-3333-3333-3333-333333333309', 'user_id' => 'ed568442-ece5-4c90-97ca-12c8969bb3a2'],
+        ['template_id' => '33333333-3333-3333-3333-333333333309', 'user_id' => '2ead4bf3-574c-41b4-95ca-cac7daed0664'],
+        // Plantilla módulo DWES 11 — doc reviewers: dirección + secretaria
+        ['template_id' => '33333333-3333-3333-3333-333333333311', 'user_id' => 'ed568442-ece5-4c90-97ca-12c8969bb3a2'],
+        ['template_id' => '33333333-3333-3333-3333-333333333311', 'user_id' => '2ead4bf3-574c-41b4-95ca-cac7daed0664'],
+    ],
+
     'template_reviewers' => [
         [
             'id' => '44444444-4444-4444-4444-444444444401',

--- a/backend/database/migrations/0001_00_00_000002_000001_create_template_reviewers_table.php
+++ b/backend/database/migrations/0001_00_00_000002_000001_create_template_reviewers_table.php
@@ -19,7 +19,9 @@ return new class extends Migration
             $table->foreignUuid('template_id')->constrained('templates')->cascadeOnDelete();
             $table->string('user_id');    // FK lógica → users (FDW)
             $table->integer('stage');     // orden de revisión (1, 2, 3...)
+            $table->string('status')->default('pending'); // pending | approved | rejected
             $table->timestamps();
+            $table->softDeletes();
 
             $table->unique(['template_id', 'user_id'], 'template_reviewers_template_id_user_id_unique');
         });

--- a/backend/database/migrations/0001_00_00_000002_000001_create_template_reviewers_table.php
+++ b/backend/database/migrations/0001_00_00_000002_000001_create_template_reviewers_table.php
@@ -17,6 +17,7 @@ return new class extends Migration
         Schema::create('template_reviewers', function (Blueprint $table) {
             $table->uuid('id')->primary();
             $table->foreignUuid('template_id')->constrained('templates')->cascadeOnDelete();
+            $table->uuid('template_version_id')->nullable();
             $table->string('user_id');    // FK lógica → users (FDW)
             $table->integer('stage');     // orden de revisión (1, 2, 3...)
             $table->string('status')->default('pending'); // pending | approved | rejected
@@ -24,6 +25,7 @@ return new class extends Migration
             $table->softDeletes();
 
             $table->unique(['template_id', 'user_id'], 'template_reviewers_template_id_user_id_unique');
+            $table->index('template_version_id');
         });
     }
 

--- a/backend/database/migrations/0001_00_00_000002_000001_create_template_reviewers_table.php
+++ b/backend/database/migrations/0001_00_00_000002_000001_create_template_reviewers_table.php
@@ -17,7 +17,6 @@ return new class extends Migration
         Schema::create('template_reviewers', function (Blueprint $table) {
             $table->uuid('id')->primary();
             $table->foreignUuid('template_id')->constrained('templates')->cascadeOnDelete();
-            $table->uuid('template_version_id')->nullable();
             $table->string('user_id');    // FK lógica → users (FDW)
             $table->integer('stage');     // orden de revisión (1, 2, 3...)
             $table->string('status')->default('pending'); // pending | approved | rejected
@@ -25,7 +24,6 @@ return new class extends Migration
             $table->softDeletes();
 
             $table->unique(['template_id', 'user_id'], 'template_reviewers_template_id_user_id_unique');
-            $table->index('template_version_id');
         });
     }
 

--- a/backend/database/migrations/0001_00_00_000002_000002_create_template_document_reviewers_table.php
+++ b/backend/database/migrations/0001_00_00_000002_000002_create_template_document_reviewers_table.php
@@ -24,10 +24,12 @@ return new class extends Migration
     {
         Schema::create('template_document_reviewers', function (Blueprint $table) {
             $table->foreignUuid('template_id')->constrained('templates')->cascadeOnDelete();
+            $table->uuid('template_version_id')->nullable();
             $table->string('user_id'); // FK lógica → users (FDW)
             $table->timestamps();
 
             $table->primary(['template_id', 'user_id']);
+            $table->index('template_version_id');
             $table->index('user_id');
         });
     }

--- a/backend/database/migrations/0001_00_00_000002_000002_create_template_document_reviewers_table.php
+++ b/backend/database/migrations/0001_00_00_000002_000002_create_template_document_reviewers_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Pool de posibles validadores de documento por plantilla.
+ *
+ * Define quiénes pueden ser elegidos como validadores de los documentos generados
+ * a partir de esta plantilla. Es una lista plana (sin stage ni estado): el orden
+ * y el estado se asignan en `document_reviews` cuando se crea el documento.
+ *
+ * PK compuesta (template_id, user_id): no hay identidad propia para cada fila;
+ * la combinación plantilla+usuario es la clave natural.
+ *
+ * Diferencia con `template_reviewers`: esa tabla gestiona quiénes revisan la
+ * plantilla normativa. Esta tabla gestiona quiénes pueden validar los documentos
+ * que se generen a partir de ella.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('template_document_reviewers', function (Blueprint $table) {
+            $table->foreignUuid('template_id')->constrained('templates')->cascadeOnDelete();
+            $table->string('user_id'); // FK lógica → users (FDW)
+            $table->timestamps();
+
+            $table->primary(['template_id', 'user_id']);
+            $table->index('user_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('template_document_reviewers');
+    }
+};

--- a/backend/database/migrations/0001_00_00_000002_000002_create_template_document_reviewers_table.php
+++ b/backend/database/migrations/0001_00_00_000002_000002_create_template_document_reviewers_table.php
@@ -24,12 +24,10 @@ return new class extends Migration
     {
         Schema::create('template_document_reviewers', function (Blueprint $table) {
             $table->foreignUuid('template_id')->constrained('templates')->cascadeOnDelete();
-            $table->uuid('template_version_id')->nullable();
             $table->string('user_id'); // FK lógica → users (FDW)
             $table->timestamps();
 
             $table->primary(['template_id', 'user_id']);
-            $table->index('template_version_id');
             $table->index('user_id');
         });
     }

--- a/backend/database/migrations/0001_00_00_000004_create_template_versions_table.php
+++ b/backend/database/migrations/0001_00_00_000004_create_template_versions_table.php
@@ -27,20 +27,6 @@ return new class extends Migration
             $table->unique(['template_id', 'version_number']);
         });
 
-        Schema::table('template_reviewers', function (Blueprint $table) {
-            $table->foreign('template_version_id')
-                ->references('id')
-                ->on('template_versions')
-                ->nullOnDelete();
-        });
-
-        Schema::table('template_document_reviewers', function (Blueprint $table) {
-            $table->foreign('template_version_id')
-                ->references('id')
-                ->on('template_versions')
-                ->nullOnDelete();
-        });
-
         if (Schema::getConnection()->getDriverName() === 'pgsql') {
             DB::unprepared(<<<'SQL'
 CREATE OR REPLACE FUNCTION forbid_append_only_mutation() RETURNS trigger AS $$
@@ -58,14 +44,6 @@ SQL);
 
     public function down(): void
     {
-        Schema::table('template_document_reviewers', function (Blueprint $table) {
-            $table->dropForeign(['template_version_id']);
-        });
-
-        Schema::table('template_reviewers', function (Blueprint $table) {
-            $table->dropForeign(['template_version_id']);
-        });
-
         if (Schema::getConnection()->getDriverName() === 'pgsql') {
             DB::unprepared('DROP TRIGGER IF EXISTS template_versions_append_only ON template_versions;');
             DB::unprepared('DROP FUNCTION IF EXISTS forbid_append_only_mutation();');

--- a/backend/database/migrations/0001_00_00_000004_create_template_versions_table.php
+++ b/backend/database/migrations/0001_00_00_000004_create_template_versions_table.php
@@ -27,6 +27,20 @@ return new class extends Migration
             $table->unique(['template_id', 'version_number']);
         });
 
+        Schema::table('template_reviewers', function (Blueprint $table) {
+            $table->foreign('template_version_id')
+                ->references('id')
+                ->on('template_versions')
+                ->nullOnDelete();
+        });
+
+        Schema::table('template_document_reviewers', function (Blueprint $table) {
+            $table->foreign('template_version_id')
+                ->references('id')
+                ->on('template_versions')
+                ->nullOnDelete();
+        });
+
         if (Schema::getConnection()->getDriverName() === 'pgsql') {
             DB::unprepared(<<<'SQL'
 CREATE OR REPLACE FUNCTION forbid_append_only_mutation() RETURNS trigger AS $$
@@ -44,6 +58,14 @@ SQL);
 
     public function down(): void
     {
+        Schema::table('template_document_reviewers', function (Blueprint $table) {
+            $table->dropForeign(['template_version_id']);
+        });
+
+        Schema::table('template_reviewers', function (Blueprint $table) {
+            $table->dropForeign(['template_version_id']);
+        });
+
         if (Schema::getConnection()->getDriverName() === 'pgsql') {
             DB::unprepared('DROP TRIGGER IF EXISTS template_versions_append_only ON template_versions;');
             DB::unprepared('DROP FUNCTION IF EXISTS forbid_append_only_mutation();');

--- a/backend/database/seeders/DatabaseSeeder.php
+++ b/backend/database/seeders/DatabaseSeeder.php
@@ -25,6 +25,7 @@ class DatabaseSeeder extends Seeder
             TeamsSeeder::class,
             TemplatesSeeder::class,
             TemplateReviewersSeeder::class,
+            TemplateDocumentReviewersSeeder::class,
             TemplateBlocksSeeder::class,
             TemplateVersionsSeeder::class,
             DocumentsSeeder::class,

--- a/backend/database/seeders/TemplateDocumentReviewersSeeder.php
+++ b/backend/database/seeders/TemplateDocumentReviewersSeeder.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+class TemplateDocumentReviewersSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $data = $this->mockData();
+
+        if ($data === [] || ! Schema::hasTable('template_document_reviewers')) {
+            return;
+        }
+
+        $reviewers = $data['template_document_reviewers'] ?? [];
+        if ($reviewers === []) {
+            return;
+        }
+
+        $now = Carbon::now();
+
+        $rows = array_map(static function (array $row) use ($now): array {
+            $row['created_at'] ??= $now;
+            $row['updated_at'] ??= $now;
+
+            return $row;
+        }, $reviewers);
+
+        DB::table('template_document_reviewers')->insertOrIgnore($rows);
+    }
+
+    /**
+     * Lee datos mock desde database/data/templates_mock.php.
+     *
+     * @return array<string, mixed>
+     */
+    private function mockData(): array
+    {
+        $filePath = database_path('data/templates_mock.php');
+
+        if (! is_file($filePath)) {
+            return [];
+        }
+
+        $data = require $filePath;
+
+        return is_array($data) ? $data : [];
+    }
+}

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -69,6 +69,8 @@ Route::prefix('v1')->group(function () {
             ->whereUuid('template');
         Route::post('templates/{template}/reject-review', [TemplateController::class, 'rejectReview'])
             ->whereUuid('template');
+        Route::post('templates/{template}/approve-review', [TemplateController::class, 'approveReview'])
+            ->whereUuid('template');
         Route::post('templates/{template}/publish', [TemplateController::class, 'publish'])
             ->whereUuid('template');
         Route::post('templates/{template}/reopen-draft', [TemplateController::class, 'reopenDraft'])
@@ -141,8 +143,9 @@ Route::prefix('v1')->group(function () {
         Route::patch('comments/{comment}/resolve', [CommentController::class, 'resolve'])
             ->whereUuid('comment');
 
-        // Usuarios — búsqueda para asignación de validadores y compartición
+        // Usuarios — búsqueda para asignación de revisores y compartición
         Route::get('/users', [UserController::class, 'index']);
+        Route::get('/users/reviewer-candidates', [UserController::class, 'reviewerCandidates']);
 
         // Sprint 6 — Dashboard BFF
         Route::get('/dashboard', [DashboardController::class, 'index']);

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -51,7 +51,9 @@ Route::prefix('v1')->group(function () {
         // Combinación de validación UUID (develop) y actualización masiva de bloques (feature).
         Route::apiResource('templates', TemplateController::class)
             ->whereUuid('template');
-        Route::post('templates/{template}/validators', [TemplateController::class, 'syncValidators'])
+        Route::post('templates/{template}/reviewers', [TemplateController::class, 'syncReviewers'])
+            ->whereUuid('template');
+        Route::post('templates/{template}/document-reviewers', [TemplateController::class, 'syncDocumentReviewers'])
             ->whereUuid('template');
         Route::put('blocks/bulk', [TemplateBlockController::class, 'bulkUpdate']);
         Route::patch('templates/{template}/blocks/reorder', [TemplateBlockController::class, 'reorder'])

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -73,8 +73,6 @@ Route::prefix('v1')->group(function () {
             ->whereUuid('template');
         Route::post('templates/{template}/publish', [TemplateController::class, 'publish'])
             ->whereUuid('template');
-        Route::post('templates/{template}/reopen-draft', [TemplateController::class, 'reopenDraft'])
-            ->whereUuid('template');
         Route::get('templates/{template}/versions', [TemplateController::class, 'versions'])
             ->whereUuid('template');
         Route::get('template-versions/{template_version}', [TemplateController::class, 'showVersion'])

--- a/backend/tests/Feature/DocumentSoDHttpAcceptanceTest.php
+++ b/backend/tests/Feature/DocumentSoDHttpAcceptanceTest.php
@@ -164,9 +164,12 @@ class DocumentSoDHttpAcceptanceTest extends TestCase
     }
 
     /**
-     * Escenario 2: creador publica plantilla en borrador sin validadores → HTTP 200.
+     * Escenario 2: creador envía a revisión una plantilla sin revisores → se publica automáticamente.
+     *
+     * El endpoint `publish` exige ser revisor asignado (SoD). Cuando no hay revisores,
+     * la publicación es automática al llamar a `submit-review`.
      */
-    public function test_creator_publish_template_returns_200_when_no_reviewers(): void
+    public function test_creator_submit_review_auto_publishes_when_no_reviewers(): void
     {
         $creatorId = 'creator-tpl-uuid-02';
         [$templateId] = $this->seedTemplateAndDocument($creatorId);
@@ -184,8 +187,8 @@ class DocumentSoDHttpAcceptanceTest extends TestCase
             ->andReturn(InMemory::plainText($publicPem));
 
         $response = $this->postJson(
-            "/api/v1/templates/{$templateId}/publish",
-            ['changelog' => 'Versión inicial'],
+            "/api/v1/templates/{$templateId}/submit-review",
+            [],
             ['Authorization' => 'Bearer '.$token],
         );
 

--- a/backend/tests/Feature/DocumentsTemplateVersionApiTest.php
+++ b/backend/tests/Feature/DocumentsTemplateVersionApiTest.php
@@ -175,6 +175,70 @@ class DocumentsTemplateVersionApiTest extends TestCase
             ->assertJsonValidationErrors(['template_id']);
     }
 
+    public function test_store_document_can_be_created_with_template_version_only(): void
+    {
+        $creatorId = (string) Str::uuid();
+        $this->grantPermissionsForUser($creatorId);
+        $reviewerId = 'ed568442-ece5-4c90-97ca-12c8969bb3a2';
+        [$hCreator, $hReviewer] = $this->authHeadersCreatorAndReviewer(
+            $creatorId,
+            $reviewerId,
+        );
+
+        $tid = (string) Str::uuid();
+        $b1 = (string) Str::uuid();
+        Template::query()->forceCreate([
+            'id' => $tid,
+            'name' => 'Normativa',
+            'description' => null,
+            'visibility_level' => TemplateVisibilityLevel::Personal->value,
+            'delivery_deadline' => null,
+            'study_type_id' => null,
+            'study_id' => null,
+            'module_id' => null,
+            'team_id' => null,
+            'created_by' => $creatorId,
+            'status' => 'draft',
+            'version' => 1,
+            'review_stages' => 0,
+            'review_mode' => 'sequential',
+        ]);
+
+        TemplateBlock::query()->forceCreate([
+            'id' => $b1,
+            'template_id' => $tid,
+            'type' => 'heading',
+            'title' => 'Bloque publicado',
+            'default_content' => null,
+            'block_state' => 'editable',
+            'mandatory' => false,
+            'sort_order' => 0,
+        ]);
+
+        TemplateReviewer::query()->forceCreate([
+            'id' => (string) Str::uuid(),
+            'template_id' => $tid,
+            'user_id' => $reviewerId,
+            'stage' => 1,
+        ]);
+
+        $this->postJson("/api/v1/templates/{$tid}/submit-review", [], $hCreator)->assertOk();
+        $this->postJson("/api/v1/templates/{$tid}/publish", ['changelog' => 'v1'], $hReviewer)->assertOk();
+
+        $versionId = (string) DB::table('template_versions')
+            ->where('template_id', $tid)
+            ->value('id');
+
+        $createDoc = $this->postJson('/api/v1/documents', [
+            'template_version_id' => $versionId,
+            'title' => 'Expediente',
+        ], $hCreator);
+
+        $createDoc->assertCreated()
+            ->assertJsonPath('data.template_id', $tid)
+            ->assertJsonPath('data.template_version_id', $versionId);
+    }
+
     public function test_show_document_references_snapshot_from_publish_time(): void
     {
         $creatorId = (string) Str::uuid();

--- a/backend/tests/Feature/DocumentsTemplateVersionApiTest.php
+++ b/backend/tests/Feature/DocumentsTemplateVersionApiTest.php
@@ -175,7 +175,7 @@ class DocumentsTemplateVersionApiTest extends TestCase
             ->assertJsonValidationErrors(['template_id']);
     }
 
-    public function test_show_document_uses_v1_snapshot_after_template_publishes_v2(): void
+    public function test_show_document_references_snapshot_from_publish_time(): void
     {
         $creatorId = (string) Str::uuid();
         $this->grantPermissionsForUser($creatorId);
@@ -209,7 +209,7 @@ class DocumentsTemplateVersionApiTest extends TestCase
             'id' => $b1,
             'template_id' => $tid,
             'type' => 'heading',
-            'title' => 'Solo v1',
+            'title' => 'Bloque publicado',
             'default_content' => null,
             'block_state' => 'editable',
             'mandatory' => false,
@@ -237,30 +237,13 @@ class DocumentsTemplateVersionApiTest extends TestCase
         $this->assertNotEmpty($versionIdV1);
         $createDoc->assertJsonCount(1, 'data.blocks');
         $createDoc->assertJsonPath('data.blocks.0.type', 'heading');
-        $createDoc->assertJsonPath('data.blocks.0.title', 'Solo v1');
-
-        $b2 = (string) Str::uuid();
-        TemplateBlock::query()->forceCreate([
-            'id' => $b2,
-            'template_id' => $tid,
-            'type' => 'paragraph',
-            'title' => 'Añadido en v2',
-            'default_content' => ['x' => 1],
-            'block_state' => 'editable',
-            'mandatory' => false,
-            'sort_order' => 1,
-        ]);
-
-        $this->postJson("/api/v1/templates/{$tid}/reopen-draft", [], $hCreator)->assertOk();
-        $this->postJson("/api/v1/templates/{$tid}/submit-review", [], $hCreator)->assertOk();
-        $this->postJson("/api/v1/templates/{$tid}/publish", ['changelog' => 'v2 segundo bloque'], $hReviewer)->assertOk();
+        $createDoc->assertJsonPath('data.blocks.0.title', 'Bloque publicado');
 
         $show = $this->getJson("/api/v1/documents/{$docId}", $hCreator);
         $show->assertOk();
         $show->assertJsonPath('data.template_version_id', $versionIdV1);
         $show->assertJsonCount(1, 'data.blocks');
-        $show->assertJsonPath('data.blocks.0.type', 'heading');
-        $show->assertJsonPath('data.blocks.0.title', 'Solo v1');
+        $show->assertJsonPath('data.blocks.0.title', 'Bloque publicado');
         $show->assertJsonPath('data.team', null);
     }
 

--- a/backend/tests/Feature/TemplatesApiTest.php
+++ b/backend/tests/Feature/TemplatesApiTest.php
@@ -861,60 +861,6 @@ class TemplatesApiTest extends TestCase
         $this->assertDatabaseCount('template_versions', 0);
     }
 
-    public function test_template_second_publish_increments_version_after_reopen(): void
-    {
-        $creatorId = (string) Str::uuid();
-        $reviewerId = 'ed568442-ece5-4c90-97ca-12c8969bb3a2';
-        [$headersCreator, $headersReviewer] = $this->authHeadersCreatorAndReviewer(
-            $creatorId,
-            $reviewerId,
-            [],
-        );
-
-        $tid = (string) Str::uuid();
-        $b1 = (string) Str::uuid();
-        Template::query()->forceCreate([
-            'id' => $tid,
-            'name' => 'v2',
-            'description' => null,
-            'visibility_level' => TemplateVisibilityLevel::Personal->value,
-            'delivery_deadline' => null,
-            'study_type_id' => null,
-            'study_id' => null,
-            'module_id' => null,
-            'team_id' => null,
-            'created_by' => $creatorId,
-            'status' => 'in_review',
-            'version' => 1,
-            'review_stages' => 0,
-            'review_mode' => 'sequential',
-        ]);
-        TemplateBlock::query()->forceCreate([
-            'id' => $b1,
-            'template_id' => $tid,
-            'type' => 'paragraph',
-            'title' => null,
-            'default_content' => null,
-            'block_state' => 'editable',
-            'mandatory' => false,
-            'sort_order' => 0,
-        ]);
-
-        $this->seedTemplateReviewer($tid, $reviewerId);
-
-        $this->postJson("/api/v1/templates/{$tid}/publish", ['changelog' => 'v1'], $headersReviewer)->assertOk();
-
-        $this->postJson("/api/v1/templates/{$tid}/reopen-draft", [], $headersCreator)
-            ->assertOk()
-            ->assertJsonPath('data.status', 'draft');
-
-        $this->postJson("/api/v1/templates/{$tid}/submit-review", [], $headersCreator)->assertOk();
-        $this->postJson("/api/v1/templates/{$tid}/publish", ['changelog' => 'v2'], $headersReviewer)
-            ->assertOk()
-            ->assertJsonPath('data.version', 2);
-
-        $this->assertDatabaseCount('template_versions', 2);
-    }
 
     public function test_patch_status_cannot_set_published_without_publish_endpoint(): void
     {

--- a/backend/tests/Feature/TemplatesApiTest.php
+++ b/backend/tests/Feature/TemplatesApiTest.php
@@ -300,7 +300,7 @@ class TemplatesApiTest extends TestCase
         ], $headers)->assertForbidden();
     }
 
-    public function test_clone_creates_draft_personal_copy_with_suffix_and_blocks(): void
+    public function test_clone_creates_draft_copy_preserving_visibility_with_suffix_and_blocks(): void
     {
         $userId = (string) Str::uuid();
         $headers = $this->authHeaders($userId);
@@ -351,7 +351,8 @@ class TemplatesApiTest extends TestCase
         $response->assertCreated()
             ->assertJsonPath('data.name', 'Original (copia)')
             ->assertJsonPath('data.status', 'draft')
-            ->assertJsonPath('data.visibility_level', TemplateVisibilityLevel::Personal->value)
+            ->assertJsonPath('data.version', 3)
+            ->assertJsonPath('data.visibility_level', TemplateVisibilityLevel::Global->value)
             ->assertJsonPath('data.review_stages', 1)
             ->assertJsonPath('data.review_mode', 'parallel');
 

--- a/backend/tests/Unit/Policies/TemplatePolicyTest.php
+++ b/backend/tests/Unit/Policies/TemplatePolicyTest.php
@@ -47,15 +47,10 @@ class TemplatePolicyTest extends TestCase
         $this->assertFalse($this->policy->review($user, $template));
     }
 
-    public function test_non_creator_can_review_template(): void
-    {
-        $creatorId  = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
-        $reviewerId = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
-        $user       = $this->makeJwtUser($reviewerId);
-        $template   = $this->makeTemplate(createdBy: $creatorId);
-
-        $this->assertTrue($this->policy->review($user, $template));
-    }
+    // Los casos "revisor asignado puede revisar" y "usuario no asignado no puede revisar"
+    // requieren consulta a BD (template_reviewers) y están cubiertos por los feature tests
+    // TemplatesApiTest::test_template_review_flow_creates_snapshot_and_history y
+    // TemplatesApiTest::test_template_reject_review_returns_to_draft.
 
     public function test_create_defaults_to_personal_and_allows_any_authenticated_user(): void
     {
@@ -87,12 +82,12 @@ class TemplatePolicyTest extends TestCase
         $this->assertFalse($this->policy->update($user, $template));
     }
 
-    public function test_update_allowed_for_coordinator_on_foreign_template(): void
+    public function test_update_denied_for_coordinator_on_foreign_template(): void
     {
         $user     = $this->makeJwtUser('11111111-2222-3333-4444-555555555555', ['templates.update']);
         $template = $this->makeTemplate(createdBy: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa');
 
-        $this->assertTrue($this->policy->update($user, $template));
+        $this->assertFalse($this->policy->update($user, $template));
     }
 
     public function test_update_with_target_shared_visibility_denied_without_role(): void
@@ -153,4 +148,6 @@ class TemplatePolicyTest extends TestCase
 
         return $t;
     }
+
 }
+


### PR DESCRIPTION
Este PR cierra el alcance backend de la gestión de plantillas en torno a CRUD, revisión y versionado por snapshot, y alinea la creación de documentos con el modelo de versión publicada.

En concreto:
- Se consolida el flujo de plantillas en backend para cubrir:  
           - creación/edición/clonado/eliminación semántica
           - transiciones de estado (draft -> in_review -> published)
           - publicación con snapshot inmutable en template_versions
- Se corrige y estabiliza el comportamiento de versionado en servicios/tests (incluyendo casos de publicación, validación y clonado).
- Se refuerza la coherencia entre plantilla viva y documento:
          - configuración viva de revisores anclada a template_id
          - consumo de snapshots publicados vía template_version_id
- Se refactoriza la creación de documentos para que el backend pueda derivar template_id desde template_version_id, evitando trasladar redundancia al frontend.
- Se actualizan tests de feature para reflejar el flujo esperado y mantener regresión en verde.