### PR TITLE
Feature/refactor backend templates

### DIFF
--- a/backend/app/Http/Controllers/Api/TemplateBlockController.php
+++ b/backend/app/Http/Controllers/Api/TemplateBlockController.php
@@ -16,6 +16,7 @@ use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\ValidationException;
 
 class TemplateBlockController extends Controller
 {
@@ -110,10 +111,21 @@ class TemplateBlockController extends Controller
      */
     public function reorder(Request $request, string $template): \Illuminate\Http\Response
     {
+        $templateModel = Template::query()->findOrFail($template);
+        $this->authorize('update', $templateModel);
+
         $blockIds = $request->validate([
             'block_ids'   => ['required', 'array'],
             'block_ids.*' => ['required', 'string', 'uuid'],
         ])['block_ids'];
+
+        $blocks = $this->blockService->findBlocksByIdsOrFail($blockIds);
+        $invalid = $blocks->first(fn ($block) => (string) $block->template_id !== $template);
+        if ($invalid !== null) {
+            throw ValidationException::withMessages([
+                'block_ids' => ['Todos los bloques deben pertenecer a la plantilla indicada.'],
+            ]);
+        }
 
         $userId = (string) Auth::id();
 

--- a/backend/app/Http/Controllers/Api/TemplateBlockController.php
+++ b/backend/app/Http/Controllers/Api/TemplateBlockController.php
@@ -6,6 +6,7 @@ use App\DTOs\TemplateBlocks\BulkUpdateTemplateBlocksDto;
 use App\DTOs\TemplateBlocks\UpdateTemplateBlockDto;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\TemplateBlocks\BulkUpdateTemplateBlockRequest;
+use App\Http\Requests\TemplateBlocks\ReorderTemplateBlocksRequest;
 use App\Http\Requests\TemplateBlocks\StoreTemplateBlockRequest;
 use App\Http\Requests\TemplateBlocks\UpdateTemplateBlockRequest;
 use App\Http\Resources\TemplateBlockResource;
@@ -108,15 +109,12 @@ class TemplateBlockController extends Controller
      * PATCH /api/v1/templates/{template}/blocks/reorder
      * Reordena todos los bloques de una plantilla. Recibe { block_ids: [...] } en el nuevo orden.
      */
-    public function reorder(Request $request, string $template): \Illuminate\Http\Response
+    public function reorder(ReorderTemplateBlocksRequest $request, string $template): \Illuminate\Http\Response
     {
         $templateModel = Template::query()->findOrFail($template);
         $this->authorize('update', $templateModel);
 
-        $blockIds = $request->validate([
-            'block_ids'   => ['required', 'array'],
-            'block_ids.*' => ['required', 'string', 'uuid'],
-        ])['block_ids'];
+        $blockIds = $request->validated('block_ids');
 
         $blocks = $this->blockService->findBlocksByIdsOrFail($blockIds);
         $invalid = $blocks->first(fn ($block) => (string) $block->template_id !== $template);

--- a/backend/app/Http/Controllers/Api/TemplateBlockController.php
+++ b/backend/app/Http/Controllers/Api/TemplateBlockController.php
@@ -16,7 +16,6 @@ use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Validation\ValidationException;
 
 class TemplateBlockController extends Controller
 {
@@ -122,9 +121,7 @@ class TemplateBlockController extends Controller
         $blocks = $this->blockService->findBlocksByIdsOrFail($blockIds);
         $invalid = $blocks->first(fn ($block) => (string) $block->template_id !== $template);
         if ($invalid !== null) {
-            throw ValidationException::withMessages([
-                'block_ids' => ['Todos los bloques deben pertenecer a la plantilla indicada.'],
-            ]);
+            abort(403, 'No tienes permiso para reordenar bloques fuera de la plantilla indicada.');
         }
 
         $userId = (string) Auth::id();

--- a/backend/app/Http/Controllers/Api/TemplateController.php
+++ b/backend/app/Http/Controllers/Api/TemplateController.php
@@ -90,6 +90,7 @@ class TemplateController extends Controller
     public function update(UpdateTemplateRequest $request, string $template): TemplateResource
     {
         $model = $this->templateService->findOrFail($template);
+        $this->authorize('update', [$model, $request->input('visibility_level')]);
 
         $dto = $request->toUpdateDto();
 

--- a/backend/app/Http/Controllers/Api/TemplateController.php
+++ b/backend/app/Http/Controllers/Api/TemplateController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\Templates\CloneTemplateRequest;
 use App\Http\Requests\Templates\IndexTemplateRequest;
 use App\Http\Requests\Templates\PublishTemplateRequest;
+use App\Http\Requests\Templates\SyncTemplateUsersRequest;
 use App\Http\Requests\Templates\StoreTemplateRequest;
 use App\Http\Requests\Templates\UpdateTemplateRequest;
 use App\Http\Resources\TemplateResource;
@@ -221,17 +222,12 @@ class TemplateController extends Controller
     /**
      * Sincroniza los revisores de la plantilla normativa.
      */
-    public function syncReviewers(Request $request, string $template): JsonResponse
+    public function syncReviewers(SyncTemplateUsersRequest $request, string $template): JsonResponse
     {
         $model = $this->templateService->findOrFail($template);
         $this->authorize('update', $model);
 
-        $request->validate([
-            'user_ids'   => ['present', 'array'],
-            'user_ids.*' => ['required', 'string', 'exists:users,id'],
-        ]);
-
-        $this->templateService->syncReviewers($model->id, $request->input('user_ids'));
+        $this->templateService->syncReviewers($model->id, $request->validated('user_ids'));
 
         return response()->json(['message' => 'Revisores de plantilla sincronizados correctamente.']);
     }
@@ -239,17 +235,12 @@ class TemplateController extends Controller
     /**
      * Sincroniza el pool de posibles revisores de documentos generados desde la plantilla.
      */
-    public function syncDocumentReviewers(Request $request, string $template): JsonResponse
+    public function syncDocumentReviewers(SyncTemplateUsersRequest $request, string $template): JsonResponse
     {
         $model = $this->templateService->findOrFail($template);
         $this->authorize('update', $model);
 
-        $request->validate([
-            'user_ids'   => ['present', 'array'],
-            'user_ids.*' => ['required', 'string', 'exists:users,id'],
-        ]);
-
-        $this->templateService->syncDocumentReviewers($model->id, $request->input('user_ids'));
+        $this->templateService->syncDocumentReviewers($model->id, $request->validated('user_ids'));
 
         return response()->json(['message' => 'Validadores de documento sincronizados correctamente.']);
     }

--- a/backend/app/Http/Controllers/Api/TemplateController.php
+++ b/backend/app/Http/Controllers/Api/TemplateController.php
@@ -125,6 +125,9 @@ class TemplateController extends Controller
      */
     public function clone(CloneTemplateRequest $_request, string $template): JsonResponse
     {
+        $model = $this->templateService->findOrFail($template);
+        $this->authorize('clone', $model);
+
         $copy = $this->templateService->clone($template, (string) Auth::id());
 
         return (new TemplateResource($copy))->response()->setStatusCode(201);

--- a/backend/app/Http/Requests/TemplateBlocks/ReorderTemplateBlocksRequest.php
+++ b/backend/app/Http/Requests/TemplateBlocks/ReorderTemplateBlocksRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Requests\TemplateBlocks;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ReorderTemplateBlocksRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Reglas de validación para el reordenamiento de bloques de una plantilla.
+     * 
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'block_ids' => ['required', 'array'],
+            'block_ids.*' => ['required', 'string', 'uuid'],
+        ];
+    }
+}

--- a/backend/app/Http/Requests/Templates/SyncTemplateUsersRequest.php
+++ b/backend/app/Http/Requests/Templates/SyncTemplateUsersRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Requests\Templates;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class SyncTemplateUsersRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Reglas de validación para la sincronización de usuarios de una plantilla.
+     * 
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'user_ids' => ['present', 'array'],
+            'user_ids.*' => ['required', 'string', 'exists:users,id'],
+        ];
+    }
+}

