### PR TITLE
Feature/backend documentos

### DIFF
--- a/backend/app/DTOs/Documents/CreateDocumentSnapshotDto.php
+++ b/backend/app/DTOs/Documents/CreateDocumentSnapshotDto.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\DTOs\Documents;
+
+/**
+ * Parámetros para crear un snapshot append-only en document_versions.
+ */
+readonly class CreateDocumentSnapshotDto
+{
+    public function __construct(
+        public string $documentId,
+        public string $triggerEvent,
+        public string $triggeredBy,
+        public string $notes,
+    ) {}
+}

--- a/backend/app/DTOs/Documents/UpdateDocumentBlockDto.php
+++ b/backend/app/DTOs/Documents/UpdateDocumentBlockDto.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\DTOs\Documents;
+
+/**
+ * Actualización de contenido de un bloque de documento.
+ */
+readonly class UpdateDocumentBlockDto
+{
+    public function __construct(
+        public string $documentId,
+        public string $documentBlockId,
+        public mixed $content,
+        public string $actorId,
+    ) {}
+}

--- a/backend/app/Http/Controllers/Api/DocumentBlockController.php
+++ b/backend/app/Http/Controllers/Api/DocumentBlockController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Documents\UpdateDocumentBlockRequest;
 use App\Services\Contracts\DocumentServiceInterface;
 use Illuminate\Http\JsonResponse;
 
@@ -39,11 +40,19 @@ class DocumentBlockController extends Controller
      * @param  string  $block
      * @return JsonResponse
      */
-    public function update(string $document, string $_block): JsonResponse
+    public function update(UpdateDocumentBlockRequest $request, string $document, string $block): JsonResponse
     {
         $doc = $this->documentService->findOrFail($document);
         $this->authorize('update', $doc);
 
-        return response()->json(['message' => 'Not implemented'], 501);
+        $updated = $this->documentService->updateBlock(
+            $request->toDto(
+                documentId: $document,
+                documentBlockId: $block,
+                actorId: (string) $request->user()->getAuthIdentifier(),
+            ),
+        );
+
+        return response()->json(['data' => $updated]);
     }
 }

--- a/backend/app/Http/Controllers/Api/DocumentController.php
+++ b/backend/app/Http/Controllers/Api/DocumentController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\Documents\DocumentCreateFromModuleRequest;
 use App\Http\Requests\Documents\DocumentCreationOptionsRequest;
 use App\Http\Requests\Documents\StoreDocumentRequest;
+use App\Http\Requests\Documents\UpdateDocumentRequest;
 use App\Http\Resources\DocumentResource;
 use App\Services\Contracts\ApiTeamEmbedServiceInterface;
 use App\Services\Contracts\DocumentServiceInterface;
@@ -127,25 +128,31 @@ class DocumentController extends Controller
     /**
      * Actualizar documento.
      */
-    public function update(Request $request, string $id): JsonResponse
+    public function update(UpdateDocumentRequest $request, string $id): JsonResponse
     {
-        // TODO: DocumentService::update(...)
         $document = $this->documentService->findOrFail($id);
         $this->authorize('update', $document);
 
-        return response()->json(['message' => 'Not implemented'], 501);
+        $updated = $this->documentService->update($id, $request->validated());
+        $this->apiTeamEmbedService->embedOnDocument(
+            $updated,
+            (string) $request->user()->getAuthIdentifier(),
+        );
+
+        return response()->json(['data' => (new DocumentResource($updated))->toArray($request)]);
     }
 
     /**
      * Eliminar documento.
      */
-    public function destroy(string $id): JsonResponse
+    public function destroy(Request $request, string $id): JsonResponse
     {
         $document = $this->documentService->findOrFail($id);
         $this->authorize('delete', $document);
-        // TODO: borrado lógico / política propia
 
-        return response()->json(['message' => 'Not implemented'], 501);
+        $this->documentService->delete($id);
+
+        return response()->json([], 204);
     }
 
     /**

--- a/backend/app/Http/Controllers/Api/DocumentController.php
+++ b/backend/app/Http/Controllers/Api/DocumentController.php
@@ -27,10 +27,12 @@ class DocumentController extends Controller
      */
     public function index(Request $request): AnonymousResourceCollection
     {
+        $viewerId = (string) $request->user()->getAuthIdentifier();
         $documents = $this->documentService->listOrderedByCreatedAtDesc();
+        $this->documentService->attachShareMetadataForViewer($documents, $viewerId);
         $this->apiTeamEmbedService->embedOnDocuments(
             $documents,
-            (string) $request->user()->getAuthIdentifier(),
+            $viewerId,
         );
 
         return DocumentResource::collection($documents);
@@ -125,11 +127,13 @@ class DocumentController extends Controller
      */
     public function show(Request $request, string $id): JsonResponse
     {
+        $viewerId = (string) $request->user()->getAuthIdentifier();
         $document = $this->documentService->findOrFail($id);
         $this->authorize('view', $document);
+        $this->documentService->attachShareMetadataForViewer(collect([$document]), $viewerId);
         $this->apiTeamEmbedService->embedOnDocument(
             $document,
-            (string) $request->user()->getAuthIdentifier(),
+            $viewerId,
         );
         $blocks = $this->documentService->blocksForDisplay($document);
 

--- a/backend/app/Http/Controllers/Api/DocumentController.php
+++ b/backend/app/Http/Controllers/Api/DocumentController.php
@@ -106,6 +106,21 @@ class DocumentController extends Controller
     }
 
     /**
+     * GET /api/v1/documents/{document}/template-version-status
+     *
+     * Indica si existe una versión de plantilla publicada más reciente que la anclada al documento.
+     */
+    public function templateVersionStatus(Request $request, string $id): JsonResponse
+    {
+        $document = $this->documentService->findOrFail($id);
+        $this->authorize('view', $document);
+
+        return response()->json([
+            'data' => $this->documentService->templateVersionStatus($document->id),
+        ]);
+    }
+
+    /**
      * Mostrar documento con bloques según la versión de plantilla anclada (F-03.4).
      */
     public function show(Request $request, string $id): JsonResponse

--- a/backend/app/Http/Controllers/Api/DocumentController.php
+++ b/backend/app/Http/Controllers/Api/DocumentController.php
@@ -121,7 +121,7 @@ class DocumentController extends Controller
     }
 
     /**
-     * Mostrar documento con bloques según la versión de plantilla anclada (F-03.4).
+     * Mostrar documento con bloques según la versión de plantilla anclada.
      */
     public function show(Request $request, string $id): JsonResponse
     {

--- a/backend/app/Http/Controllers/Api/DocumentController.php
+++ b/backend/app/Http/Controllers/Api/DocumentController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Api;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Documents\DocumentCreateFromModuleRequest;
 use App\Http\Requests\Documents\DocumentCreationOptionsRequest;
+use App\Http\Requests\Documents\PublishDocumentRequest;
 use App\Http\Requests\Documents\StoreDocumentRequest;
 use App\Http\Requests\Documents\UpdateDocumentRequest;
 use App\Http\Resources\DocumentResource;
@@ -172,13 +173,17 @@ class DocumentController extends Controller
     /**
      * Publicar documento.
      */
-    public function publish(Request $request, string $id): JsonResponse
+    public function publish(PublishDocumentRequest $request, string $id): JsonResponse
     {
         $document = $this->documentService->findOrFail($id);
         $this->authorize('review', $document);
 
         $actorId = $request->user()->getAuthIdentifier();
-        $updated = $this->documentService->publishDocument($document->id, $actorId);
+        $updated = $this->documentService->publishDocument(
+            $document->id,
+            $actorId,
+            $request->validated('changelog'),
+        );
 
         return response()->json(['data' => $updated]);
     }

--- a/backend/app/Http/Controllers/Api/DocumentShareController.php
+++ b/backend/app/Http/Controllers/Api/DocumentShareController.php
@@ -3,13 +3,14 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Documents\StoreDocumentShareRequest;
 use App\Services\Contracts\DocumentServiceInterface;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 
 /**
- * TODO(permisos): reglas por documento (titular vs colaborador read/edit en
- * `document_shares`) y alinear con F-05.1; hoy se usa `authorize('update')` global.
+ * Compartición: alta/revocación gestionada solo por el titular ({@see \App\Policies\DocumentPolicy::share}).
  */
 class DocumentShareController extends Controller
 {
@@ -19,34 +20,41 @@ class DocumentShareController extends Controller
 
     /**
      * POST /api/v1/documents/{document}/shares
-     * 
-     * Comparte un documento con un usuario.
-     * 
-     * @param  string  $document
-     * @return JsonResponse
+     *
+     * Comparte un documento con un usuario (permiso read o edit).
      */
-    public function store(Request $request, string $document): JsonResponse
+    public function store(StoreDocumentShareRequest $request, string $document): JsonResponse
     {
         $doc = $this->documentService->findOrFail($document);
-        $this->authorize('update', $doc);
+        $this->authorize('share', $doc);
 
-        return response()->json(['message' => 'Not implemented'], 501);
+        $actorId = (string) $request->user()->getAuthIdentifier();
+        $data = $this->documentService->upsertDocumentShare(
+            $doc->id,
+            $request->validated('user_id'),
+            $request->validated('permission'),
+            $actorId,
+        );
+
+        return response()->json(['data' => $data], 201);
     }
 
     /**
      * DELETE /api/v1/documents/{document}/shares/{userId}
-     * 
-     * Elimina un usuario de la lista de compartición de un documento.
-     * 
-     * @param  string  $document
-     * @param  string  $userId
-     * @return JsonResponse
+     *
+     * Revoca el acceso de un colaborador (idempotente).
      */
-    public function destroy(Request $request, string $document, string $userId): JsonResponse
+    public function destroy(Request $request, string $document, string $userId): Response
     {
         $doc = $this->documentService->findOrFail($document);
-        $this->authorize('update', $doc);
+        $this->authorize('share', $doc);
 
-        return response()->json(['message' => 'Not implemented'], 501);
+        $this->documentService->removeDocumentShare(
+            $doc->id,
+            $userId,
+            (string) $request->user()->getAuthIdentifier(),
+        );
+
+        return response()->noContent();
     }
 }

--- a/backend/app/Http/Controllers/Api/DocumentVersionController.php
+++ b/backend/app/Http/Controllers/Api/DocumentVersionController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Models\DocumentVersion;
 use App\Services\Contracts\DocumentServiceInterface;
 use Illuminate\Http\JsonResponse;
+
 class DocumentVersionController extends Controller
 {
     public function __construct(
@@ -14,11 +15,6 @@ class DocumentVersionController extends Controller
 
     /**
      * GET /api/v1/documents/{document}/versions
-     * 
-     * Lista las versiones de un documento.
-     * 
-     * @param  string  $document
-     * @return JsonResponse
      *
      * Metadatos de versiones (sin incluir el snapshot completo en el listado).
      */
@@ -32,18 +28,45 @@ class DocumentVersionController extends Controller
             ->get()
             ->map(static function (DocumentVersion $v): array {
                 return [
-                    'id'             => $v->id,
-                    'document_id'    => $v->document_id,
+                    'id' => $v->id,
+                    'document_id' => $v->document_id,
                     'version_number' => $v->version_number,
-                    'trigger_event'  => $v->trigger_event,
-                    'triggered_by'   => $v->triggered_by,
-                    'notes'          => $v->notes,
-                    'created_at'     => $v->created_at?->toIso8601String(),
+                    'trigger_event' => $v->trigger_event,
+                    'triggered_by' => $v->triggered_by,
+                    'changelog' => $v->notes,
+                    'notes' => $v->notes,
+                    'created_at' => $v->created_at?->toIso8601String(),
                 ];
             })
             ->values()
             ->all();
 
         return response()->json(['data' => $rows]);
+    }
+
+    /**
+     * GET /api/v1/documents/{document}/versions/{version}
+     *
+     * Detalle de una versión con snapshot completo (solo lectura).
+     */
+    public function show(string $document, string $version): JsonResponse
+    {
+        $doc = $this->documentService->findOrFail($document);
+        $this->authorize('view', $doc);
+
+        $v = $this->documentService->findDocumentVersionOrFail($document, $version);
+
+        return response()->json([
+            'data' => [
+                'id' => $v->id,
+                'document_id' => $v->document_id,
+                'version_number' => $v->version_number,
+                'trigger_event' => $v->trigger_event,
+                'triggered_by' => $v->triggered_by,
+                'changelog' => $v->notes,
+                'snapshot_data' => $v->snapshot_data,
+                'created_at' => $v->created_at?->toIso8601String(),
+            ],
+        ]);
     }
 }

--- a/backend/app/Http/Controllers/Api/ReviewController.php
+++ b/backend/app/Http/Controllers/Api/ReviewController.php
@@ -37,8 +37,17 @@ class ReviewController extends Controller
         $document = $this->documentService->findOrFail($documentId);
         $this->authorize('review', $document);
 
+        $validated = $request->validate([
+            'changelog' => ['nullable', 'string', 'max:5000'],
+        ]);
+
         $actorId = $request->user()->getAuthIdentifier();
-        $updated = $this->documentService->approveReview($document->id, $reviewId, $actorId);
+        $updated = $this->documentService->approveReview(
+            $document->id,
+            $reviewId,
+            $actorId,
+            $validated['changelog'] ?? null,
+        );
 
         return response()->json(['data' => $updated]);
     }

--- a/backend/app/Http/Requests/Documents/PublishDocumentRequest.php
+++ b/backend/app/Http/Requests/Documents/PublishDocumentRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Requests\Documents;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class PublishDocumentRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'changelog' => ['required', 'string', 'min:1', 'max:5000'],
+        ];
+    }
+}

--- a/backend/app/Http/Requests/Documents/StoreDocumentShareRequest.php
+++ b/backend/app/Http/Requests/Documents/StoreDocumentShareRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Requests\Documents;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreDocumentShareRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'user_id' => ['required', 'string', 'max:255'],
+            'permission' => ['required', 'string', 'in:read,edit'],
+        ];
+    }
+}

--- a/backend/app/Http/Requests/Documents/UpdateDocumentBlockRequest.php
+++ b/backend/app/Http/Requests/Documents/UpdateDocumentBlockRequest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Requests\Documents;
+
+use App\DTOs\Documents\UpdateDocumentBlockDto;
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateDocumentBlockRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'content' => ['present'],
+        ];
+    }
+
+    /**
+     * Transforma el request en un DTO.
+     *
+     * @param string $documentId
+     * @param string $documentBlockId
+     * @param string $actorId
+     * @return UpdateDocumentBlockDto
+     */
+    public function toDto(string $documentId, string $documentBlockId, string $actorId): UpdateDocumentBlockDto
+    {
+        return new UpdateDocumentBlockDto(
+            documentId: $documentId,
+            documentBlockId: $documentBlockId,
+            content: $this->input('content'),
+            actorId: $actorId,
+        );
+    }
+}

--- a/backend/app/Http/Requests/Documents/UpdateDocumentRequest.php
+++ b/backend/app/Http/Requests/Documents/UpdateDocumentRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Requests\Documents;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateDocumentRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'title' => ['required', 'string', 'max:255'],
+        ];
+    }
+}

--- a/backend/app/Http/Resources/DocumentResource.php
+++ b/backend/app/Http/Resources/DocumentResource.php
@@ -30,6 +30,8 @@ class DocumentResource extends JsonResource
             'published_at' => $this->published_at?->toIso8601String(),
             'created_at' => $this->created_at?->toIso8601String(),
             'updated_at' => $this->updated_at?->toIso8601String(),
+            'is_shared_with_me' => (bool) ($this->resource->getAttribute('is_shared_with_me') ?? false),
+            'share_permission' => $this->resource->getAttribute('viewer_share_permission'),
         ];
     }
 }

--- a/backend/app/Models/Document.php
+++ b/backend/app/Models/Document.php
@@ -17,7 +17,7 @@ class Document extends Model
     protected static function booted(): void
     {
         // TODO(permisos): ampliar visibilidad como en plantillas (ámbito académico
-        // / equipo en JWT) y enlazar `documents.read` en policy + scope; ver backlog.
+        // / equipo en JWT) y enlazar `documents.read` en policy + scope.
         static::addGlobalScope('user_access', function (Builder $builder) {
             // Si no hay usuario autenticado, NO devolvemos nada (fail-closed)
             // Esto previene fugas de datos si el middleware aún no ha corrido

--- a/backend/app/Models/DocumentVersion.php
+++ b/backend/app/Models/DocumentVersion.php
@@ -26,6 +26,7 @@ class DocumentVersion extends Model
         'triggered_by',
         'snapshot_data',
         'notes',
+        'is_immutable',
         'created_at',
     ];
 
@@ -34,6 +35,7 @@ class DocumentVersion extends Model
         return [
             'snapshot_data'  => 'array',
             'version_number' => 'integer',
+            'is_immutable'   => 'boolean',
             'created_at'     => 'datetime',
         ];
     }

--- a/backend/app/Policies/DocumentPolicy.php
+++ b/backend/app/Policies/DocumentPolicy.php
@@ -11,12 +11,14 @@ use App\Models\JwtUser;
  * Creador y titular actual (owner tras delegación) no pueden revisar ni aprobar
  * el mismo artefacto. Solo comparación de IDs en memoria — sin consultas extra.
  *
- * Envío a revisión ({@see self::submit}): solo el titular ({@see Document::$owner_id}),
- * alineado con F-05.1 (autor principal).
+ * Envío a revisión ({@see self::submit}): solo el titular ({@see Document::$owner_id}).
  *
  * Mutaciones de persistencia: el creador o el titular pueden editar sin el permiso
- * global; terceros requieren `documents.update`. `delete` sigue exigiendo
- * `documents.delete`.
+ * global; un colaborador con share `edit` puede mutar contenido; el resto
+ * requiere `documents.update`. `delete` sigue exigiendo `documents.delete`.
+ *
+ * Compartición ({@see self::share}): solo el titular actual gestiona filas en
+ * `document_shares`.
  */
 class DocumentPolicy
 {
@@ -41,7 +43,37 @@ class DocumentPolicy
             return true;
         }
 
+        if ($this->hasEditShare($document, (string) $id)) {
+            return true;
+        }
+
         return $user->hasPermission('documents.update');
+    }
+
+    /**
+     * Alta o modificación de compartidos del documento (POST shares).
+     */
+    public function share(JwtUser $user, Document $document): bool
+    {
+        return $user->getAuthIdentifier() === $document->owner_id;
+    }
+
+    private function hasEditShare(Document $document, string $userId): bool
+    {
+        if ($document->relationLoaded('shares')) {
+            return $document->shares->contains(
+                fn ($share) => (string) $share->user_id === $userId && $share->permission === 'edit',
+            );
+        }
+
+        if ($document->getKey() === null) {
+            return false;
+        }
+
+        return $document->shares()
+            ->where('user_id', $userId)
+            ->where('permission', 'edit')
+            ->exists();
     }
 
     /**

--- a/backend/app/Policies/TemplatePolicy.php
+++ b/backend/app/Policies/TemplatePolicy.php
@@ -111,7 +111,7 @@ class TemplatePolicy
     }
 
     /**
-     * Revisión / aprobación (SoD — F-01.3).
+     * Revisión / aprobación (SoD).
      *
      * Requiere estar asignado en `template_reviewers` Y no ser el creador de la plantilla.
      * El creador nunca puede aprobar o rechazar su propia plantilla.

--- a/backend/app/Providers/AppServiceProvider.php
+++ b/backend/app/Providers/AppServiceProvider.php
@@ -40,6 +40,7 @@ use App\Services\Contracts\DocumentServiceInterface;
 use App\Services\Contracts\HealthCheckServiceInterface;
 use App\Services\Contracts\TeamReadServiceInterface;
 use Maya\Auth\Contracts\JwksServiceInterface;
+use App\Services\Contracts\SnapshotServiceInterface;
 use App\Services\Contracts\TemplateBlockServiceInterface;
 use App\Services\Contracts\TemplateServiceInterface;
 use App\Services\Contracts\UserProfileServiceInterface;
@@ -47,6 +48,7 @@ use App\Services\DocumentService;
 use App\Services\DashboardService;
 use App\Services\HealthCheckService;
 use App\Services\TeamReadService;
+use App\Services\SnapshotService;
 use App\Services\TemplateBlockService;
 use App\Services\TemplateService;
 use App\Services\UserProfileService;
@@ -73,6 +75,7 @@ class AppServiceProvider extends ServiceProvider
         // Service bindings
         $this->app->bind(AuditLogServiceInterface::class, AuditLogService::class);
         $this->app->bind(ApiTeamEmbedServiceInterface::class, ApiTeamEmbedService::class);
+        $this->app->bind(SnapshotServiceInterface::class, SnapshotService::class);
         $this->app->bind(DocumentServiceInterface::class, DocumentService::class);
         $this->app->bind(TeamReadServiceInterface::class, TeamReadService::class);
         $this->app->bind(CommentServiceInterface::class, CommentService::class);

--- a/backend/app/Repositories/Contracts/DocumentRepositoryInterface.php
+++ b/backend/app/Repositories/Contracts/DocumentRepositoryInterface.php
@@ -123,4 +123,12 @@ interface DocumentRepositoryInterface
      * Elimina un compartido; no lanza si no existía.
      */
     public function deleteDocumentShare(string $documentId, string $userId): void;
+
+    /**
+     * Permisos de compartición del usuario sobre los documentos indicados.
+     *
+     * @param  list<string>  $documentIds
+     * @return array<string, string> mapa document_id => permission (read|edit)
+     */
+    public function sharePermissionsForViewer(array $documentIds, string $userId): array;
 }

--- a/backend/app/Repositories/Contracts/DocumentRepositoryInterface.php
+++ b/backend/app/Repositories/Contracts/DocumentRepositoryInterface.php
@@ -131,4 +131,24 @@ interface DocumentRepositoryInterface
      * @return array<string, string> mapa document_id => permission (read|edit)
      */
     public function sharePermissionsForViewer(array $documentIds, string $userId): array;
+
+    /**
+     * Mayor número de versión de bloque guardado (0 si no hay filas).
+     */
+    public function maxBlockVersionNumberForDocumentBlock(string $documentBlockId): int;
+
+    /**
+     * Inserta una fila append-only en block_versions.
+     *
+     * @param  array<string, mixed>  $content
+     * @param  array<string, mixed>|null  $diff
+     */
+    public function insertDocumentBlockVersion(
+        string $documentBlockId,
+        string $documentId,
+        int $versionNumber,
+        array $content,
+        ?array $diff,
+        string $editedBy,
+    ): void;
 }

--- a/backend/app/Repositories/Contracts/DocumentRepositoryInterface.php
+++ b/backend/app/Repositories/Contracts/DocumentRepositoryInterface.php
@@ -108,4 +108,19 @@ interface DocumentRepositoryInterface
      * Localiza una fila de document_versions por id dentro del documento.
      */
     public function findDocumentVersionInDocumentOrFail(string $documentId, string $versionId): DocumentVersion;
+
+    /**
+     * Crea o actualiza un compartido (document_id, user_id) único.
+     */
+    public function upsertDocumentShare(
+        string $documentId,
+        string $userId,
+        string $permission,
+        string $grantedBy,
+    ): void;
+
+    /**
+     * Elimina un compartido; no lanza si no existía.
+     */
+    public function deleteDocumentShare(string $documentId, string $userId): void;
 }

--- a/backend/app/Repositories/Contracts/DocumentRepositoryInterface.php
+++ b/backend/app/Repositories/Contracts/DocumentRepositoryInterface.php
@@ -5,6 +5,7 @@ namespace App\Repositories\Contracts;
 use App\Models\Document;
 use App\Models\DocumentBlock;
 use App\Models\DocumentReview;
+use App\Models\DocumentVersion;
 use Illuminate\Support\Collection;
 
 interface DocumentRepositoryInterface
@@ -102,4 +103,9 @@ interface DocumentRepositoryInterface
         array $snapshotData,
         ?string $notes = null,
     ): void;
+
+    /**
+     * Localiza una fila de document_versions por id dentro del documento.
+     */
+    public function findDocumentVersionInDocumentOrFail(string $documentId, string $versionId): DocumentVersion;
 }

--- a/backend/app/Repositories/Contracts/DocumentRepositoryInterface.php
+++ b/backend/app/Repositories/Contracts/DocumentRepositoryInterface.php
@@ -3,6 +3,7 @@
 namespace App\Repositories\Contracts;
 
 use App\Models\Document;
+use App\Models\DocumentBlock;
 use App\Models\DocumentReview;
 use Illuminate\Support\Collection;
 
@@ -20,6 +21,16 @@ interface DocumentRepositoryInterface
      * @param  list<array{template_block_id: string, content: mixed, sort_order: int}>  $blockRows
      */
     public function createDocumentWithBlocks(array $documentAttributes, array $blockRows): Document;
+
+    /**
+     * Localiza un bloque por su ID dentro del documento o lanza ModelNotFoundException.
+     */
+    public function findBlockInDocumentOrFail(string $documentId, string $blockId): DocumentBlock;
+
+    /**
+     * Persiste un bloque del documento.
+     */
+    public function saveBlock(DocumentBlock $block): void;
 
     /**
      * Indica si el usuario es autor (owner_id / created_by) o revisor asignado

--- a/backend/app/Repositories/Contracts/DocumentRepositoryInterface.php
+++ b/backend/app/Repositories/Contracts/DocumentRepositoryInterface.php
@@ -83,4 +83,23 @@ interface DocumentRepositoryInterface
      * @return Collection<int, Document>
      */
     public function listOrderedByCreatedAtDesc(): Collection;
+
+    /**
+     * Mayor número de versión de snapshot guardado para el documento (0 si no hay ninguna).
+     */
+    public function maxDocumentVersionNumber(string $documentId): int;
+
+    /**
+     * Inserta un registro append-only en document_versions.
+     *
+     * @param  array<string, mixed>  $snapshotData
+     */
+    public function insertDocumentVersion(
+        string $documentId,
+        int $versionNumber,
+        string $triggerEvent,
+        string $triggeredBy,
+        array $snapshotData,
+        ?string $notes = null,
+    ): void;
 }

--- a/backend/app/Repositories/Contracts/TemplateVersionRepositoryInterface.php
+++ b/backend/app/Repositories/Contracts/TemplateVersionRepositoryInterface.php
@@ -15,6 +15,20 @@ interface TemplateVersionRepositoryInterface
     public function findLatestPublishedForTemplate(string $templateId): ?TemplateVersion;
 
     /**
+     * Metadatos de una versión publicada por id (sin cargar blocks_snapshot).
+     *
+     * @return array{id: string, version_number: int, changelog: string}|null
+     */
+    public function findPublishedMetaById(string $versionId): ?array;
+
+    /**
+     * Metadatos de la versión publicada más reciente de la plantilla (sin blocks_snapshot).
+     *
+     * @return array{id: string, version_number: int, changelog: string}|null
+     */
+    public function findLatestPublishedMetaForTemplate(string $templateId): ?array;
+
+    /**
      * Lista todas las versiones de una plantilla ordenadas por número de versión.
      *
      * @return Collection<int, TemplateVersion>

--- a/backend/app/Repositories/Eloquent/DocumentRepository.php
+++ b/backend/app/Repositories/Eloquent/DocumentRepository.php
@@ -5,6 +5,7 @@ namespace App\Repositories\Eloquent;
 use App\Models\Document;
 use App\Models\DocumentBlock;
 use App\Models\DocumentReview;
+use App\Models\DocumentVersion;
 use App\Repositories\Contracts\DocumentRepositoryInterface;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
@@ -180,5 +181,42 @@ class DocumentRepository implements DocumentRepositoryInterface
             ->where('document_id', $documentId)
             ->where('reviewer_id', $userId)
             ->exists();
+    }
+
+    /**
+     * Mayor número de versión de snapshot guardado para el documento.
+     */
+    public function maxDocumentVersionNumber(string $documentId): int
+    {
+        $max = DocumentVersion::query()
+            ->where('document_id', $documentId)
+            ->max('version_number');
+
+        return $max !== null ? (int) $max : 0;
+    }
+
+    /**
+     * Inserta un registro append-only en document_versions.
+     *
+     * @param  array<string, mixed>  $snapshotData
+     */
+    public function insertDocumentVersion(
+        string $documentId,
+        int $versionNumber,
+        string $triggerEvent,
+        string $triggeredBy,
+        array $snapshotData,
+        ?string $notes = null,
+    ): void {
+        DocumentVersion::forceCreate([
+            'id' => (string) Str::uuid(),
+            'document_id' => $documentId,
+            'version_number' => $versionNumber,
+            'trigger_event' => $triggerEvent,
+            'triggered_by' => $triggeredBy,
+            'snapshot_data' => $snapshotData,
+            'notes' => $notes,
+            'created_at' => now(),
+        ]);
     }
 }

--- a/backend/app/Repositories/Eloquent/DocumentRepository.php
+++ b/backend/app/Repositories/Eloquent/DocumentRepository.php
@@ -5,6 +5,7 @@ namespace App\Repositories\Eloquent;
 use App\Models\Document;
 use App\Models\DocumentBlock;
 use App\Models\DocumentReview;
+use App\Models\DocumentShare;
 use App\Models\DocumentVersion;
 use App\Repositories\Contracts\DocumentRepositoryInterface;
 use Illuminate\Support\Collection;
@@ -230,5 +231,42 @@ class DocumentRepository implements DocumentRepositoryInterface
             ->where('document_id', $documentId)
             ->where('id', $versionId)
             ->firstOrFail();
+    }
+
+    public function upsertDocumentShare(
+        string $documentId,
+        string $userId,
+        string $permission,
+        string $grantedBy,
+    ): void {
+        $existing = DocumentShare::query()
+            ->where('document_id', $documentId)
+            ->where('user_id', $userId)
+            ->first();
+
+        if ($existing !== null) {
+            $existing->update([
+                'permission' => $permission,
+                'granted_by' => $grantedBy,
+            ]);
+
+            return;
+        }
+
+        DocumentShare::forceCreate([
+            'id' => (string) Str::uuid(),
+            'document_id' => $documentId,
+            'user_id' => $userId,
+            'permission' => $permission,
+            'granted_by' => $grantedBy,
+        ]);
+    }
+
+    public function deleteDocumentShare(string $documentId, string $userId): void
+    {
+        DocumentShare::query()
+            ->where('document_id', $documentId)
+            ->where('user_id', $userId)
+            ->delete();
     }
 }

--- a/backend/app/Repositories/Eloquent/DocumentRepository.php
+++ b/backend/app/Repositories/Eloquent/DocumentRepository.php
@@ -52,6 +52,25 @@ class DocumentRepository implements DocumentRepositoryInterface
     }
 
     /**
+     * Busca un bloque por su ID dentro del documento o lanza ModelNotFoundException.
+     */
+    public function findBlockInDocumentOrFail(string $documentId, string $blockId): DocumentBlock
+    {
+        return DocumentBlock::query()
+            ->where('document_id', $documentId)
+            ->where('id', $blockId)
+            ->firstOrFail();
+    }
+
+    /**
+     * Guarda un bloque del documento.
+     */
+    public function saveBlock(DocumentBlock $block): void
+    {
+        $block->save();
+    }
+
+    /**
      * Listado de revisiones del documento ordenadas por etapa.
      */
     public function listReviewsForDocument(string $documentId): Collection

--- a/backend/app/Repositories/Eloquent/DocumentRepository.php
+++ b/backend/app/Repositories/Eloquent/DocumentRepository.php
@@ -2,6 +2,7 @@
 
 namespace App\Repositories\Eloquent;
 
+use App\Models\BlockVersion;
 use App\Models\Document;
 use App\Models\DocumentBlock;
 use App\Models\DocumentReview;
@@ -300,5 +301,42 @@ class DocumentRepository implements DocumentRepositoryInterface
         }
 
         return $out;
+    }
+
+    /**
+     * Mayor número de versión de snapshot guardado para el bloque del documento.
+     */
+    public function maxBlockVersionNumberForDocumentBlock(string $documentBlockId): int
+    {
+        $max = BlockVersion::query()
+            ->where('document_block_id', $documentBlockId)
+            ->max('version_number');
+
+        return $max !== null ? (int) $max : 0;
+    }
+
+    /**
+     * Inserta un registro append-only en block_versions.
+     *
+     * @param  array<string, mixed>  $snapshotData
+     */
+    public function insertDocumentBlockVersion(
+        string $documentBlockId,
+        string $documentId,
+        int $versionNumber,
+        array $content,
+        ?array $diff,
+        string $editedBy,
+    ): void {
+        BlockVersion::forceCreate([
+            'id' => (string) Str::uuid(),
+            'document_block_id' => $documentBlockId,
+            'document_id' => $documentId,
+            'version_number' => $versionNumber,
+            'content' => $content,
+            'diff' => $diff,
+            'edited_by' => $editedBy,
+            'created_at' => now(),
+        ]);
     }
 }

--- a/backend/app/Repositories/Eloquent/DocumentRepository.php
+++ b/backend/app/Repositories/Eloquent/DocumentRepository.php
@@ -216,7 +216,19 @@ class DocumentRepository implements DocumentRepositoryInterface
             'triggered_by' => $triggeredBy,
             'snapshot_data' => $snapshotData,
             'notes' => $notes,
+            'is_immutable' => true,
             'created_at' => now(),
         ]);
+    }
+
+    /**
+     * Busca una versión de documento por su ID dentro del documento o lanza ModelNotFoundException.
+     */
+    public function findDocumentVersionInDocumentOrFail(string $documentId, string $versionId): DocumentVersion
+    {
+        return DocumentVersion::query()
+            ->where('document_id', $documentId)
+            ->where('id', $versionId)
+            ->firstOrFail();
     }
 }

--- a/backend/app/Repositories/Eloquent/DocumentRepository.php
+++ b/backend/app/Repositories/Eloquent/DocumentRepository.php
@@ -233,6 +233,9 @@ class DocumentRepository implements DocumentRepositoryInterface
             ->firstOrFail();
     }
 
+    /**
+     * Crea o actualiza un compartido del documento (solo titular vía policy en controlador).
+     */
     public function upsertDocumentShare(
         string $documentId,
         string $userId,
@@ -262,11 +265,40 @@ class DocumentRepository implements DocumentRepositoryInterface
         ]);
     }
 
+    /**
+     * Elimina un compartido; no lanza si no existía.
+     */
     public function deleteDocumentShare(string $documentId, string $userId): void
     {
         DocumentShare::query()
             ->where('document_id', $documentId)
             ->where('user_id', $userId)
             ->delete();
+    }
+
+    /**
+     * Permisos de compartición del usuario sobre los documentos indicados.
+     *
+     * @param  list<string>  $documentIds
+     * @return array<string, string> mapa document_id => permission (read|edit)
+     */
+    public function sharePermissionsForViewer(array $documentIds, string $userId): array
+    {
+        $documentIds = array_values(array_unique(array_filter($documentIds)));
+        if ($documentIds === []) {
+            return [];
+        }
+
+        $rows = DocumentShare::query()
+            ->whereIn('document_id', $documentIds)
+            ->where('user_id', $userId)
+            ->get(['document_id', 'permission']);
+
+        $out = [];
+        foreach ($rows as $row) {
+            $out[(string) $row->document_id] = (string) $row->permission;
+        }
+
+        return $out;
     }
 }

--- a/backend/app/Repositories/Eloquent/TemplateVersionRepository.php
+++ b/backend/app/Repositories/Eloquent/TemplateVersionRepository.php
@@ -5,6 +5,7 @@ namespace App\Repositories\Eloquent;
 use App\Models\TemplateVersion;
 use App\Repositories\Contracts\TemplateVersionRepositoryInterface;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 
 class TemplateVersionRepository implements TemplateVersionRepositoryInterface
@@ -26,6 +27,53 @@ class TemplateVersionRepository implements TemplateVersionRepositoryInterface
             ->where('template_id', $templateId)
             ->orderByDesc('version_number')
             ->first();