--- a/backend/app/Policies/TemplatePolicy.php
+++ b/backend/app/Policies/TemplatePolicy.php
@@ -105,11 +105,18 @@ class TemplatePolicy
     /**
      * Clonar plantilla.
      *
-     * Solo se permite clonar plantillas publicadas que el usuario pueda ver.
+     * Solo se permite clonar plantillas publicadas que el usuario pueda ver
+     * y para las cuales tenga permiso de creación en la visibilidad origen.
      */
     public function clone(JwtUser $user, Template $template): bool
     {
-        return $this->view($user, $template) && $template->status === 'published';
+        $visibility = $template->visibility_level instanceof TemplateVisibilityLevel
+            ? $template->visibility_level->value
+            : (string) $template->visibility_level;
+
+        return $this->view($user, $template)
+            && $template->status === 'published'
+            && $this->create($user, $visibility);
     }
 
     /**

--- a/backend/tests/Feature/TemplatesApiTest.php
+++ b/backend/tests/Feature/TemplatesApiTest.php
@@ -304,6 +304,7 @@ class TemplatesApiTest extends TestCase
     {
         $userId = (string) Str::uuid();
         $headers = $this->authHeaders($userId);
+        $this->assignUserPermissions($userId, ['templates.read', 'templates.create']);
 
         $tid = (string) Str::uuid();
         Template::query()->forceCreate([


### PR DESCRIPTION
- Se refuerza la autorización en operaciones críticas de plantillas para cerrar bypasses detectados en auditoría.
- Se añade control de pertenencia de bloques al reordenar, evitando modificaciones cruzadas entre plantillas.
- Se alinea la política de clonación con reglas de visibilidad y estado publicado de la plantilla origen.