+    }
+
+    /**
+     * Metadatos de una versión por id (consulta ligera, sin JSON de bloques).
+     *
+     * @return array{id: string, version_number: int, changelog: string}|null
+     */
+    public function findPublishedMetaById(string $versionId): ?array
+    {
+        $row = DB::table('template_versions')
+            ->where('id', $versionId)
+            ->select(['id', 'version_number', 'changelog'])
+            ->first();
+
+        if ($row === null) {
+            return null;
+        }
+
+        return [
+            'id' => (string) $row->id,
+            'version_number' => (int) $row->version_number,
+            'changelog' => (string) $row->changelog,
+        ];
+    }
+
+    /**
+     * Metadatos de la versión publicada más reciente (consulta ligera).
+     *
+     * @return array{id: string, version_number: int, changelog: string}|null
+     */
+    public function findLatestPublishedMetaForTemplate(string $templateId): ?array
+    {
+        $row = DB::table('template_versions')
+            ->where('template_id', $templateId)
+            ->orderByDesc('version_number')
+            ->select(['id', 'version_number', 'changelog'])
+            ->first();
+
+        if ($row === null) {
+            return null;
+        }
+
+        return [
+            'id' => (string) $row->id,
+            'version_number' => (int) $row->version_number,
+            'changelog' => (string) $row->changelog,
+        ];
     }
 
     /**

--- a/backend/app/Services/Contracts/DocumentServiceInterface.php
+++ b/backend/app/Services/Contracts/DocumentServiceInterface.php
@@ -3,6 +3,7 @@
 namespace App\Services\Contracts;
 
 use App\DTOs\Documents\CreateDocumentDto;
+use App\DTOs\Documents\UpdateDocumentBlockDto;
 use App\Models\Document;
 use App\Models\DocumentReview;
 use Illuminate\Support\Collection;
@@ -25,6 +26,11 @@ interface DocumentServiceInterface
      * @return list<array<string, mixed>>
      */
     public function blocksForDisplay(Document $document): array;
+
+    /**
+     * Actualiza el contenido de un bloque de documento.
+     */
+    public function updateBlock(UpdateDocumentBlockDto $dto): array;
 
     /**
      * Transiciona el documento a un nuevo estado y emite el evento de dominio DocumentStateChanged.

--- a/backend/app/Services/Contracts/DocumentServiceInterface.php
+++ b/backend/app/Services/Contracts/DocumentServiceInterface.php
@@ -145,4 +145,11 @@ interface DocumentServiceInterface
      * Elimina un compartido (idempotente si no existía).
      */
     public function removeDocumentShare(string $documentId, string $targetUserId, string $actorId): void;
+
+    /**
+     * Anota en cada documento si el visor accede vía `document_shares` y con qué permiso (listado / detalle).
+     *
+     * @param  Collection<int, Document>  $documents
+     */
+    public function attachShareMetadataForViewer(Collection $documents, string $viewerId): void;
 }

--- a/backend/app/Services/Contracts/DocumentServiceInterface.php
+++ b/backend/app/Services/Contracts/DocumentServiceInterface.php
@@ -6,6 +6,7 @@ use App\DTOs\Documents\CreateDocumentDto;
 use App\DTOs\Documents\UpdateDocumentBlockDto;
 use App\Models\Document;
 use App\Models\DocumentReview;
+use App\Models\DocumentVersion;
 use Illuminate\Support\Collection;
 
 interface DocumentServiceInterface
@@ -59,7 +60,7 @@ interface DocumentServiceInterface
     /**
      * Publica el documento.
      */
-    public function publishDocument(string $documentId, string $actorId): Document;
+    public function publishDocument(string $documentId, string $actorId, string $changelog): Document;
 
     /**
      * Rechaza el documento.
@@ -81,7 +82,12 @@ interface DocumentServiceInterface
     /**
      * Aprueba una revisión del documento.
      */
-    public function approveReview(string $documentId, string $reviewId, string $actorId): Document;
+    public function approveReview(string $documentId, string $reviewId, string $actorId, ?string $publicationChangelog = null): Document;
+
+    /**
+     * Localiza una versión snapshot del documento por id.
+     */
+    public function findDocumentVersionOrFail(string $documentId, string $versionId): DocumentVersion;
 
     /**
      * Rechaza una revisión del documento.

--- a/backend/app/Services/Contracts/DocumentServiceInterface.php
+++ b/backend/app/Services/Contracts/DocumentServiceInterface.php
@@ -116,4 +116,16 @@ interface DocumentServiceInterface
         string $creatorId,
         ?string $templateVersionId = null,
     ): Document;
+
+    /**
+     * Comparación ligera entre la versión de plantilla anclada al documento y la última publicada.
+     *
+     * @return array{
+     *   current_version: ?array{id: string, version_number: int},
+     *   latest_version: ?array{id: string, version_number: int, changelog: string},
+     *   has_update: bool,
+     *   changelog: ?string
+     * }
+     */
+    public function templateVersionStatus(string $documentId): array;
 }

--- a/backend/app/Services/Contracts/DocumentServiceInterface.php
+++ b/backend/app/Services/Contracts/DocumentServiceInterface.php
@@ -128,4 +128,21 @@ interface DocumentServiceInterface
      * }
      */
     public function templateVersionStatus(string $documentId): array;
+
+    /**
+     * Crea o actualiza un compartido del documento (solo titular vía policy en controlador).
+     *
+     * @return array{user_id: string, permission: string, granted_by: string}
+     */
+    public function upsertDocumentShare(
+        string $documentId,
+        string $targetUserId,
+        string $permission,
+        string $actorId,
+    ): array;
+
+    /**
+     * Elimina un compartido (idempotente si no existía).
+     */
+    public function removeDocumentShare(string $documentId, string $targetUserId, string $actorId): void;
 }

--- a/backend/app/Services/Contracts/DocumentServiceInterface.php
+++ b/backend/app/Services/Contracts/DocumentServiceInterface.php
@@ -21,6 +21,18 @@ interface DocumentServiceInterface
     public function create(CreateDocumentDto $dto): Document;
 
     /**
+     * Actualiza metadatos editables del documento.
+     *
+     * @param  array<string, mixed>  $attributes
+     */
+    public function update(string $documentId, array $attributes): Document;
+
+    /**
+     * Borrado lógico del documento.
+     */
+    public function delete(string $documentId): void;
+
+    /**
      * Bloques para mostrar/editar: definición según {@see Document::$template_version_id} y contenido en document_blocks.
      *
      * @return list<array<string, mixed>>

--- a/backend/app/Services/Contracts/SnapshotServiceInterface.php
+++ b/backend/app/Services/Contracts/SnapshotServiceInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Services\Contracts;
+
+use App\DTOs\Documents\CreateDocumentSnapshotDto;
+
+interface SnapshotServiceInterface
+{
+    /**
+     * Inserta un snapshot inmutable del documento (append-only).
+     */
+    public function createDocumentSnapshot(CreateDocumentSnapshotDto $dto): void;
+}

--- a/backend/app/Services/DocumentService.php
+++ b/backend/app/Services/DocumentService.php
@@ -8,6 +8,7 @@ use App\DTOs\Documents\UpdateDocumentBlockDto;
 use App\Events\DocumentStateChanged;
 use App\Models\CourseModule;
 use App\Models\Document;
+use App\Models\DocumentBlock;
 use App\Models\DocumentReview;
 use App\Models\DocumentVersion;
 use App\Models\Template;
@@ -373,37 +374,52 @@ class DocumentService implements DocumentServiceInterface
      */
     public function updateBlock(UpdateDocumentBlockDto $dto): array
     {
-        $document = $this->documentRepository->findOrFail($dto->documentId);
-        if ($document->status !== 'draft') {
-            abort(403, 'Solo se pueden editar bloques de documentos en borrador.');
-        }
+        return DB::transaction(function () use ($dto) {
+            $document = $this->documentRepository->findOrFail($dto->documentId);
+            if ($document->status !== 'draft') {
+                abort(403, 'Solo se pueden editar bloques de documentos en borrador.');
+            }
 
-        $block = $this->documentRepository->findBlockInDocumentOrFail(
-            $dto->documentId,
-            $dto->documentBlockId,
-        );
+            $block = $this->documentRepository->findBlockInDocumentOrFail(
+                $dto->documentId,
+                $dto->documentBlockId,
+            );
 
-        $definitions = collect($this->blockDefinitionsForDocument($document))
-            ->keyBy(fn (array $def) => (string) $def['id']);
-        $definition = $definitions->get((string) $block->template_block_id);
+            $definitions = collect($this->blockDefinitionsForDocument($document))
+                ->keyBy(fn (array $def) => (string) $def['id']);
+            $definition = $definitions->get((string) $block->template_block_id) ?? [];
 
-        if (($definition['block_state'] ?? 'editable') === 'locked') {
-            abort(403, 'Este bloque está bloqueado y no admite edición.');
-        }
+            if (($definition['block_state'] ?? 'editable') === 'locked') {
+                abort(403, 'Este bloque está bloqueado y no admite edición.');
+            }
 
-        $block->content = $dto->content;
-        $block->is_filled = $this->isContentFilled($dto->content);
-        $block->last_edited_by = $dto->actorId;
-        $this->documentRepository->saveBlock($block);
+            if ($this->documentBlockContentEquals($block->content, $dto->content)) {
+                return [
+                    'document_block_id' => (string) $block->id,
+                    'template_block_id' => (string) $block->template_block_id,
+                    'content' => $block->content,
+                    'is_filled' => (bool) $block->is_filled,
+                    'last_edited_by' => (string) $block->last_edited_by,
+                    'updated_at' => $block->updated_at?->toIso8601String(),
+                ];
+            }
 
-        return [
-            'document_block_id' => (string) $block->id,
-            'template_block_id' => (string) $block->template_block_id,
-            'content' => $block->content,
-            'is_filled' => (bool) $block->is_filled,
-            'last_edited_by' => (string) $block->last_edited_by,
-            'updated_at' => $block->updated_at?->toIso8601String(),
-        ];
+            $this->appendModifiableBlockVersionSnapshotsIfNeeded($document, $block, $definition, $dto);
+
+            $block->content = $dto->content;
+            $block->is_filled = $this->isContentFilled($dto->content);
+            $block->last_edited_by = $dto->actorId;
+            $this->documentRepository->saveBlock($block);
+
+            return [
+                'document_block_id' => (string) $block->id,
+                'template_block_id' => (string) $block->template_block_id,
+                'content' => $block->content,
+                'is_filled' => (bool) $block->is_filled,
+                'last_edited_by' => (string) $block->last_edited_by,
+                'updated_at' => $block->updated_at?->toIso8601String(),
+            ];
+        });
     }
 
     /**
@@ -732,6 +748,9 @@ class DocumentService implements DocumentServiceInterface
         }
     }
 
+    /**
+     * Verifica si el contenido del bloque está completado.
+     */
     private function isContentFilled(mixed $content): bool
     {
         if ($content === null) {
@@ -804,5 +823,109 @@ class DocumentService implements DocumentServiceInterface
         $this->documentRepository->findOrFail($documentId);
 
         return $this->documentRepository->findDocumentVersionInDocumentOrFail($documentId, $versionId);
+    }
+
+    /**
+     * Compara dos valores JSON canónicamente.
+     */
+    private function documentBlockContentEquals(mixed $a, mixed $b): bool
+    {
+        return $this->jsonEncodeCanonical($a) === $this->jsonEncodeCanonical($b);
+    }
+
+    /**
+     * Codifica un valor JSON canónicamente.
+     */
+    private function jsonEncodeCanonical(mixed $value): string
+    {
+        try {
+            $normalized = $this->normalizeKeysForCanonicalJson($value);
+
+            return json_encode(
+                $normalized,
+                \JSON_THROW_ON_ERROR | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE | \JSON_PRESERVE_ZERO_FRACTION,
+            );
+        } catch (\JsonException) {
+            return '';
+        }
+    }
+
+    /**
+     * Ordena claves de objetos JSON (arrays asociativos) de forma recursiva; preserva el orden de listas.
+     */
+    private function normalizeKeysForCanonicalJson(mixed $value): mixed
+    {
+        if (! is_array($value)) {
+            return $value;
+        }
+
+        if ($value === [] || array_is_list($value)) {
+            return array_map(fn (mixed $item): mixed => $this->normalizeKeysForCanonicalJson($item), $value);
+        }
+
+        ksort($value);
+
+        foreach ($value as $k => $nested) {
+            $value[$k] = $this->normalizeKeysForCanonicalJson($nested);
+        }
+
+        return $value;
+    }
+
+    /**
+     * Si el bloque es editable y modificable, crea una nueva versión del bloque.
+     * 
+     * @param  array<string, mixed>  $definition
+     */
+    private function appendModifiableBlockVersionSnapshotsIfNeeded(
+        Document $document,
+        DocumentBlock $block,
+        array $definition,
+        UpdateDocumentBlockDto $dto,
+    ): void {
+        if (($definition['block_state'] ?? 'editable') !== 'modifiable') {
+            return;
+        }
+
+        $blockId = (string) $block->id;
+        $documentId = (string) $document->id;
+        $max = $this->documentRepository->maxBlockVersionNumberForDocumentBlock($blockId);
+
+        if ($max === 0) {
+            $baseline = $this->normalizeBlockVersionPayload($definition['default_content'] ?? null);
+            $baselineEditor = (string) ($document->created_by ?? $document->owner_id ?? $dto->actorId);
+            $this->documentRepository->insertDocumentBlockVersion(
+                $blockId,
+                $documentId,
+                1,
+                $baseline,
+                null,
+                $baselineEditor,
+            );
+            $max = 1;
+        }
+
+        $this->documentRepository->insertDocumentBlockVersion(
+            $blockId,
+            $documentId,
+            $max + 1,
+            $this->normalizeBlockVersionPayload($dto->content),
+            null,
+            $dto->actorId,
+        );
+    }
+
+    /**
+     * Normaliza el payload del bloque para la versión.
+     * 
+     * @return array<string, mixed>
+     */
+    private function normalizeBlockVersionPayload(mixed $value): array
+    {
+        if ($value === null) {
+            return [];
+        }
+
+        return is_array($value) ? $value : [];
     }
 }

--- a/backend/app/Services/DocumentService.php
+++ b/backend/app/Services/DocumentService.php
@@ -3,16 +3,19 @@
 namespace App\Services;
 
 use App\DTOs\Documents\CreateDocumentDto;
+use App\DTOs\Documents\CreateDocumentSnapshotDto;
 use App\DTOs\Documents\UpdateDocumentBlockDto;
 use App\Events\DocumentStateChanged;
 use App\Models\CourseModule;
 use App\Models\Document;
 use App\Models\DocumentReview;
+use App\Models\DocumentVersion;
 use App\Models\Template;
 use App\Repositories\Contracts\DocumentRepositoryInterface;
 use App\Repositories\Contracts\TemplateRepositoryInterface;
 use App\Repositories\Contracts\TemplateVersionRepositoryInterface;
 use App\Services\Contracts\DocumentServiceInterface;
+use App\Services\Contracts\SnapshotServiceInterface;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\ValidationException;
@@ -23,6 +26,7 @@ class DocumentService implements DocumentServiceInterface
         private readonly DocumentRepositoryInterface $documentRepository,
         private readonly TemplateRepositoryInterface $templateRepository,
         private readonly TemplateVersionRepositoryInterface $templateVersionRepository,
+        private readonly SnapshotServiceInterface $snapshotService,
     ) {}
 
     /**
@@ -253,9 +257,7 @@ class DocumentService implements DocumentServiceInterface
     {
         $document = $this->documentRepository->findOrFail($dto->documentId);
         if ($document->status !== 'draft') {
-            throw ValidationException::withMessages([
-                'status' => ['Solo se pueden editar bloques de documentos en borrador.'],
-            ]);
+            abort(403, 'Solo se pueden editar bloques de documentos en borrador.');
         }
 
         $block = $this->documentRepository->findBlockInDocumentOrFail(
@@ -268,9 +270,7 @@ class DocumentService implements DocumentServiceInterface
         $definition = $definitions->get((string) $block->template_block_id);
 
         if (($definition['block_state'] ?? 'editable') === 'locked') {
-            throw ValidationException::withMessages([
-                'block' => ['Este bloque está bloqueado y no admite edición.'],
-            ]);
+            abort(403, 'Este bloque está bloqueado y no admite edición.');
         }
 
         $block->content = $dto->content;
@@ -396,7 +396,7 @@ class DocumentService implements DocumentServiceInterface
     /**
      * Publica el documento.
      */
-    public function publishDocument(string $documentId, string $actorId): Document
+    public function publishDocument(string $documentId, string $actorId, string $changelog): Document
     {
         $document = $this->documentRepository->findOrFail($documentId);
 
@@ -412,11 +412,16 @@ class DocumentService implements DocumentServiceInterface
             ]);
         }
 
-        return DB::transaction(function () use ($documentId, $actorId) {
+        return DB::transaction(function () use ($documentId, $actorId, $changelog) {
             $this->transition($documentId, 'published', $actorId, [
                 'published_at' => now(),
             ]);
-            $this->recordPublishedDocumentVersion($documentId, $actorId);
+            $this->snapshotService->createDocumentSnapshot(new CreateDocumentSnapshotDto(
+                documentId: $documentId,
+                triggerEvent: 'published',
+                triggeredBy: $actorId,
+                notes: $changelog,
+            ));
 
             return $this->documentRepository->findOrFail($documentId);
         });
@@ -484,9 +489,9 @@ class DocumentService implements DocumentServiceInterface
     /**
      * Aprueba una revisión del documento.
      */
-    public function approveReview(string $documentId, string $reviewId, string $actorId): Document
+    public function approveReview(string $documentId, string $reviewId, string $actorId, ?string $publicationChangelog = null): Document
     {
-        return DB::transaction(function () use ($documentId, $reviewId, $actorId) {
+        return DB::transaction(function () use ($documentId, $reviewId, $actorId, $publicationChangelog) {
             $document = $this->documentRepository->findOrFail($documentId);
 
             if ($document->status !== 'in_review') {
@@ -521,7 +526,15 @@ class DocumentService implements DocumentServiceInterface
                 $this->transition($documentId, 'published', $actorId, [
                     'published_at' => now(),
                 ]);
-                $this->recordPublishedDocumentVersion($documentId, $actorId);
+                $changelog = $publicationChangelog !== null && trim($publicationChangelog) !== ''
+                    ? trim($publicationChangelog)
+                    : 'Publicado tras aprobación de revisión.';
+                $this->snapshotService->createDocumentSnapshot(new CreateDocumentSnapshotDto(
+                    documentId: $documentId,
+                    triggerEvent: 'published',
+                    triggeredBy: $actorId,
+                    notes: $changelog,
+                ));
 
                 return $this->documentRepository->findOrFail($documentId);
             }
@@ -624,6 +637,9 @@ class DocumentService implements DocumentServiceInterface
         return true;
     }
 
+    /**
+     * Verifica que todos los bloques obligatorios estén completos.
+     */
     private function assertMandatoryBlocksAreFilled(Document $document): void
     {
         $definitions = collect($this->blockDefinitionsForDocument($document))
@@ -663,62 +679,12 @@ class DocumentService implements DocumentServiceInterface
     }
 
     /**
-     * Persiste snapshot append-only en document_versions y alinea current_version.
+     * Localiza una versión de documento por su ID.
      */
-    private function recordPublishedDocumentVersion(string $documentId, string $actorId): void
+    public function findDocumentVersionOrFail(string $documentId, string $versionId): DocumentVersion
     {
-        $document = $this->documentRepository->findOrFail($documentId);
-        $nextNumber = $this->documentRepository->maxDocumentVersionNumber($documentId) + 1;
-        $snapshot = $this->buildDocumentVersionSnapshot($document, $nextNumber);
+        $this->documentRepository->findOrFail($documentId);
 
-        $this->documentRepository->insertDocumentVersion(
-            $documentId,
-            $nextNumber,
-            'published',
-            $actorId,
-            $snapshot,
-            null,
-        );
-
-        $document->update(['current_version' => $nextNumber]);
-    }
-
-    /**
-     * @return array<string, mixed>
-     */
-    private function buildDocumentVersionSnapshot(Document $document, int $snapshotVersionNumber): array
-    {
-        $document->loadMissing(['blocks' => fn ($q) => $q->orderBy('sort_order')]);
-
-        return [
-            'snapshot_version_number' => $snapshotVersionNumber,
-            'document' => [
-                'id' => $document->id,
-                'template_id' => $document->template_id,
-                'template_version_id' => $document->template_version_id,
-                'title' => $document->title,
-                'study_type_id' => $document->study_type_id,
-                'study_id' => $document->study_id,
-                'module_id' => $document->module_id,
-                'created_by' => $document->created_by,
-                'owner_id' => $document->owner_id,
-                'status' => $document->status,
-                'current_version' => (int) $document->current_version,
-                'submitted_at' => $document->submitted_at?->toIso8601String(),
-                'published_at' => $document->published_at?->toIso8601String(),
-            ],
-            'blocks' => $document->blocks->map(static function ($b): array {
-                return [
-                    'id' => $b->id,
-                    'template_block_id' => $b->template_block_id,
-                    'content' => $b->content,
-                    'is_filled' => (bool) $b->is_filled,
-                    'sort_order' => (int) $b->sort_order,
-                    'last_edited_by' => $b->last_edited_by,
-                    'locked_by' => $b->locked_by,
-                    'locked_at' => $b->locked_at?->toIso8601String(),
-                ];
-            })->values()->all(),
-        ];
+        return $this->documentRepository->findDocumentVersionInDocumentOrFail($documentId, $versionId);
     }
 }

--- a/backend/app/Services/DocumentService.php
+++ b/backend/app/Services/DocumentService.php
@@ -205,6 +205,46 @@ class DocumentService implements DocumentServiceInterface
     }
 
     /**
+     * Comparación ligera entre la versión de plantilla anclada al documento y la última publicada.
+     *
+     * @return array{
+     *   current_version: ?array{id: string, version_number: int},
+     *   latest_version: ?array{id: string, version_number: int, changelog: string},
+     *   has_update: bool,
+     *   changelog: ?string
+     * }
+     */
+    public function templateVersionStatus(string $documentId): array
+    {
+        $document = $this->documentRepository->findOrFail($documentId);
+        $versionId = $document->template_version_id;
+
+        $currentFull = is_string($versionId)
+            ? $this->templateVersionRepository->findPublishedMetaById($versionId)
+            : null;
+
+        $latestFull = $this->templateVersionRepository->findLatestPublishedMetaForTemplate((string) $document->template_id);
+
+        $current = $currentFull !== null
+            ? [
+                'id' => $currentFull['id'],
+                'version_number' => $currentFull['version_number'],
+            ]
+            : null;
+
+        $hasUpdate = $currentFull !== null
+            && $latestFull !== null
+            && $latestFull['version_number'] > $currentFull['version_number'];
+
+        return [
+            'current_version' => $current,
+            'latest_version' => $latestFull,
+            'has_update' => $hasUpdate,
+            'changelog' => $hasUpdate ? $latestFull['changelog'] : null,
+        ];
+    }
+
+    /**
      * Lista documentos visibles para el usuario actual ordenados por fecha de creación descendente.
      * 
      * @return Collection<int, Document>

--- a/backend/app/Services/DocumentService.php
+++ b/backend/app/Services/DocumentService.php
@@ -307,8 +307,12 @@ class DocumentService implements DocumentServiceInterface
             }
         }
 
-        $template = $this->templateRepository->findOrFail($document->template_id);
-        $template->loadMissing(['blocks' => fn ($q) => $q->orderBy('sort_order')]);
+        // Sin global scope: durante submit/revisión el titular puede no tener visibilidad
+        // de catálogo sobre la plantilla, pero el documento ya está anclado a ella.
+        $template = Template::query()
+            ->withoutGlobalScopes(['user_access'])
+            ->with(['blocks' => fn ($q) => $q->orderBy('sort_order')])
+            ->findOrFail($document->template_id);
 
         return $template->blocks->map(fn ($b) => [
             'id' => $b->id,
@@ -355,6 +359,8 @@ class DocumentService implements DocumentServiceInterface
                 'status' => ['Solo los documentos en borrador pueden enviarse a revisión.'],
             ]);
         }
+
+        $this->assertMandatoryBlocksAreFilled($document);
 
         return DB::transaction(function () use ($documentId, $actorId, $document) {
             $this->documentRepository->deleteReviewsForDocument($documentId);
@@ -608,5 +614,43 @@ class DocumentService implements DocumentServiceInterface
         }
 
         return true;
+    }
+
+    private function assertMandatoryBlocksAreFilled(Document $document): void
+    {
+        $definitions = collect($this->blockDefinitionsForDocument($document))
+            ->filter(fn (array $def) => (bool) ($def['mandatory'] ?? false));
+
+        if ($definitions->isEmpty()) {
+            return;
+        }
+
+        $document->loadMissing('blocks');
+        $blocksByTemplateBlockId = $document->blocks->keyBy('template_block_id');
+        $missing = [];
+
+        foreach ($definitions as $definition) {
+            $templateBlockId = (string) ($definition['id'] ?? '');
+            if ($templateBlockId === '') {
+                continue;
+            }
+
+            $block = $blocksByTemplateBlockId->get($templateBlockId);
+            if ($block === null) {
+                $missing[] = $templateBlockId;
+                continue;
+            }
+
+            if (! ((bool) $block->is_filled) && ! $this->isContentFilled($block->content)) {
+                $missing[] = $templateBlockId;
+            }
+        }
+
+        if ($missing !== []) {
+            throw ValidationException::withMessages([
+                'blocks' => ['Debes completar todos los bloques obligatorios antes de enviar a revisión.'],
+                'missing_template_block_ids' => $missing,
+            ]);
+        }
     }
 }

--- a/backend/app/Services/DocumentService.php
+++ b/backend/app/Services/DocumentService.php
@@ -302,6 +302,27 @@ class DocumentService implements DocumentServiceInterface
     }
 
     /**
+     * Anota en cada documento si el visor accede vía `document_shares` y con qué permiso (listado / detalle).
+     * 
+     * @param  Collection<int, Document>  $documents
+     */
+    public function attachShareMetadataForViewer(Collection $documents, string $viewerId): void
+    {
+        if ($documents->isEmpty()) {
+            return;
+        }
+
+        $ids = $documents->pluck('id')->map(fn ($id) => (string) $id)->values()->all();
+        $byDoc = $this->documentRepository->sharePermissionsForViewer($ids, $viewerId);
+
+        foreach ($documents as $document) {
+            $permission = $byDoc[(string) $document->getKey()] ?? null;
+            $document->setAttribute('viewer_share_permission', $permission);
+            $document->setAttribute('is_shared_with_me', $permission !== null);
+        }
+    }
+
+    /**
      * Lista documentos visibles para el usuario actual ordenados por fecha de creación descendente.
      * 
      * @return Collection<int, Document>

--- a/backend/app/Services/DocumentService.php
+++ b/backend/app/Services/DocumentService.php
@@ -412,9 +412,14 @@ class DocumentService implements DocumentServiceInterface
             ]);
         }
 
-        return $this->transition($documentId, 'published', $actorId, [
-            'published_at' => now(),
-        ]);
+        return DB::transaction(function () use ($documentId, $actorId) {
+            $this->transition($documentId, 'published', $actorId, [
+                'published_at' => now(),
+            ]);
+            $this->recordPublishedDocumentVersion($documentId, $actorId);
+
+            return $this->documentRepository->findOrFail($documentId);
+        });
     }
 
     /**
@@ -513,9 +518,12 @@ class DocumentService implements DocumentServiceInterface
             $this->documentRepository->saveReview($review);
 
             if ($this->documentRepository->countPendingReviewsForDocument($documentId) === 0) {
-                return $this->transition($documentId, 'published', $actorId, [
+                $this->transition($documentId, 'published', $actorId, [
                     'published_at' => now(),
                 ]);
+                $this->recordPublishedDocumentVersion($documentId, $actorId);
+
+                return $this->documentRepository->findOrFail($documentId);
             }
 
             return $this->documentRepository->findOrFail($documentId);
@@ -652,5 +660,65 @@ class DocumentService implements DocumentServiceInterface
                 'missing_template_block_ids' => $missing,
             ]);
         }
+    }
+
+    /**
+     * Persiste snapshot append-only en document_versions y alinea current_version.
+     */
+    private function recordPublishedDocumentVersion(string $documentId, string $actorId): void
+    {
+        $document = $this->documentRepository->findOrFail($documentId);
+        $nextNumber = $this->documentRepository->maxDocumentVersionNumber($documentId) + 1;
+        $snapshot = $this->buildDocumentVersionSnapshot($document, $nextNumber);
+
+        $this->documentRepository->insertDocumentVersion(
+            $documentId,
+            $nextNumber,
+            'published',
+            $actorId,
+            $snapshot,
+            null,
+        );
+
+        $document->update(['current_version' => $nextNumber]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function buildDocumentVersionSnapshot(Document $document, int $snapshotVersionNumber): array
+    {
+        $document->loadMissing(['blocks' => fn ($q) => $q->orderBy('sort_order')]);
+
+        return [
+            'snapshot_version_number' => $snapshotVersionNumber,
+            'document' => [
+                'id' => $document->id,
+                'template_id' => $document->template_id,
+                'template_version_id' => $document->template_version_id,
+                'title' => $document->title,
+                'study_type_id' => $document->study_type_id,
+                'study_id' => $document->study_id,
+                'module_id' => $document->module_id,
+                'created_by' => $document->created_by,
+                'owner_id' => $document->owner_id,
+                'status' => $document->status,
+                'current_version' => (int) $document->current_version,
+                'submitted_at' => $document->submitted_at?->toIso8601String(),
+                'published_at' => $document->published_at?->toIso8601String(),
+            ],
+            'blocks' => $document->blocks->map(static function ($b): array {
+                return [
+                    'id' => $b->id,
+                    'template_block_id' => $b->template_block_id,
+                    'content' => $b->content,
+                    'is_filled' => (bool) $b->is_filled,
+                    'sort_order' => (int) $b->sort_order,
+                    'last_edited_by' => $b->last_edited_by,
+                    'locked_by' => $b->locked_by,
+                    'locked_at' => $b->locked_at?->toIso8601String(),
+                ];
+            })->values()->all(),
+        ];
     }
 }

--- a/backend/app/Services/DocumentService.php
+++ b/backend/app/Services/DocumentService.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use App\DTOs\Documents\CreateDocumentDto;
+use App\DTOs\Documents\UpdateDocumentBlockDto;
 use App\Events\DocumentStateChanged;
 use App\Models\CourseModule;
 use App\Models\Document;
@@ -216,6 +217,50 @@ class DocumentService implements DocumentServiceInterface
         }
 
         return $out;
+    }
+
+    /**
+     * Actualiza el contenido de un bloque de documento.
+     *
+     * @return array<string, mixed>
+     */
+    public function updateBlock(UpdateDocumentBlockDto $dto): array
+    {
+        $document = $this->documentRepository->findOrFail($dto->documentId);
+        if ($document->status !== 'draft') {
+            throw ValidationException::withMessages([
+                'status' => ['Solo se pueden editar bloques de documentos en borrador.'],
+            ]);
+        }
+
+        $block = $this->documentRepository->findBlockInDocumentOrFail(
+            $dto->documentId,
+            $dto->documentBlockId,
+        );
+
+        $definitions = collect($this->blockDefinitionsForDocument($document))
+            ->keyBy(fn (array $def) => (string) $def['id']);
+        $definition = $definitions->get((string) $block->template_block_id);
+
+        if (($definition['block_state'] ?? 'editable') === 'locked') {
+            throw ValidationException::withMessages([
+                'block' => ['Este bloque está bloqueado y no admite edición.'],
+            ]);
+        }
+
+        $block->content = $dto->content;
+        $block->is_filled = $this->isContentFilled($dto->content);
+        $block->last_edited_by = $dto->actorId;
+        $this->documentRepository->saveBlock($block);
+
+        return [
+            'document_block_id' => (string) $block->id,
+            'template_block_id' => (string) $block->template_block_id,
+            'content' => $block->content,
+            'is_filled' => (bool) $block->is_filled,
+            'last_edited_by' => (string) $block->last_edited_by,
+            'updated_at' => $block->updated_at?->toIso8601String(),
+        ];
     }
 
     /**
@@ -515,5 +560,28 @@ class DocumentService implements DocumentServiceInterface
                 'review' => ['En revisión secuencial, solo puede actuar la etapa pendiente más baja.'],
             ]);
         }
+    }
+
+    private function isContentFilled(mixed $content): bool
+    {
+        if ($content === null) {
+            return false;
+        }
+
+        if (is_string($content)) {
+            return trim($content) !== '';
+        }
+
+        if (is_array($content)) {
+            if ($content === []) {
+                return false;
+            }
+
+            $encoded = json_encode($content);
+
+            return $encoded !== false && $encoded !== '[]' && $encoded !== '{}' && $encoded !== 'null';
+        }
+
+        return true;
     }
 }

--- a/backend/app/Services/DocumentService.php
+++ b/backend/app/Services/DocumentService.php
@@ -90,6 +90,31 @@ class DocumentService implements DocumentServiceInterface
     }
 
     /**
+     * Actualiza metadatos editables del documento.
+     *
+     * @param  array<string, mixed>  $attributes
+     */
+    public function update(string $documentId, array $attributes): Document
+    {
+        $document = $this->documentRepository->findOrFail($documentId);
+
+        $document->update([
+            'title' => $attributes['title'],
+        ]);
+
+        return $document->fresh();
+    }
+
+    /**
+     * Borrado lógico del documento.
+     */
+    public function delete(string $documentId): void
+    {
+        $document = $this->documentRepository->findOrFail($documentId);
+        $document->delete();
+    }
+
+    /**
      * Opciones de creación de documento disponibles para un módulo.
      * 
      * @return list<array{template_id: string, template_version_id: string, name: string, description: ?string}>

--- a/backend/app/Services/DocumentService.php
+++ b/backend/app/Services/DocumentService.php
@@ -245,6 +245,63 @@ class DocumentService implements DocumentServiceInterface
     }
 
     /**
+     * Crea o actualiza un compartido del documento (solo titular vía policy en controlador).
+     *
+     * @return array{user_id: string, permission: string, granted_by: string}
+     */
+    public function upsertDocumentShare(
+        string $documentId,
+        string $targetUserId,
+        string $permission,
+        string $actorId,
+    ): array {
+        $document = $this->documentRepository->findOrFail($documentId);
+
+        if ($document->owner_id !== $actorId) {
+            abort(403, 'Solo el titular puede gestionar colaboradores.');
+        }
+
+        if ($targetUserId === $actorId) {
+            throw ValidationException::withMessages([
+                'user_id' => ['No puedes compartir el documento contigo mismo.'],
+            ]);
+        }
+
+        if ($targetUserId === $document->owner_id) {
+            throw ValidationException::withMessages([
+                'user_id' => ['El titular ya tiene acceso completo al documento.'],
+            ]);
+        }
+
+        $this->documentRepository->upsertDocumentShare(
+            $documentId,
+            $targetUserId,
+            $permission,
+            $actorId,
+        );
+
+        return [
+            'user_id' => $targetUserId,
+            'permission' => $permission,
+            'granted_by' => $actorId,
+        ];
+    }
+
+    /**
+     * Elimina un compartido (idempotente si no existía).
+     */
+    public function removeDocumentShare(string $documentId, string $targetUserId, string $actorId): void
+    {
+        $document = $this->documentRepository->findOrFail($documentId);
+
+        if ($document->owner_id !== $actorId) {
+            abort(403, 'Solo el titular puede gestionar colaboradores.');
+        }
+
+        $this->documentRepository->deleteDocumentShare($documentId, $targetUserId);
+    }
+
+    /**
      * Lista documentos visibles para el usuario actual ordenados por fecha de creación descendente.
      * 
      * @return Collection<int, Document>

--- a/backend/app/Services/SnapshotService.php
+++ b/backend/app/Services/SnapshotService.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Services;
+
+use App\DTOs\Documents\CreateDocumentSnapshotDto;
+use App\Models\Document;
+use App\Repositories\Contracts\DocumentRepositoryInterface;
+use App\Services\Contracts\SnapshotServiceInterface;
+
+class SnapshotService implements SnapshotServiceInterface
+{
+    public function __construct(
+        private readonly DocumentRepositoryInterface $documentRepository,
+    ) {}
+
+    public function createDocumentSnapshot(CreateDocumentSnapshotDto $dto): void
+    {
+        $document = $this->documentRepository->findOrFail($dto->documentId);
+        $nextNumber = $this->documentRepository->maxDocumentVersionNumber($dto->documentId) + 1;
+        $snapshot = $this->buildDocumentVersionSnapshot($document, $nextNumber);
+
+        $this->documentRepository->insertDocumentVersion(
+            $dto->documentId,
+            $nextNumber,
+            $dto->triggerEvent,
+            $dto->triggeredBy,
+            $snapshot,
+            $dto->notes,
+        );
+
+        $document->update(['current_version' => $nextNumber]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function buildDocumentVersionSnapshot(Document $document, int $snapshotVersionNumber): array
+    {
+        $document->loadMissing(['blocks' => fn ($q) => $q->orderBy('sort_order')]);
+
+        return [
+            'snapshot_version_number' => $snapshotVersionNumber,
+            'document' => [
+                'id' => $document->id,
+                'template_id' => $document->template_id,
+                'template_version_id' => $document->template_version_id,
+                'title' => $document->title,
+                'study_type_id' => $document->study_type_id,
+                'study_id' => $document->study_id,
+                'module_id' => $document->module_id,
+                'created_by' => $document->created_by,
+                'owner_id' => $document->owner_id,
+                'status' => $document->status,
+                'current_version' => (int) $document->current_version,
+                'submitted_at' => $document->submitted_at?->toIso8601String(),
+                'published_at' => $document->published_at?->toIso8601String(),
+            ],
+            'blocks' => $document->blocks->map(static function ($b): array {
+                return [
+                    'id' => $b->id,
+                    'template_block_id' => $b->template_block_id,
+                    'content' => $b->content,
+                    'is_filled' => (bool) $b->is_filled,
+                    'sort_order' => (int) $b->sort_order,
+                    'last_edited_by' => $b->last_edited_by,
+                    'locked_by' => $b->locked_by,
+                    'locked_at' => $b->locked_at?->toIso8601String(),
+                ];
+            })->values()->all(),
+        ];
+    }
+}

--- a/backend/database/migrations/0001_00_00_000007_create_block_versions_table.php
+++ b/backend/database/migrations/0001_00_00_000007_create_block_versions_table.php
@@ -8,12 +8,12 @@ use Illuminate\Support\Facades\Schema;
 return new class extends Migration
 {
     /**
-     * Versionado append-only de bloques (F-04.4).
+     * Versionado append-only de bloques.
      * NUNCA se actualiza un registro existente: solo INSERT.
      * En PostgreSQL se reutiliza la función forbid_append_only_mutation() creada en create_template_versions.
      *
      * El diff entre versiones consecutivas se calcula en la capa de aplicación
-     * y se muestra en el drawer de revisión (F-06.3).
+     * y se muestra en el drawer de revisión.
      */
     public function up(): void
     {

--- a/backend/database/migrations/0001_00_00_000008_create_document_versions_table.php
+++ b/backend/database/migrations/0001_00_00_000008_create_document_versions_table.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
@@ -11,6 +12,9 @@ return new class extends Migration
      * Se crean en eventos clave: submit_for_review, publish, reject.
      * snapshot_data contiene el JSON completo del documento (todos sus bloques)
      * para poder reconstruir cualquier versión pasada sin joins.
+     *
+     * En PostgreSQL se reutiliza forbid_append_only_mutation() (migración template_versions).
+     * En SQLite (tests) solo aplica la capa de aplicación.
      */
     public function up(): void
     {
@@ -21,16 +25,29 @@ return new class extends Migration
             $table->string('trigger_event');     // submitted | published | rejected
             $table->string('triggered_by');      // FK lógica → users (FDW)
             $table->json('snapshot_data');      // snapshot completo del documento
-            $table->text('notes')->nullable();   // motivo de rechazo u observaciones
+            $table->text('notes')->nullable();   // changelog de publicación, rechazo, etc.
+            $table->boolean('is_immutable')->default(true);
             $table->timestamp('created_at');
 
             $table->unique(['document_id', 'version_number']);
-            $table->index('document_id');
+            $table->index(['document_id', 'version_number']);
         });
+
+        if (Schema::getConnection()->getDriverName() === 'pgsql') {
+            DB::unprepared(<<<'SQL'
+CREATE TRIGGER document_versions_append_only
+  BEFORE UPDATE OR DELETE ON document_versions
+  FOR EACH ROW EXECUTE PROCEDURE forbid_append_only_mutation();
+SQL);
+        }
     }
 
     public function down(): void
     {
+        if (Schema::getConnection()->getDriverName() === 'pgsql') {
+            DB::unprepared('DROP TRIGGER IF EXISTS document_versions_append_only ON document_versions;');
+        }
+
         Schema::dropIfExists('document_versions');
     }
 };

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -85,6 +85,8 @@ Route::prefix('v1')->group(function () {
         Route::post('documents/create-from-module', [DocumentController::class, 'createFromModule']);
         Route::get('documents', [DocumentController::class, 'index']);
         Route::post('documents', [DocumentController::class, 'store']);
+        Route::get('documents/{document}/template-version-status', [DocumentController::class, 'templateVersionStatus'])
+            ->whereUuid('document');
         Route::get('documents/{document}', [DocumentController::class, 'show'])
             ->whereUuid('document');
         Route::match(['put', 'patch'], 'documents/{document}', [DocumentController::class, 'update'])

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -108,6 +108,12 @@ Route::prefix('v1')->group(function () {
 
         Route::get('documents/{document}/versions', [DocumentVersionController::class, 'index'])
             ->whereUuid('document');
+        Route::get('documents/{document}/versions/{version}', [DocumentVersionController::class, 'show'])
+            ->whereUuid('document')
+            ->whereUuid('version');
+        Route::match(['put', 'patch', 'delete'], 'documents/{document}/versions/{version}', fn () => abort(403, 'Los snapshots de documento son de solo inserción (append-only).'))
+            ->whereUuid('document')
+            ->whereUuid('version');
 
         // Auditoría
         Route::get('documents/{document}/audit', [AuditLogController::class, 'indexForDocument'])

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -22,15 +22,6 @@ use Illuminate\Support\Facades\Route;
 |--------------------------------------------------------------------------
 | Todas las rutas bajo /api/v1 están protegidas por JwtMiddleware (RS256).
 | Los controladores son deliberadamente delgados: delegan a Services.
-|
-| Sprints planificados:
-|   Sprint 0 — infraestructura (este archivo, health check)
-|   Sprint 1 — auth, academic hierarchy
-|   Sprint 2 — templates CRUD
-|   Sprint 3 — documents CRUD + block editor
-|   Sprint 4 — review workflow
-|   Sprint 5 — comments + collaboration
-|   Sprint 6 — dashboard BFF
 */
 
 Route::prefix('v1')->group(function () {
@@ -43,11 +34,11 @@ Route::prefix('v1')->group(function () {
     // ── Rutas protegidas por JWT ───────────────────────────────
     Route::middleware('jwt')->group(function () {
 
-        // Sprint 1 — Auth / sesión
+        // Autenticación y sesión
         Route::get('/me', [AuthController::class, 'me']);
         Route::get('/hierarchy', [AcademicHierarchyController::class, 'index']);
 
-        // Sprint 2 — Plantillas
+        // Plantillas
         // Combinación de validación UUID (develop) y actualización masiva de bloques (feature).
         Route::apiResource('templates', TemplateController::class)
             ->whereUuid('template');
@@ -80,7 +71,7 @@ Route::prefix('v1')->group(function () {
         Route::match(['put', 'patch', 'delete'], 'template-versions/{template_version}', fn () => abort(403, 'Los snapshots de plantilla son de solo inserción (append-only).'))
             ->whereUuid('template_version');
 
-        // Sprint 3 — Documentos
+        // Documentos
         Route::get('documents/creation-options', [DocumentController::class, 'creationOptions']);
         Route::post('documents/create-from-module', [DocumentController::class, 'createFromModule']);
         Route::get('documents', [DocumentController::class, 'index']);
@@ -125,13 +116,13 @@ Route::prefix('v1')->group(function () {
         Route::get('comments/{comment}/audit', [AuditLogController::class, 'indexForComment'])
             ->whereUuid('comment');
 
-        // Sprint 3 — Compartición
+        // Compartición de documentos
         Route::post('documents/{document}/shares', [DocumentShareController::class, 'store'])
             ->whereUuid('document');
         Route::delete('documents/{document}/shares/{userId}', [DocumentShareController::class, 'destroy'])
             ->whereUuid('document');
 
-        // Sprint 4 — Revisión
+        // Revisión de documentos
         Route::get('documents/{document}/reviews', [ReviewController::class, 'index'])
             ->whereUuid('document');
         Route::post('documents/{document}/reviews/{review}/approve', [ReviewController::class, 'approve'])
@@ -141,7 +132,7 @@ Route::prefix('v1')->group(function () {
             ->whereUuid('document')
             ->whereUuid('review');
 
-        // Sprint 5 — Comentarios
+        // Comentarios
         Route::apiResource('documents.comments', CommentController::class)
             ->shallow()
             ->whereUuid('document')
@@ -153,7 +144,7 @@ Route::prefix('v1')->group(function () {
         Route::get('/users', [UserController::class, 'index']);
         Route::get('/users/reviewer-candidates', [UserController::class, 'reviewerCandidates']);
 
-        // Sprint 6 — Dashboard BFF
+        // Dashboard (BFF)
         Route::get('/dashboard', [DashboardController::class, 'index']);
 
     });

--- a/backend/tests/Feature/DashboardApiTest.php
+++ b/backend/tests/Feature/DashboardApiTest.php
@@ -193,7 +193,7 @@ class DashboardApiTest extends TestCase
             [
                 'id' => (string) Str::uuid(),
                 'template_id' => $normalTemplateId,
-                'user_id' => $reviewerId,
+                'user_id' => $otherReviewerId,
                 'stage' => 2,
                 'status' => 'approved',
                 'created_at' => now(),

--- a/backend/tests/Feature/DocumentModifiableBlockVersionApiTest.php
+++ b/backend/tests/Feature/DocumentModifiableBlockVersionApiTest.php
@@ -1,0 +1,286 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Enums\BlockState;
+use App\Enums\TemplateVisibilityLevel;
+use App\Models\BlockVersion;
+use App\Models\Document;
+use App\Models\DocumentBlock;
+use App\Models\Template;
+use App\Models\TemplateBlock;
+use App\Models\TemplateVersion;
+use Database\Seeders\PermissionsSeeder;
+use Database\Seeders\UserPermissionsSeeder;
+use Database\Seeders\UsersSourceSeeder;
+use Maya\Auth\Contracts\JwksServiceInterface;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Lcobucci\JWT\Signer\Key\InMemory;
+use Tests\Concerns\AssignsTestUserPermissions;
+use Tests\Concerns\BuildsTestJwt;
+use Tests\TestCase;
+
+/**
+ * Bloques en estado modificable: historial append-only en block_versions (línea base de plantilla + cada guardado).
+ */
+class DocumentModifiableBlockVersionApiTest extends TestCase
+{
+    use AssignsTestUserPermissions;
+    use BuildsTestJwt;
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config([
+            'auth.jwt_issuer' => 'test-issuer',
+            'auth.jwt_audience' => 'test-audience',
+        ]);
+
+        $this->seed(UsersSourceSeeder::class);
+        $this->seed(PermissionsSeeder::class);
+        $this->seed(UserPermissionsSeeder::class);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function authHeaders(string $sub, array $permissionCodes = ['templates.read', 'documents.read']): array
+    {
+        auth()->forgetUser();
+        $this->assignUserPermissions($sub, $permissionCodes);
+
+        [$privatePem, $publicPem] = $this->generateRsaKeyPairForTests();
+
+        $this->mock(JwksServiceInterface::class)
+            ->shouldReceive('getPublicKey')
+            ->andReturn(InMemory::plainText($publicPem));
+
+        $token = $this->buildJwtForSub(
+            $privatePem,
+            $publicPem,
+            'kid-'.substr($sub, 0, 8),
+            $sub,
+            'test-issuer',
+            'test-audience',
+            [],
+            [],
+        );
+
+        return ['Authorization' => 'Bearer '.$token];
+    }
+
+    /**
+     * @return array{ownerId: string, documentId: string, blockId: string, baseline: array<string, mixed>}
+     */
+    private function seedDraftWithModifiableBlock(): array
+    {
+        $ownerId = (string) Str::uuid();
+        $templateId = (string) Str::uuid();
+        $blockSnapId = (string) Str::uuid();
+        $versionId = (string) Str::uuid();
+        $documentId = (string) Str::uuid();
+        $docBlockId = (string) Str::uuid();
+
+        $baseline = [
+            'type' => 'doc',
+            'content' => [
+                ['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => 'BASE', 'styles' => []]]],
+            ],
+        ];
+
+        Template::query()->forceCreate([
+            'id' => $templateId,
+            'name' => 'T mod',
+            'description' => null,
+            'visibility_level' => TemplateVisibilityLevel::Personal->value,
+            'delivery_deadline' => null,
+            'study_type_id' => null,
+            'study_id' => null,
+            'module_id' => null,
+            'team_id' => null,
+            'created_by' => $ownerId,
+            'status' => 'draft',
+            'version' => 1,
+            'review_stages' => 0,
+            'review_mode' => 'parallel',
+        ]);
+
+        TemplateBlock::query()->forceCreate([
+            'id' => $blockSnapId,
+            'template_id' => $templateId,
+            'type' => 'paragraph',
+            'title' => 'Normativa',
+            'default_content' => $baseline,
+            'description' => null,
+            'block_state' => BlockState::Modifiable->value,
+            'mandatory' => false,
+            'sort_order' => 0,
+        ]);
+
+        TemplateVersion::query()->forceCreate([
+            'id' => $versionId,
+            'template_id' => $templateId,
+            'version_number' => 1,
+            'blocks_snapshot' => [[
+                'id' => $blockSnapId,
+                'type' => 'paragraph',
+                'title' => 'Normativa',
+                'default_content' => $baseline,
+                'block_state' => BlockState::Modifiable->value,
+                'mandatory' => false,
+                'sort_order' => 0,
+            ]],
+            'changelog' => 'v1',
+            'published_by' => $ownerId,
+            'published_at' => now(),
+        ]);
+
+        Document::query()->forceCreate([
+            'id' => $documentId,
+            'template_id' => $templateId,
+            'template_version_id' => $versionId,
+            'title' => 'Doc mod',
+            'study_id' => null,
+            'created_by' => $ownerId,
+            'owner_id' => $ownerId,
+            'status' => 'draft',
+            'current_version' => 1,
+            'submitted_at' => null,
+            'published_at' => null,
+        ]);
+
+        DocumentBlock::query()->forceCreate([
+            'id' => $docBlockId,
+            'document_id' => $documentId,
+            'template_block_id' => $blockSnapId,
+            'content' => $baseline,
+            'is_filled' => true,
+            'last_edited_by' => null,
+            'locked_by' => null,
+            'locked_at' => null,
+            'sort_order' => 0,
+        ]);
+
+        return [
+            'ownerId' => $ownerId,
+            'documentId' => $documentId,
+            'blockId' => $docBlockId,
+            'baseline' => $baseline,
+        ];
+    }
+
+    public function test_first_edit_on_modifiable_block_inserts_baseline_and_new_version(): void
+    {
+        $ctx = $this->seedDraftWithModifiableBlock();
+        $h = $this->authHeaders($ctx['ownerId']);
+
+        $newContent = [
+            'type' => 'doc',
+            'content' => [
+                ['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => 'EDIT1', 'styles' => []]]],
+            ],
+        ];
+
+        $this->putJson(
+            "/api/v1/documents/{$ctx['documentId']}/blocks/{$ctx['blockId']}",
+            ['content' => $newContent],
+            $h,
+        )->assertOk();
+
+        $versions = BlockVersion::query()
+            ->where('document_block_id', $ctx['blockId'])
+            ->orderBy('version_number')
+            ->get();
+
+        $this->assertCount(2, $versions);
+        $this->assertSame(1, $versions[0]->version_number);
+        $this->assertSame($ctx['ownerId'], $versions[0]->edited_by);
+        $this->assertTrue($this->jsonCanonical($versions[0]->content) === $this->jsonCanonical($ctx['baseline']));
+
+        $this->assertSame(2, $versions[1]->version_number);
+        $this->assertSame($ctx['ownerId'], $versions[1]->edited_by);
+        $this->assertTrue($this->jsonCanonical($versions[1]->content) === $this->jsonCanonical($newContent));
+    }
+
+    public function test_second_edit_appends_single_version_row(): void
+    {
+        $ctx = $this->seedDraftWithModifiableBlock();
+        $h = $this->authHeaders($ctx['ownerId']);
+
+        $edit1 = [
+            'type' => 'doc',
+            'content' => [
+                ['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => 'EDIT1', 'styles' => []]]],
+            ],
+        ];
+        $edit2 = [
+            'type' => 'doc',
+            'content' => [
+                ['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => 'EDIT2', 'styles' => []]]],
+            ],
+        ];
+
+        $this->putJson(
+            "/api/v1/documents/{$ctx['documentId']}/blocks/{$ctx['blockId']}",
+            ['content' => $edit1],
+            $h,
+        )->assertOk();
+
+        $this->putJson(
+            "/api/v1/documents/{$ctx['documentId']}/blocks/{$ctx['blockId']}",
+            ['content' => $edit2],
+            $h,
+        )->assertOk();
+
+        $this->assertSame(3, BlockVersion::query()->where('document_block_id', $ctx['blockId'])->count());
+        $last = BlockVersion::query()
+            ->where('document_block_id', $ctx['blockId'])
+            ->orderByDesc('version_number')
+            ->first();
+        $this->assertNotNull($last);
+        $this->assertSame(3, $last->version_number);
+        $this->assertTrue($this->jsonCanonical($last->content) === $this->jsonCanonical($edit2));
+    }
+
+    /**
+     * Codifica un valor JSON canónicamente.
+     */
+    private function jsonCanonical(mixed $data): string
+    {
+        $normalized = $data === null ? [] : (is_array($data) ? $data : []);
+
+        return json_encode(
+            $this->normalizeKeysForCanonicalJson($normalized),
+            \JSON_THROW_ON_ERROR | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE | \JSON_PRESERVE_ZERO_FRACTION,
+        );
+    }
+
+    /**
+     * Ordena claves de objetos JSON (arrays asociativos) de forma recursiva; preserva el orden de listas.
+     * 
+     * @return mixed
+     */
+    private function normalizeKeysForCanonicalJson(mixed $value): mixed
+    {
+        if (! is_array($value)) {
+            return $value;
+        }
+
+        if ($value === [] || array_is_list($value)) {
+            return array_map(fn (mixed $item): mixed => $this->normalizeKeysForCanonicalJson($item), $value);
+        }
+
+        ksort($value);
+
+        foreach ($value as $k => $nested) {
+            $value[$k] = $this->normalizeKeysForCanonicalJson($nested);
+        }
+
+        return $value;
+    }
+}

--- a/backend/tests/Feature/DocumentReviewModeFlowTest.php
+++ b/backend/tests/Feature/DocumentReviewModeFlowTest.php
@@ -16,7 +16,7 @@ use Tests\Concerns\BuildsTestJwt;
 use Tests\TestCase;
 
 /**
- * Modo secuencial vs paralelo en aprobación/rechazo por revisión (F-06.1).
+ * Modo secuencial vs paralelo en aprobación/rechazo por revisión.
  */
 class DocumentReviewModeFlowTest extends TestCase
 {

--- a/backend/tests/Feature/DocumentShareApiTest.php
+++ b/backend/tests/Feature/DocumentShareApiTest.php
@@ -1,0 +1,324 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Enums\BlockState;
+use App\Enums\TemplateVisibilityLevel;
+use App\Models\Document;
+use App\Models\DocumentBlock;
+use App\Models\DocumentShare;
+use App\Models\Template;
+use App\Models\TemplateBlock;
+use App\Models\TemplateVersion;
+use Database\Seeders\PermissionsSeeder;
+use Database\Seeders\UserPermissionsSeeder;
+use Database\Seeders\UsersSourceSeeder;
+use Maya\Auth\Contracts\JwksServiceInterface;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Lcobucci\JWT\Signer\Key\InMemory;
+use Tests\Concerns\AssignsTestUserPermissions;
+use Tests\Concerns\BuildsTestJwt;
+use Tests\TestCase;
+
+/**
+ * Compartición de documentos: POST/DELETE shares y efectos en policy de edición / envío.
+ */
+class DocumentShareApiTest extends TestCase
+{
+    use AssignsTestUserPermissions;
+    use BuildsTestJwt;
+    use RefreshDatabase;
+
+    /** Par RSA fijo por caso de prueba: varios usuarios deben firmar con la misma clave que expone el mock JWKS. */
+    private ?string $testJwtPrivatePem = null;
+
+    private ?string $testJwtPublicPem = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config([
+            'auth.jwt_issuer' => 'test-issuer',
+            'auth.jwt_audience' => 'test-audience',
+        ]);
+
+        $this->seed(UsersSourceSeeder::class);
+        $this->seed(PermissionsSeeder::class);
+        $this->seed(UserPermissionsSeeder::class);
+    }
+
+    /**
+     * @param  list<string>  $permissionCodes
+     * @return array<string, string>
+     */
+    private function authHeaders(string $sub, array $permissionCodes = []): array
+    {
+        auth()->forgetUser();
+        $this->assignUserPermissions($sub, $permissionCodes);
+
+        if ($this->testJwtPrivatePem === null) {
+            [$this->testJwtPrivatePem, $this->testJwtPublicPem] = $this->generateRsaKeyPairForTests();
+        }
+
+        $privatePem = $this->testJwtPrivatePem;
+        $publicPem = $this->testJwtPublicPem;
+
+        $this->mock(JwksServiceInterface::class)
+            ->shouldReceive('getPublicKey')
+            ->andReturn(InMemory::plainText($publicPem));
+
+        $token = $this->buildJwtForSub(
+            $privatePem,
+            $publicPem,
+            'kid-'.substr($sub, 0, 8),
+            $sub,
+            'test-issuer',
+            'test-audience',
+            [],
+            [],
+        );
+
+        return ['Authorization' => 'Bearer '.$token];
+    }
+
+    /**
+     * @return array{
+     *   creatorId: string,
+     *   ownerId: string,
+     *   collabId: string,
+     *   documentId: string,
+     *   blockId: string
+     * }
+     */
+    private function seedDraftDocumentWithEditableBlock(): array
+    {
+        $creatorId = (string) Str::uuid();
+        $ownerId = (string) Str::uuid();
+        $collabId = (string) Str::uuid();
+        $templateId = (string) Str::uuid();
+        $blockSnapId = (string) Str::uuid();
+        $versionId = (string) Str::uuid();
+        $documentId = (string) Str::uuid();
+        $docBlockId = (string) Str::uuid();
+
+        Template::query()->forceCreate([
+            'id' => $templateId,
+            'name' => 'T share',
+            'description' => null,
+            'visibility_level' => TemplateVisibilityLevel::Personal->value,
+            'delivery_deadline' => null,
+            'study_type_id' => null,
+            'study_id' => null,
+            'module_id' => null,
+            'team_id' => null,
+            'created_by' => $ownerId,
+            'status' => 'draft',
+            'version' => 1,
+            'review_stages' => 1,
+            'review_mode' => 'parallel',
+        ]);
+
+        TemplateBlock::query()->forceCreate([
+            'id' => $blockSnapId,
+            'template_id' => $templateId,
+            'type' => 'paragraph',
+            'title' => 'B1',
+            'default_content' => null,
+            'description' => null,
+            'block_state' => BlockState::Editable->value,
+            'mandatory' => false,
+            'sort_order' => 0,
+        ]);
+
+        TemplateVersion::query()->forceCreate([
+            'id' => $versionId,
+            'template_id' => $templateId,
+            'version_number' => 1,
+            'blocks_snapshot' => [[
+                'id' => $blockSnapId,
+                'type' => 'paragraph',
+                'title' => 'B1',
+                'default_content' => null,
+                'block_state' => 'editable',
+                'mandatory' => false,
+                'sort_order' => 0,
+            ]],
+            'changelog' => 'v1',
+            'published_by' => $ownerId,
+            'published_at' => now(),
+        ]);
+
+        Document::query()->forceCreate([
+            'id' => $documentId,
+            'template_id' => $templateId,
+            'template_version_id' => $versionId,
+            'title' => 'Doc compartir',
+            'study_id' => null,
+            'created_by' => $creatorId,
+            'owner_id' => $ownerId,
+            'status' => 'draft',
+            'current_version' => 1,
+            'submitted_at' => null,
+            'published_at' => null,
+        ]);
+
+        DocumentBlock::query()->forceCreate([
+            'id' => $docBlockId,
+            'document_id' => $documentId,
+            'template_block_id' => $blockSnapId,
+            'content' => null,
+            'is_filled' => false,
+            'last_edited_by' => null,
+            'locked_by' => null,
+            'locked_at' => null,
+            'sort_order' => 0,
+        ]);
+
+        return [
+            'creatorId' => $creatorId,
+            'ownerId' => $ownerId,
+            'collabId' => $collabId,
+            'documentId' => $documentId,
+            'blockId' => $docBlockId,
+        ];
+    }
+
+    public function test_only_owner_can_post_shares_even_if_creator(): void
+    {
+        $ctx = $this->seedDraftDocumentWithEditableBlock();
+        $h = $this->authHeaders($ctx['creatorId'], ['templates.read']);
+
+        $this->postJson("/api/v1/documents/{$ctx['documentId']}/shares", [
+            'user_id' => $ctx['collabId'],
+            'permission' => 'read',
+        ], $h)->assertForbidden();
+    }
+
+    public function test_owner_can_create_share_and_collaborator_sees_document(): void
+    {
+        $ctx = $this->seedDraftDocumentWithEditableBlock();
+        $hOwner = $this->authHeaders($ctx['ownerId'], ['templates.read']);
+
+        $this->postJson("/api/v1/documents/{$ctx['documentId']}/shares", [
+            'user_id' => $ctx['collabId'],
+            'permission' => 'read',
+        ], $hOwner)
+            ->assertCreated()
+            ->assertJsonPath('data.user_id', $ctx['collabId'])
+            ->assertJsonPath('data.permission', 'read');
+
+        $hCollab = $this->authHeaders($ctx['collabId'], ['templates.read']);
+
+        $this->getJson("/api/v1/documents/{$ctx['documentId']}", $hCollab)->assertOk();
+    }
+
+    public function test_post_share_with_self_returns_422(): void
+    {
+        $ctx = $this->seedDraftDocumentWithEditableBlock();
+        $hOwner = $this->authHeaders($ctx['ownerId'], ['templates.read']);
+
+        $this->postJson("/api/v1/documents/{$ctx['documentId']}/shares", [
+            'user_id' => $ctx['ownerId'],
+            'permission' => 'read',
+        ], $hOwner)->assertUnprocessable();
+    }
+
+    public function test_delete_share_hides_document_for_collaborator(): void
+    {
+        $ctx = $this->seedDraftDocumentWithEditableBlock();
+        $hOwner = $this->authHeaders($ctx['ownerId'], ['templates.read']);
+
+        $this->postJson("/api/v1/documents/{$ctx['documentId']}/shares", [
+            'user_id' => $ctx['collabId'],
+            'permission' => 'read',
+        ], $hOwner)->assertCreated();
+
+        $hCollab = $this->authHeaders($ctx['collabId'], ['templates.read']);
+        $this->getJson("/api/v1/documents/{$ctx['documentId']}", $hCollab)->assertOk();
+
+        $this->deleteJson("/api/v1/documents/{$ctx['documentId']}/shares/{$ctx['collabId']}", [], $hOwner)
+            ->assertNoContent();
+
+        $this->getJson("/api/v1/documents/{$ctx['documentId']}", $hCollab)->assertNotFound();
+    }
+
+    public function test_collaborator_with_edit_can_update_block(): void
+    {
+        $ctx = $this->seedDraftDocumentWithEditableBlock();
+        $hOwner = $this->authHeaders($ctx['ownerId'], ['templates.read']);
+
+        $this->postJson("/api/v1/documents/{$ctx['documentId']}/shares", [
+            'user_id' => $ctx['collabId'],
+            'permission' => 'edit',
+        ], $hOwner)->assertCreated();
+
+        $hCollab = $this->authHeaders($ctx['collabId'], ['templates.read']);
+
+        $this->putJson(
+            "/api/v1/documents/{$ctx['documentId']}/blocks/{$ctx['blockId']}",
+            ['content' => ['type' => 'doc', 'content' => []]],
+            $hCollab,
+        )->assertOk();
+    }
+
+    public function test_collaborator_with_edit_cannot_submit_to_review(): void
+    {
+        $ctx = $this->seedDraftDocumentWithEditableBlock();
+        $hOwner = $this->authHeaders($ctx['ownerId'], ['templates.read']);
+
+        $this->postJson("/api/v1/documents/{$ctx['documentId']}/shares", [
+            'user_id' => $ctx['collabId'],
+            'permission' => 'edit',
+        ], $hOwner)->assertCreated();
+
+        $hCollab = $this->authHeaders($ctx['collabId'], ['templates.read']);
+
+        $this->postJson("/api/v1/documents/{$ctx['documentId']}/submit", [], $hCollab)->assertForbidden();
+    }
+
+    public function test_collaborator_with_read_cannot_update_document_title(): void
+    {
+        $ctx = $this->seedDraftDocumentWithEditableBlock();
+        $hOwner = $this->authHeaders($ctx['ownerId'], ['templates.read']);
+
+        $this->postJson("/api/v1/documents/{$ctx['documentId']}/shares", [
+            'user_id' => $ctx['collabId'],
+            'permission' => 'read',
+        ], $hOwner)->assertCreated();
+
+        $hCollab = $this->authHeaders($ctx['collabId'], ['templates.read']);
+
+        $this->patchJson("/api/v1/documents/{$ctx['documentId']}", [
+            'title' => 'Nuevo título',
+        ], $hCollab)->assertForbidden();
+    }
+
+    public function test_owner_can_change_share_permission_via_post_again(): void
+    {
+        $ctx = $this->seedDraftDocumentWithEditableBlock();
+        $hOwner = $this->authHeaders($ctx['ownerId'], ['templates.read']);
+
+        $this->postJson("/api/v1/documents/{$ctx['documentId']}/shares", [
+            'user_id' => $ctx['collabId'],
+            'permission' => 'read',
+        ], $hOwner)->assertCreated();
+
+        $this->postJson("/api/v1/documents/{$ctx['documentId']}/shares", [
+            'user_id' => $ctx['collabId'],
+            'permission' => 'edit',
+        ], $hOwner)->assertCreated()
+            ->assertJsonPath('data.permission', 'edit');
+
+        $row = DocumentShare::query()
+            ->where('document_id', $ctx['documentId'])
+            ->where('user_id', $ctx['collabId'])
+            ->first();
+
+        $this->assertNotNull($row);
+        $this->assertSame('edit', $row->permission);
+    }
+}

--- a/backend/tests/Feature/DocumentShareApiTest.php
+++ b/backend/tests/Feature/DocumentShareApiTest.php
@@ -321,4 +321,60 @@ class DocumentShareApiTest extends TestCase
         $this->assertNotNull($row);
         $this->assertSame('edit', $row->permission);
     }
+
+    public function test_documents_index_sets_is_shared_with_me_for_collaborator(): void
+    {
+        $ctx = $this->seedDraftDocumentWithEditableBlock();
+        $hOwner = $this->authHeaders($ctx['ownerId'], ['templates.read', 'documents.read']);
+
+        $this->postJson("/api/v1/documents/{$ctx['documentId']}/shares", [
+            'user_id' => $ctx['collabId'],
+            'permission' => 'read',
+        ], $hOwner)->assertCreated();
+
+        $hCollab = $this->authHeaders($ctx['collabId'], ['templates.read', 'documents.read']);
+
+        $list = $this->getJson('/api/v1/documents', $hCollab)->assertOk();
+        $items = $list->json('data');
+        $this->assertIsArray($items);
+        $row = collect($items)->firstWhere('id', $ctx['documentId']);
+        $this->assertNotNull($row);
+        $this->assertTrue($row['is_shared_with_me']);
+        $this->assertSame('read', $row['share_permission']);
+    }
+
+    public function test_documents_index_sets_is_shared_with_me_false_for_owner(): void
+    {
+        $ctx = $this->seedDraftDocumentWithEditableBlock();
+        $hOwner = $this->authHeaders($ctx['ownerId'], ['templates.read', 'documents.read']);
+
+        $this->postJson("/api/v1/documents/{$ctx['documentId']}/shares", [
+            'user_id' => $ctx['collabId'],
+            'permission' => 'read',
+        ], $hOwner)->assertCreated();
+
+        $list = $this->getJson('/api/v1/documents', $hOwner)->assertOk();
+        $row = collect($list->json('data'))->firstWhere('id', $ctx['documentId']);
+        $this->assertNotNull($row);
+        $this->assertFalse($row['is_shared_with_me']);
+        $this->assertNull($row['share_permission']);
+    }
+
+    public function test_document_show_includes_share_metadata_for_collaborator(): void
+    {
+        $ctx = $this->seedDraftDocumentWithEditableBlock();
+        $hOwner = $this->authHeaders($ctx['ownerId'], ['templates.read', 'documents.read']);
+
+        $this->postJson("/api/v1/documents/{$ctx['documentId']}/shares", [
+            'user_id' => $ctx['collabId'],
+            'permission' => 'edit',
+        ], $hOwner)->assertCreated();
+
+        $hCollab = $this->authHeaders($ctx['collabId'], ['templates.read', 'documents.read']);
+
+        $this->getJson("/api/v1/documents/{$ctx['documentId']}", $hCollab)
+            ->assertOk()
+            ->assertJsonPath('data.is_shared_with_me', true)
+            ->assertJsonPath('data.share_permission', 'edit');
+    }
 }

--- a/backend/tests/Feature/DocumentsTemplateVersionApiTest.php
+++ b/backend/tests/Feature/DocumentsTemplateVersionApiTest.php
@@ -395,4 +395,136 @@ class DocumentsTemplateVersionApiTest extends TestCase
         $show->assertJsonPath('data.team.name', 'Equipo doc');
         $show->assertJsonPath('data.team.is_department', true);
     }
+
+    public function test_update_document_block_persists_content_in_draft(): void
+    {
+        $creatorId = (string) Str::uuid();
+        $this->grantPermissionsForUser($creatorId);
+        $reviewerId = 'ed568442-ece5-4c90-97ca-12c8969bb3a2';
+        [$hCreator, $hReviewer] = $this->authHeadersCreatorAndReviewer($creatorId, $reviewerId);
+
+        $tid = (string) Str::uuid();
+        $b1 = (string) Str::uuid();
+
+        Template::query()->forceCreate([
+            'id' => $tid,
+            'name' => 'Plantilla editable',
+            'description' => null,
+            'visibility_level' => TemplateVisibilityLevel::Personal->value,
+            'delivery_deadline' => null,
+            'study_type_id' => null,
+            'study_id' => null,
+            'module_id' => null,
+            'team_id' => null,
+            'created_by' => $creatorId,
+            'status' => 'draft',
+            'version' => 1,
+            'review_stages' => 0,
+            'review_mode' => 'sequential',
+        ]);
+
+        TemplateBlock::query()->forceCreate([
+            'id' => $b1,
+            'template_id' => $tid,
+            'type' => 'paragraph',
+            'title' => 'Bloque editable',
+            'default_content' => null,
+            'block_state' => 'editable',
+            'mandatory' => false,
+            'sort_order' => 0,
+        ]);
+
+        TemplateReviewer::query()->forceCreate([
+            'id' => (string) Str::uuid(),
+            'template_id' => $tid,
+            'user_id' => $reviewerId,
+            'stage' => 1,
+        ]);
+
+        $this->postJson("/api/v1/templates/{$tid}/submit-review", [], $hCreator)->assertOk();
+        $this->postJson("/api/v1/templates/{$tid}/publish", ['changelog' => 'v1'], $hReviewer)->assertOk();
+
+        $createDoc = $this->postJson('/api/v1/documents', [
+            'template_id' => $tid,
+            'title' => 'Doc editable',
+        ], $hCreator)->assertCreated();
+
+        $docId = (string) $createDoc->json('data.id');
+        $documentBlockId = (string) $createDoc->json('data.blocks.0.document_block_id');
+
+        $payload = [
+            'content' => [
+                ['type' => 'paragraph', 'content' => 'Contenido actualizado'],
+            ],
+        ];
+
+        $this->putJson("/api/v1/documents/{$docId}/blocks/{$documentBlockId}", $payload, $hCreator)
+            ->assertOk()
+            ->assertJsonPath('data.document_block_id', $documentBlockId)
+            ->assertJsonPath('data.is_filled', true)
+            ->assertJsonPath('data.last_edited_by', $creatorId);
+    }
+
+    public function test_update_document_block_rejects_locked_blocks(): void
+    {
+        $creatorId = (string) Str::uuid();
+        $this->grantPermissionsForUser($creatorId);
+        $reviewerId = 'ed568442-ece5-4c90-97ca-12c8969bb3a2';
+        [$hCreator, $hReviewer] = $this->authHeadersCreatorAndReviewer($creatorId, $reviewerId);
+
+        $tid = (string) Str::uuid();
+        $b1 = (string) Str::uuid();
+
+        Template::query()->forceCreate([
+            'id' => $tid,
+            'name' => 'Plantilla bloqueada',
+            'description' => null,
+            'visibility_level' => TemplateVisibilityLevel::Personal->value,
+            'delivery_deadline' => null,
+            'study_type_id' => null,
+            'study_id' => null,
+            'module_id' => null,
+            'team_id' => null,
+            'created_by' => $creatorId,
+            'status' => 'draft',
+            'version' => 1,
+            'review_stages' => 0,
+            'review_mode' => 'sequential',
+        ]);
+
+        TemplateBlock::query()->forceCreate([
+            'id' => $b1,
+            'template_id' => $tid,
+            'type' => 'paragraph',
+            'title' => 'Bloque bloqueado',
+            'default_content' => null,
+            'block_state' => 'locked',
+            'mandatory' => false,
+            'sort_order' => 0,
+        ]);
+
+        TemplateReviewer::query()->forceCreate([
+            'id' => (string) Str::uuid(),
+            'template_id' => $tid,
+            'user_id' => $reviewerId,
+            'stage' => 1,
+        ]);
+
+        $this->postJson("/api/v1/templates/{$tid}/submit-review", [], $hCreator)->assertOk();
+        $this->postJson("/api/v1/templates/{$tid}/publish", ['changelog' => 'v1'], $hReviewer)->assertOk();
+
+        $createDoc = $this->postJson('/api/v1/documents', [
+            'template_id' => $tid,
+            'title' => 'Doc bloqueado',
+        ], $hCreator)->assertCreated();
+
+        $docId = (string) $createDoc->json('data.id');
+        $documentBlockId = (string) $createDoc->json('data.blocks.0.document_block_id');
+
+        $this->putJson("/api/v1/documents/{$docId}/blocks/{$documentBlockId}", [
+            'content' => [['type' => 'paragraph', 'content' => 'No debería guardar']],
+        ], $hCreator)
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors(['block']);
+    }
 }

--- a/backend/tests/Feature/DocumentsTemplateVersionApiTest.php
+++ b/backend/tests/Feature/DocumentsTemplateVersionApiTest.php
@@ -527,4 +527,126 @@ class DocumentsTemplateVersionApiTest extends TestCase
             ->assertUnprocessable()
             ->assertJsonValidationErrors(['block']);
     }
+
+    public function test_update_document_updates_title(): void
+    {
+        $creatorId = (string) Str::uuid();
+        $this->grantPermissionsForUser($creatorId);
+        $reviewerId = 'ed568442-ece5-4c90-97ca-12c8969bb3a2';
+        [$hCreator, $hReviewer] = $this->authHeadersCreatorAndReviewer($creatorId, $reviewerId);
+
+        $tid = (string) Str::uuid();
+        $b1 = (string) Str::uuid();
+
+        Template::query()->forceCreate([
+            'id' => $tid,
+            'name' => 'Plantilla update título',
+            'description' => null,
+            'visibility_level' => TemplateVisibilityLevel::Personal->value,
+            'delivery_deadline' => null,
+            'study_type_id' => null,
+            'study_id' => null,
+            'module_id' => null,
+            'team_id' => null,
+            'created_by' => $creatorId,
+            'status' => 'draft',
+            'version' => 1,
+            'review_stages' => 0,
+            'review_mode' => 'sequential',
+        ]);
+
+        TemplateBlock::query()->forceCreate([
+            'id' => $b1,
+            'template_id' => $tid,
+            'type' => 'paragraph',
+            'title' => 'Bloque',
+            'default_content' => null,
+            'block_state' => 'editable',
+            'mandatory' => false,
+            'sort_order' => 0,
+        ]);
+
+        TemplateReviewer::query()->forceCreate([
+            'id' => (string) Str::uuid(),
+            'template_id' => $tid,
+            'user_id' => $reviewerId,
+            'stage' => 1,
+        ]);
+
+        $this->postJson("/api/v1/templates/{$tid}/submit-review", [], $hCreator)->assertOk();
+        $this->postJson("/api/v1/templates/{$tid}/publish", ['changelog' => 'v1'], $hReviewer)->assertOk();
+
+        $createDoc = $this->postJson('/api/v1/documents', [
+            'template_id' => $tid,
+            'title' => 'Título inicial',
+        ], $hCreator)->assertCreated();
+
+        $docId = (string) $createDoc->json('data.id');
+
+        $this->putJson("/api/v1/documents/{$docId}", [
+            'title' => 'Título actualizado',
+        ], $hCreator)
+            ->assertOk()
+            ->assertJsonPath('data.title', 'Título actualizado');
+    }
+
+    public function test_destroy_document_soft_deletes_record(): void
+    {
+        $creatorId = (string) Str::uuid();
+        $this->grantPermissionsForUser($creatorId, ['documents.create', 'documents.delete', 'templates.read', 'users.search']);
+        $reviewerId = 'ed568442-ece5-4c90-97ca-12c8969bb3a2';
+        [$hCreator, $hReviewer] = $this->authHeadersCreatorAndReviewer($creatorId, $reviewerId);
+
+        $tid = (string) Str::uuid();
+        $b1 = (string) Str::uuid();
+
+        Template::query()->forceCreate([
+            'id' => $tid,
+            'name' => 'Plantilla delete',
+            'description' => null,
+            'visibility_level' => TemplateVisibilityLevel::Personal->value,
+            'delivery_deadline' => null,
+            'study_type_id' => null,
+            'study_id' => null,
+            'module_id' => null,
+            'team_id' => null,
+            'created_by' => $creatorId,
+            'status' => 'draft',
+            'version' => 1,
+            'review_stages' => 0,
+            'review_mode' => 'sequential',
+        ]);
+
+        TemplateBlock::query()->forceCreate([
+            'id' => $b1,
+            'template_id' => $tid,
+            'type' => 'paragraph',
+            'title' => 'Bloque',
+            'default_content' => null,
+            'block_state' => 'editable',
+            'mandatory' => false,
+            'sort_order' => 0,
+        ]);
+
+        TemplateReviewer::query()->forceCreate([
+            'id' => (string) Str::uuid(),
+            'template_id' => $tid,
+            'user_id' => $reviewerId,
+            'stage' => 1,
+        ]);
+
+        $this->postJson("/api/v1/templates/{$tid}/submit-review", [], $hCreator)->assertOk();
+        $this->postJson("/api/v1/templates/{$tid}/publish", ['changelog' => 'v1'], $hReviewer)->assertOk();
+
+        $createDoc = $this->postJson('/api/v1/documents', [
+            'template_id' => $tid,
+            'title' => 'Documento borrable',
+        ], $hCreator)->assertCreated();
+
+        $docId = (string) $createDoc->json('data.id');
+
+        $this->deleteJson("/api/v1/documents/{$docId}", [], $hCreator)->assertNoContent();
+
+        $this->assertSoftDeleted('documents', ['id' => $docId]);
+    }
 }

--- a/backend/tests/Feature/DocumentsTemplateVersionApiTest.php
+++ b/backend/tests/Feature/DocumentsTemplateVersionApiTest.php
@@ -958,4 +958,145 @@ class DocumentsTemplateVersionApiTest extends TestCase
             (string) DB::table('document_versions')->where('document_id', $docId)->value('notes'),
         );
     }
+
+    public function test_template_version_status_reports_update_when_newer_published_template_version_exists(): void
+    {
+        $creatorId = (string) Str::uuid();
+        $this->grantPermissionsForUser($creatorId);
+        $reviewerId = 'ed568442-ece5-4c90-97ca-12c8969bb3a2';
+        [$hCreator, $hReviewer] = $this->authHeadersCreatorAndReviewer($creatorId, $reviewerId);
+
+        $tid = (string) Str::uuid();
+        $b1 = (string) Str::uuid();
+
+        Template::query()->forceCreate([
+            'id' => $tid,
+            'name' => 'Plantilla F-04.6',
+            'description' => null,
+            'visibility_level' => TemplateVisibilityLevel::Personal->value,
+            'delivery_deadline' => null,
+            'study_type_id' => null,
+            'study_id' => null,
+            'module_id' => null,
+            'team_id' => null,
+            'created_by' => $creatorId,
+            'status' => 'draft',
+            'version' => 1,
+            'review_stages' => 1,
+            'review_mode' => 'sequential',
+        ]);
+
+        TemplateBlock::query()->forceCreate([
+            'id' => $b1,
+            'template_id' => $tid,
+            'type' => 'paragraph',
+            'title' => 'Bloque',
+            'default_content' => null,
+            'block_state' => 'editable',
+            'mandatory' => false,
+            'sort_order' => 0,
+        ]);
+
+        TemplateReviewer::query()->forceCreate([
+            'id' => (string) Str::uuid(),
+            'template_id' => $tid,
+            'user_id' => $reviewerId,
+            'stage' => 1,
+        ]);
+
+        $this->postJson("/api/v1/templates/{$tid}/submit-review", [], $hCreator)->assertOk();
+        $this->postJson("/api/v1/templates/{$tid}/publish", ['changelog' => 'v1 plantilla'], $hReviewer)->assertOk();
+
+        $createDoc = $this->postJson('/api/v1/documents', [
+            'template_id' => $tid,
+            'title' => 'Doc banner',
+        ], $hCreator)->assertCreated();
+
+        $docId = (string) $createDoc->json('data.id');
+
+        $v2Id = (string) Str::uuid();
+        $now = now();
+        DB::table('template_versions')->insert([
+            'id' => $v2Id,
+            'template_id' => $tid,
+            'version_number' => 2,
+            'blocks_snapshot' => json_encode([]),
+            'changelog' => 'Normativa v2 publicada',
+            'published_by' => $reviewerId,
+            'published_at' => $now,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+
+        $this->getJson("/api/v1/documents/{$docId}/template-version-status", $hCreator)
+            ->assertOk()
+            ->assertJsonPath('data.has_update', true)
+            ->assertJsonPath('data.changelog', 'Normativa v2 publicada')
+            ->assertJsonPath('data.current_version.version_number', 1)
+            ->assertJsonPath('data.latest_version.version_number', 2)
+            ->assertJsonPath('data.latest_version.id', $v2Id);
+    }
+
+    public function test_template_version_status_has_no_update_when_document_on_latest_template_version(): void
+    {
+        $creatorId = (string) Str::uuid();
+        $this->grantPermissionsForUser($creatorId);
+        $reviewerId = 'ed568442-ece5-4c90-97ca-12c8969bb3a2';
+        [$hCreator, $hReviewer] = $this->authHeadersCreatorAndReviewer($creatorId, $reviewerId);
+
+        $tid = (string) Str::uuid();
+        $b1 = (string) Str::uuid();
+
+        Template::query()->forceCreate([
+            'id' => $tid,
+            'name' => 'Plantilla al día',
+            'description' => null,
+            'visibility_level' => TemplateVisibilityLevel::Personal->value,
+            'delivery_deadline' => null,
+            'study_type_id' => null,
+            'study_id' => null,
+            'module_id' => null,
+            'team_id' => null,
+            'created_by' => $creatorId,
+            'status' => 'draft',
+            'version' => 1,
+            'review_stages' => 1,
+            'review_mode' => 'sequential',
+        ]);
+
+        TemplateBlock::query()->forceCreate([
+            'id' => $b1,
+            'template_id' => $tid,
+            'type' => 'paragraph',
+            'title' => 'Bloque',
+            'default_content' => null,
+            'block_state' => 'editable',
+            'mandatory' => false,
+            'sort_order' => 0,
+        ]);
+
+        TemplateReviewer::query()->forceCreate([
+            'id' => (string) Str::uuid(),
+            'template_id' => $tid,
+            'user_id' => $reviewerId,
+            'stage' => 1,
+        ]);
+
+        $this->postJson("/api/v1/templates/{$tid}/submit-review", [], $hCreator)->assertOk();
+        $this->postJson("/api/v1/templates/{$tid}/publish", ['changelog' => 'v1'], $hReviewer)->assertOk();
+
+        $createDoc = $this->postJson('/api/v1/documents', [
+            'template_id' => $tid,
+            'title' => 'Doc al día',
+        ], $hCreator)->assertCreated();
+
+        $docId = (string) $createDoc->json('data.id');
+
+        $this->getJson("/api/v1/documents/{$docId}/template-version-status", $hCreator)
+            ->assertOk()
+            ->assertJsonPath('data.has_update', false)
+            ->assertJsonPath('data.changelog', null)
+            ->assertJsonPath('data.current_version.version_number', 1)
+            ->assertJsonPath('data.latest_version.version_number', 1);
+    }
 }

--- a/backend/tests/Feature/DocumentsTemplateVersionApiTest.php
+++ b/backend/tests/Feature/DocumentsTemplateVersionApiTest.php
@@ -774,4 +774,91 @@ class DocumentsTemplateVersionApiTest extends TestCase
             ->assertOk()
             ->assertJsonPath('data.status', 'in_review');
     }
+
+    public function test_approve_last_review_persists_published_document_version_snapshot(): void
+    {
+        $creatorId = (string) Str::uuid();
+        $this->grantPermissionsForUser($creatorId);
+        $reviewerId = 'ed568442-ece5-4c90-97ca-12c8969bb3a2';
+        [$hCreator, $hReviewer] = $this->authHeadersCreatorAndReviewer($creatorId, $reviewerId);
+
+        $tid = (string) Str::uuid();
+        $b1 = (string) Str::uuid();
+
+        Template::query()->forceCreate([
+            'id' => $tid,
+            'name' => 'Plantilla snapshot doc',
+            'description' => null,
+            'visibility_level' => TemplateVisibilityLevel::Personal->value,
+            'delivery_deadline' => null,
+            'study_type_id' => null,
+            'study_id' => null,
+            'module_id' => null,
+            'team_id' => null,
+            'created_by' => $creatorId,
+            'status' => 'draft',
+            'version' => 1,
+            'review_stages' => 1,
+            'review_mode' => 'sequential',
+        ]);
+
+        TemplateBlock::query()->forceCreate([
+            'id' => $b1,
+            'template_id' => $tid,
+            'type' => 'paragraph',
+            'title' => 'Bloque',
+            'default_content' => null,
+            'block_state' => 'editable',
+            'mandatory' => false,
+            'sort_order' => 0,
+        ]);
+
+        TemplateReviewer::query()->forceCreate([
+            'id' => (string) Str::uuid(),
+            'template_id' => $tid,
+            'user_id' => $reviewerId,
+            'stage' => 1,
+        ]);
+
+        $this->postJson("/api/v1/templates/{$tid}/submit-review", [], $hCreator)->assertOk();
+        $this->postJson("/api/v1/templates/{$tid}/publish", ['changelog' => 'v1'], $hReviewer)->assertOk();
+
+        $createDoc = $this->postJson('/api/v1/documents', [
+            'template_id' => $tid,
+            'title' => 'Doc snapshot',
+        ], $hCreator)->assertCreated();
+
+        $docId = (string) $createDoc->json('data.id');
+
+        $this->postJson("/api/v1/documents/{$docId}/submit", [], $hCreator)
+            ->assertOk()
+            ->assertJsonPath('data.status', 'in_review');
+
+        $reviews = $this->getJson("/api/v1/documents/{$docId}/reviews", $hCreator)
+            ->assertOk()
+            ->json('data');
+        $this->assertNotEmpty($reviews);
+        $reviewId = (string) $reviews[0]['id'];
+
+        $this->postJson("/api/v1/documents/{$docId}/reviews/{$reviewId}/approve", [], $hReviewer)
+            ->assertOk()
+            ->assertJsonPath('data.status', 'published');
+
+        $row = DB::table('document_versions')->where('document_id', $docId)->first();
+        $this->assertNotNull($row);
+        $this->assertSame(1, (int) $row->version_number);
+        $this->assertSame('published', $row->trigger_event);
+        $this->assertSame($reviewerId, $row->triggered_by);
+
+        $raw = $row->snapshot_data;
+        $snapshot = is_string($raw) ? json_decode($raw, true) : $raw;
+        $this->assertIsArray($snapshot);
+        $this->assertArrayHasKey('document', $snapshot);
+        $this->assertArrayHasKey('blocks', $snapshot);
+        $this->assertSame($docId, $snapshot['document']['id']);
+        $this->assertSame('published', $snapshot['document']['status']);
+        $this->assertNotEmpty($snapshot['blocks']);
+
+        $this->assertSame(1, (int) DB::table('documents')->where('id', $docId)->value('current_version'));
+    }
 }

--- a/backend/tests/Feature/DocumentsTemplateVersionApiTest.php
+++ b/backend/tests/Feature/DocumentsTemplateVersionApiTest.php
@@ -23,7 +23,7 @@ use Tests\Concerns\BuildsTestJwt;
 use Tests\TestCase;
 
 /**
- * F-03.4 Escenario 4: documento anclado a template_version_id; al abrir, estructura de esa versión.
+ * Documento anclado a template_version_id; al abrir, estructura de esa versión.
  */
 class DocumentsTemplateVersionApiTest extends TestCase
 {
@@ -932,7 +932,7 @@ class DocumentsTemplateVersionApiTest extends TestCase
             ->assertOk();
 
         // Tras borrar revisiones el revisor deja de entrar por `document_reviews` en el scope del modelo;
-        // un share mantiene acceso de lectura coherente con F-05.1 para poder publicar sin filas pendientes.
+        // un share de lectura mantiene visibilidad para publicar sin filas pendientes.
         DocumentShare::query()->forceCreate([
             'id' => (string) Str::uuid(),
             'document_id' => $docId,
@@ -971,7 +971,7 @@ class DocumentsTemplateVersionApiTest extends TestCase
 
         Template::query()->forceCreate([
             'id' => $tid,
-            'name' => 'Plantilla F-04.6',
+            'name' => 'Plantilla estado versión',
             'description' => null,
             'visibility_level' => TemplateVisibilityLevel::Personal->value,
             'delivery_deadline' => null,

--- a/backend/tests/Feature/DocumentsTemplateVersionApiTest.php
+++ b/backend/tests/Feature/DocumentsTemplateVersionApiTest.php
@@ -649,4 +649,129 @@ class DocumentsTemplateVersionApiTest extends TestCase
 
         $this->assertSoftDeleted('documents', ['id' => $docId]);
     }
+
+    public function test_submit_document_fails_when_mandatory_block_is_empty(): void
+    {
+        $creatorId = (string) Str::uuid();
+        $this->grantPermissionsForUser($creatorId);
+        $reviewerId = 'ed568442-ece5-4c90-97ca-12c8969bb3a2';
+        [$hCreator, $hReviewer] = $this->authHeadersCreatorAndReviewer($creatorId, $reviewerId);
+
+        $tid = (string) Str::uuid();
+        $b1 = (string) Str::uuid();
+
+        Template::query()->forceCreate([
+            'id' => $tid,
+            'name' => 'Plantilla mandatory',
+            'description' => null,
+            'visibility_level' => TemplateVisibilityLevel::Personal->value,
+            'delivery_deadline' => null,
+            'study_type_id' => null,
+            'study_id' => null,
+            'module_id' => null,
+            'team_id' => null,
+            'created_by' => $creatorId,
+            'status' => 'draft',
+            'version' => 1,
+            'review_stages' => 1,
+            'review_mode' => 'sequential',
+        ]);
+
+        TemplateBlock::query()->forceCreate([
+            'id' => $b1,
+            'template_id' => $tid,
+            'type' => 'paragraph',
+            'title' => 'Bloque obligatorio',
+            'default_content' => null,
+            'block_state' => 'editable',
+            'mandatory' => true,
+            'sort_order' => 0,
+        ]);
+
+        TemplateReviewer::query()->forceCreate([
+            'id' => (string) Str::uuid(),
+            'template_id' => $tid,
+            'user_id' => $reviewerId,
+            'stage' => 1,
+        ]);
+
+        $this->postJson("/api/v1/templates/{$tid}/submit-review", [], $hCreator)->assertOk();
+        $this->postJson("/api/v1/templates/{$tid}/publish", ['changelog' => 'v1'], $hReviewer)->assertOk();
+
+        $createDoc = $this->postJson('/api/v1/documents', [
+            'template_id' => $tid,
+            'title' => 'Doc mandatory',
+        ], $hCreator)->assertCreated();
+
+        $docId = (string) $createDoc->json('data.id');
+
+        $this->postJson("/api/v1/documents/{$docId}/submit", [], $hCreator)
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors(['blocks']);
+    }
+
+    public function test_submit_document_succeeds_when_mandatory_block_is_filled(): void
+    {
+        $creatorId = (string) Str::uuid();
+        $this->grantPermissionsForUser($creatorId);
+        $reviewerId = 'ed568442-ece5-4c90-97ca-12c8969bb3a2';
+        [$hCreator, $hReviewer] = $this->authHeadersCreatorAndReviewer($creatorId, $reviewerId);
+
+        $tid = (string) Str::uuid();
+        $b1 = (string) Str::uuid();
+
+        Template::query()->forceCreate([
+            'id' => $tid,
+            'name' => 'Plantilla mandatory ok',
+            'description' => null,
+            'visibility_level' => TemplateVisibilityLevel::Personal->value,
+            'delivery_deadline' => null,
+            'study_type_id' => null,
+            'study_id' => null,
+            'module_id' => null,
+            'team_id' => null,
+            'created_by' => $creatorId,
+            'status' => 'draft',
+            'version' => 1,
+            'review_stages' => 1,
+            'review_mode' => 'sequential',
+        ]);
+
+        TemplateBlock::query()->forceCreate([
+            'id' => $b1,
+            'template_id' => $tid,
+            'type' => 'paragraph',
+            'title' => 'Bloque obligatorio',
+            'default_content' => null,
+            'block_state' => 'editable',
+            'mandatory' => true,
+            'sort_order' => 0,
+        ]);
+
+        TemplateReviewer::query()->forceCreate([
+            'id' => (string) Str::uuid(),
+            'template_id' => $tid,
+            'user_id' => $reviewerId,
+            'stage' => 1,
+        ]);
+
+        $this->postJson("/api/v1/templates/{$tid}/submit-review", [], $hCreator)->assertOk();
+        $this->postJson("/api/v1/templates/{$tid}/publish", ['changelog' => 'v1'], $hReviewer)->assertOk();
+
+        $createDoc = $this->postJson('/api/v1/documents', [
+            'template_id' => $tid,
+            'title' => 'Doc mandatory ok',
+        ], $hCreator)->assertCreated();
+
+        $docId = (string) $createDoc->json('data.id');
+        $documentBlockId = (string) $createDoc->json('data.blocks.0.document_block_id');
+
+        $this->putJson("/api/v1/documents/{$docId}/blocks/{$documentBlockId}", [
+            'content' => [['type' => 'paragraph', 'content' => 'Contenido obligatorio cumplido']],
+        ], $hCreator)->assertOk();
+
+        $this->postJson("/api/v1/documents/{$docId}/submit", [], $hCreator)
+            ->assertOk()
+            ->assertJsonPath('data.status', 'in_review');
+    }
 }

--- a/backend/tests/Feature/DocumentsTemplateVersionApiTest.php
+++ b/backend/tests/Feature/DocumentsTemplateVersionApiTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use App\Enums\TemplateVisibilityLevel;
+use App\Models\DocumentShare;
 use App\Models\Team;
 use App\Models\TeamMember;
 use App\Models\Template;
@@ -524,8 +525,7 @@ class DocumentsTemplateVersionApiTest extends TestCase
         $this->putJson("/api/v1/documents/{$docId}/blocks/{$documentBlockId}", [
             'content' => [['type' => 'paragraph', 'content' => 'No debería guardar']],
         ], $hCreator)
-            ->assertUnprocessable()
-            ->assertJsonValidationErrors(['block']);
+            ->assertForbidden();
     }
 
     public function test_update_document_updates_title(): void
@@ -840,7 +840,9 @@ class DocumentsTemplateVersionApiTest extends TestCase
         $this->assertNotEmpty($reviews);
         $reviewId = (string) $reviews[0]['id'];
 
-        $this->postJson("/api/v1/documents/{$docId}/reviews/{$reviewId}/approve", [], $hReviewer)
+        $this->postJson("/api/v1/documents/{$docId}/reviews/{$reviewId}/approve", [
+            'changelog' => 'Cierre v1 liberado',
+        ], $hReviewer)
             ->assertOk()
             ->assertJsonPath('data.status', 'published');
 
@@ -849,6 +851,7 @@ class DocumentsTemplateVersionApiTest extends TestCase
         $this->assertSame(1, (int) $row->version_number);
         $this->assertSame('published', $row->trigger_event);
         $this->assertSame($reviewerId, $row->triggered_by);
+        $this->assertSame('Cierre v1 liberado', $row->notes);
 
         $raw = $row->snapshot_data;
         $snapshot = is_string($raw) ? json_decode($raw, true) : $raw;
@@ -860,5 +863,99 @@ class DocumentsTemplateVersionApiTest extends TestCase
         $this->assertNotEmpty($snapshot['blocks']);
 
         $this->assertSame(1, (int) DB::table('documents')->where('id', $docId)->value('current_version'));
+
+        $versionId = (string) $row->id;
+        $show = $this->getJson("/api/v1/documents/{$docId}/versions/{$versionId}", $hCreator)
+            ->assertOk()
+            ->json('data');
+        $this->assertSame($versionId, $show['id']);
+        $this->assertArrayHasKey('snapshot_data', $show);
+        $this->assertSame('Cierre v1 liberado', $show['changelog']);
+    }
+
+    public function test_publish_document_requires_changelog(): void
+    {
+        $creatorId = (string) Str::uuid();
+        $this->grantPermissionsForUser($creatorId);
+        $reviewerId = 'ed568442-ece5-4c90-97ca-12c8969bb3a2';
+        [$hCreator, $hReviewer] = $this->authHeadersCreatorAndReviewer($creatorId, $reviewerId);
+
+        $tid = (string) Str::uuid();
+        $b1 = (string) Str::uuid();
+
+        Template::query()->forceCreate([
+            'id' => $tid,
+            'name' => 'Plantilla publish changelog',
+            'description' => null,
+            'visibility_level' => TemplateVisibilityLevel::Personal->value,
+            'delivery_deadline' => null,
+            'study_type_id' => null,
+            'study_id' => null,
+            'module_id' => null,
+            'team_id' => null,
+            'created_by' => $creatorId,
+            'status' => 'draft',
+            'version' => 1,
+            'review_stages' => 1,
+            'review_mode' => 'sequential',
+        ]);
+
+        TemplateBlock::query()->forceCreate([
+            'id' => $b1,
+            'template_id' => $tid,
+            'type' => 'paragraph',
+            'title' => 'Bloque',
+            'default_content' => null,
+            'block_state' => 'editable',
+            'mandatory' => false,
+            'sort_order' => 0,
+        ]);
+
+        TemplateReviewer::query()->forceCreate([
+            'id' => (string) Str::uuid(),
+            'template_id' => $tid,
+            'user_id' => $reviewerId,
+            'stage' => 1,
+        ]);
+
+        $this->postJson("/api/v1/templates/{$tid}/submit-review", [], $hCreator)->assertOk();
+        $this->postJson("/api/v1/templates/{$tid}/publish", ['changelog' => 'v1'], $hReviewer)->assertOk();
+
+        $createDoc = $this->postJson('/api/v1/documents', [
+            'template_id' => $tid,
+            'title' => 'Doc publish',
+        ], $hCreator)->assertCreated();
+
+        $docId = (string) $createDoc->json('data.id');
+
+        $this->postJson("/api/v1/documents/{$docId}/submit", [], $hCreator)
+            ->assertOk();
+
+        // Tras borrar revisiones el revisor deja de entrar por `document_reviews` en el scope del modelo;
+        // un share mantiene acceso de lectura coherente con F-05.1 para poder publicar sin filas pendientes.
+        DocumentShare::query()->forceCreate([
+            'id' => (string) Str::uuid(),
+            'document_id' => $docId,
+            'user_id' => $reviewerId,
+            'permission' => 'read',
+            'granted_by' => $creatorId,
+        ]);
+
+        DB::table('document_reviews')->where('document_id', $docId)->delete();
+
+        $this->postJson("/api/v1/documents/{$docId}/publish", [], $hReviewer)
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors(['changelog']);
+
+        $this->postJson("/api/v1/documents/{$docId}/publish", [
+            'changelog' => 'Publicación directa con notas',
+        ], $hReviewer)
+            ->assertOk()
+            ->assertJsonPath('data.status', 'published');
+
+        $this->assertSame(
+            'Publicación directa con notas',
+            (string) DB::table('document_versions')->where('document_id', $docId)->value('notes'),
+        );
     }
 }

--- a/backend/tests/Unit/Policies/DocumentPolicyPerformanceTest.php
+++ b/backend/tests/Unit/Policies/DocumentPolicyPerformanceTest.php
@@ -8,7 +8,7 @@ use App\Policies\DocumentPolicy;
 use Tests\TestCase;
 
 /**
- * Requisito técnico F-01.3: verificación SoD sin consultas a BD (comparación de IDs en memoria).
+ * Verificación SoD sin consultas a BD (comparación de IDs en memoria).
  */
 class DocumentPolicyPerformanceTest extends TestCase
 {

--- a/backend/tests/Unit/Policies/DocumentPolicyTest.php
+++ b/backend/tests/Unit/Policies/DocumentPolicyTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit\Policies;
 
 use App\Models\Document;
+use App\Models\DocumentShare;
 use App\Models\JwtUser;
 use App\Policies\DocumentPolicy;
 use Tests\TestCase;
@@ -18,7 +19,7 @@ class DocumentPolicyTest extends TestCase
     }
 
     /**
-     * SoD (F-01.3): creador/titular no pueden actuar como revisor del mismo documento.
+     * SoD: creador/titular no pueden actuar como revisor del mismo documento.
      */
     public function test_creator_owner_cannot_review(): void
     {
@@ -40,7 +41,7 @@ class DocumentPolicyTest extends TestCase
     }
 
     /**
-     * Solo el titular puede enviar a revisión (F-05.1).
+     * Solo el titular puede enviar a revisión.
      */
     public function test_owner_can_submit(): void
     {
@@ -112,6 +113,51 @@ class DocumentPolicyTest extends TestCase
         );
 
         $this->assertFalse($this->policy->update($user, $doc));
+    }
+
+    public function test_update_allows_collaborator_with_edit_share_when_shares_relation_loaded(): void
+    {
+        $collabId = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+        $user     = $this->makeJwtUser($collabId);
+        $doc      = $this->makeDocument(
+            createdBy: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+            ownerId: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+        );
+        $share = new DocumentShare;
+        $share->forceFill(['user_id' => $collabId, 'permission' => 'edit']);
+        $doc->setRelation('shares', collect([$share]));
+
+        $this->assertTrue($this->policy->update($user, $doc));
+    }
+
+    public function test_update_denies_collaborator_with_read_share_when_shares_relation_loaded(): void
+    {
+        $collabId = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+        $user     = $this->makeJwtUser($collabId);
+        $doc      = $this->makeDocument(
+            createdBy: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+            ownerId: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+        );
+        $share = new DocumentShare;
+        $share->forceFill(['user_id' => $collabId, 'permission' => 'read']);
+        $doc->setRelation('shares', collect([$share]));
+
+        $this->assertFalse($this->policy->update($user, $doc));
+    }
+
+    public function test_share_allows_only_owner(): void
+    {
+        $ownerId = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+        $owner   = $this->makeJwtUser($ownerId);
+        $doc     = $this->makeDocument(
+            createdBy: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+            ownerId: $ownerId,
+        );
+
+        $this->assertTrue($this->policy->share($owner, $doc));
+
+        $creator = $this->makeJwtUser('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa');
+        $this->assertFalse($this->policy->share($creator, $doc));
     }
 
     public function test_delete_requires_documents_delete_permission(): void

--- a/backend/tests/Unit/Services/DocumentServiceCreationOptionsTest.php
+++ b/backend/tests/Unit/Services/DocumentServiceCreationOptionsTest.php
@@ -7,6 +7,7 @@ use App\Models\TemplateVersion;
 use App\Repositories\Contracts\DocumentRepositoryInterface;
 use App\Repositories\Contracts\TemplateRepositoryInterface;
 use App\Repositories\Contracts\TemplateVersionRepositoryInterface;
+use App\Services\Contracts\SnapshotServiceInterface;
 use App\Services\DocumentService;
 use Illuminate\Validation\ValidationException;
 use Mockery;
@@ -58,7 +59,8 @@ class DocumentServiceCreationOptionsTest extends TestCase
             ->with('tpl-2')
             ->andReturn(null);
 
-        $service = new DocumentService($docRepo, $tplRepo, $verRepo);
+        $snap = Mockery::mock(SnapshotServiceInterface::class);
+        $service = new DocumentService($docRepo, $tplRepo, $verRepo, $snap);
 
         $out = $service->creationOptionsForModule('MOD-1');
 
@@ -78,7 +80,8 @@ class DocumentServiceCreationOptionsTest extends TestCase
             ->with('MOD-1')
             ->andReturn(collect());
 
-        $service = new DocumentService($docRepo, $tplRepo, $verRepo);
+        $snap = Mockery::mock(SnapshotServiceInterface::class);
+        $service = new DocumentService($docRepo, $tplRepo, $verRepo, $snap);
 
         $this->expectException(ValidationException::class);
 

--- a/backend/tests/Unit/Services/DocumentServiceSubmitTest.php
+++ b/backend/tests/Unit/Services/DocumentServiceSubmitTest.php
@@ -6,6 +6,7 @@ use App\Models\Document;
 use App\Repositories\Contracts\DocumentRepositoryInterface;
 use App\Repositories\Contracts\TemplateRepositoryInterface;
 use App\Repositories\Contracts\TemplateVersionRepositoryInterface;
+use App\Services\Contracts\SnapshotServiceInterface;
 use App\Services\DocumentService;
 use Illuminate\Validation\ValidationException;
 use Mockery;
@@ -35,8 +36,9 @@ class DocumentServiceSubmitTest extends TestCase
 
         $tplRepo = Mockery::mock(TemplateRepositoryInterface::class);
         $verRepo = Mockery::mock(TemplateVersionRepositoryInterface::class);
+        $snap = Mockery::mock(SnapshotServiceInterface::class);
 
-        $service = new DocumentService($repo, $tplRepo, $verRepo);
+        $service = new DocumentService($repo, $tplRepo, $verRepo, $snap);
 
         $this->expectException(ValidationException::class);
 


### PR DESCRIPTION
Este PR cierra el alcance de backend para documentos y para compartir documentos con otros usuarios (solo lectura o edición, sin ceder el control del envío a revisión al colaborador). 

Incluye la API de creación y ciclo de vida del documento, edición de bloques en borrador, snapshots de versión al publicar, indicador de nueva versión de plantilla respecto al documento, compartidos read/edit, políticas alineadas con SoD en revisión y envío, metadatos de compartido en listado y detalle, e historial en block_versions para bloques modifiable.

Queda fuera de este PR: integración RabbitMQ, UI del editor y del banner, y el resto de entregables de colaboración avanzada o PDF que no van en este cambio.