### PR TITLE
Feature/refactor backend documents

### DIFF
--- a/backend/app/Http/Controllers/Api/AuditLogController.php
+++ b/backend/app/Http/Controllers/Api/AuditLogController.php
@@ -4,10 +4,7 @@ namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
 use App\Http\Resources\AuditLogResource;
-use App\Models\Comment;
-use App\Models\Document;
 use App\Models\JwtUser;
-use App\Models\Template;
 use App\Services\Contracts\AuditLogServiceInterface;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Resources\Json\ResourceCollection;
@@ -23,7 +20,7 @@ class AuditLogController extends Controller
      */
     public function indexForDocument(string $documentId): ResourceCollection|JsonResponse
     {
-        $this->assertCanAccessDocumentAudit($documentId);
+        $this->auditLogService->assertCanAccessDocumentAudit($documentId, $this->jwtUser());
 
         return AuditLogResource::collection(
             $this->auditLogService->historyFor('document', $documentId)
@@ -35,7 +32,7 @@ class AuditLogController extends Controller
      */
     public function indexForTemplate(string $templateId): ResourceCollection|JsonResponse
     {
-        $this->assertCanAccessTemplateAudit($templateId);
+        $this->auditLogService->assertCanAccessTemplateAudit($templateId, $this->jwtUser());
 
         return AuditLogResource::collection(
             $this->auditLogService->historyFor('template', $templateId)
@@ -47,7 +44,7 @@ class AuditLogController extends Controller
      */
     public function indexForComment(string $commentId): ResourceCollection|JsonResponse
     {
-        $this->assertCanAccessCommentAudit($commentId);
+        $this->auditLogService->assertCanAccessCommentAudit($commentId, $this->jwtUser());
 
         return AuditLogResource::collection(
             $this->auditLogService->historyFor('comment', $commentId)
@@ -62,49 +59,5 @@ class AuditLogController extends Controller
         }
 
         return $user;
-    }
-
-    /**
-     * Participante (alcance del modelo) o permiso `audit.read` en BD (lectura elevada).
-     *
-     * TODO(permisos): valorar restringir a solo `audit.read` (sin camino participante).
-     */
-    private function assertCanAccessDocumentAudit(string $documentId): void
-    {
-        if (Document::query()->whereKey($documentId)->exists()) {
-            return;
-        }
-
-        if (! $this->jwtUser()->hasPermission('audit.read')) {
-            abort(404);
-        }
-
-        Document::query()->withoutGlobalScopes(['user_access'])->findOrFail($documentId);
-    }
-
-    private function assertCanAccessTemplateAudit(string $templateId): void
-    {
-        if (Template::query()->whereKey($templateId)->exists()) {
-            return;
-        }
-
-        if (! $this->jwtUser()->hasPermission('audit.read')) {
-            abort(404);
-        }
-
-        Template::query()->withoutGlobalScopes(['user_access'])->findOrFail($templateId);
-    }
-
-    private function assertCanAccessCommentAudit(string $commentId): void
-    {
-        if (Comment::query()->whereKey($commentId)->exists()) {
-            return;
-        }
-
-        if (! $this->jwtUser()->hasPermission('audit.read')) {
-            abort(404);
-        }
-
-        Comment::query()->withoutGlobalScopes(['user_access'])->findOrFail($commentId);
     }
 }

--- a/backend/app/Http/Controllers/Api/DocumentController.php
+++ b/backend/app/Http/Controllers/Api/DocumentController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Api;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Documents\DocumentCreateFromModuleRequest;
 use App\Http\Requests\Documents\DocumentCreationOptionsRequest;
+use App\Http\Requests\Documents\DelegateDocumentRequest;
 use App\Http\Requests\Documents\PublishDocumentRequest;
 use App\Http\Requests\Documents\StoreDocumentRequest;
 use App\Http\Requests\Documents\UpdateDocumentRequest;
@@ -224,19 +225,15 @@ class DocumentController extends Controller
     /**
      * Delegar documento a otro usuario.
      */
-    public function delegate(Request $request, string $id): JsonResponse
+    public function delegate(DelegateDocumentRequest $request, string $id): JsonResponse
     {
         $document = $this->documentService->findOrFail($id);
         $this->authorize('view', $document);
 
-        $validated = $request->validate([
-            'new_owner_id' => ['required', 'string'],
-        ]);
-
         $actorId = (string) $request->user()->getAuthIdentifier();
         $updated = $this->documentService->delegateOwner(
             $id,
-            $validated['new_owner_id'],
+            (string) $request->validated('new_owner_id'),
             $actorId,
         );
 

--- a/backend/app/Http/Controllers/Api/DocumentController.php
+++ b/backend/app/Http/Controllers/Api/DocumentController.php
@@ -183,10 +183,10 @@ class DocumentController extends Controller
         $document = $this->documentService->findOrFail($id);
         $this->authorize('submit', $document);
 
-        $actorId = $request->user()->getAuthIdentifier();
+        $actorId = (string) $request->user()->getAuthIdentifier();
         $updated = $this->documentService->submitToReview($document->id, $actorId);
 
-        return response()->json(['data' => $updated]);
+        return response()->json(['data' => (new DocumentResource($updated))->toArray($request)]);
     }
 
     /**
@@ -197,14 +197,14 @@ class DocumentController extends Controller
         $document = $this->documentService->findOrFail($id);
         $this->authorize('review', $document);
 
-        $actorId = $request->user()->getAuthIdentifier();
+        $actorId = (string) $request->user()->getAuthIdentifier();
         $updated = $this->documentService->publishDocument(
             $document->id,
             $actorId,
             $request->validated('changelog'),
         );
 
-        return response()->json(['data' => $updated]);
+        return response()->json(['data' => (new DocumentResource($updated))->toArray($request)]);
     }
 
     /**
@@ -215,10 +215,10 @@ class DocumentController extends Controller
         $document = $this->documentService->findOrFail($id);
         $this->authorize('review', $document);
 
-        $actorId = $request->user()->getAuthIdentifier();
+        $actorId = (string) $request->user()->getAuthIdentifier();
         $updated = $this->documentService->rejectDocument($document->id, $actorId);
 
-        return response()->json(['data' => $updated]);
+        return response()->json(['data' => (new DocumentResource($updated))->toArray($request)]);
     }
 
     /**
@@ -233,13 +233,13 @@ class DocumentController extends Controller
             'new_owner_id' => ['required', 'string'],
         ]);
 
-        $actorId = $request->user()->getAuthIdentifier();
+        $actorId = (string) $request->user()->getAuthIdentifier();
         $updated = $this->documentService->delegateOwner(
             $id,
             $validated['new_owner_id'],
             $actorId,
         );
 
-        return response()->json(['data' => $updated]);
+        return response()->json(['data' => (new DocumentResource($updated))->toArray($request)]);
     }
 }

--- a/backend/app/Http/Controllers/Api/DocumentVersionController.php
+++ b/backend/app/Http/Controllers/Api/DocumentVersionController.php
@@ -3,7 +3,6 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
-use App\Models\DocumentVersion;
 use App\Services\Contracts\DocumentServiceInterface;
 use Illuminate\Http\JsonResponse;
 
@@ -23,23 +22,7 @@ class DocumentVersionController extends Controller
         $doc = $this->documentService->findOrFail($document);
         $this->authorize('view', $doc);
 
-        $rows = $doc->versions()
-            ->orderByDesc('version_number')
-            ->get()
-            ->map(static function (DocumentVersion $v): array {
-                return [
-                    'id' => $v->id,
-                    'document_id' => $v->document_id,
-                    'version_number' => $v->version_number,
-                    'trigger_event' => $v->trigger_event,
-                    'triggered_by' => $v->triggered_by,
-                    'changelog' => $v->notes,
-                    'notes' => $v->notes,
-                    'created_at' => $v->created_at?->toIso8601String(),
-                ];
-            })
-            ->values()
-            ->all();
+        $rows = $this->documentService->listDocumentVersions($doc->id);
 
         return response()->json(['data' => $rows]);
     }

--- a/backend/app/Http/Controllers/Api/ReviewController.php
+++ b/backend/app/Http/Controllers/Api/ReviewController.php
@@ -3,8 +3,8 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
-use App\Models\Document;
-use App\Models\DocumentReview;
+use App\Http\Requests\Documents\ApproveDocumentReviewRequest;
+use App\Http\Requests\Documents\RejectDocumentReviewRequest;
 use App\Services\Contracts\DocumentServiceInterface;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -32,21 +32,17 @@ class ReviewController extends Controller
     /**
      * Aprobar revisión de un documento.
      */
-    public function approve(Request $request, string $documentId, string $reviewId): JsonResponse
+    public function approve(ApproveDocumentReviewRequest $request, string $documentId, string $reviewId): JsonResponse
     {
         $document = $this->documentService->findOrFail($documentId);
         $this->authorize('review', $document);
 
-        $validated = $request->validate([
-            'changelog' => ['nullable', 'string', 'max:5000'],
-        ]);
-
-        $actorId = $request->user()->getAuthIdentifier();
+        $actorId = (string) $request->user()->getAuthIdentifier();
         $updated = $this->documentService->approveReview(
             $document->id,
             $reviewId,
             $actorId,
-            $validated['changelog'] ?? null,
+            $request->validated('changelog'),
         );
 
         return response()->json(['data' => $updated]);
@@ -55,21 +51,17 @@ class ReviewController extends Controller
     /**
      * Rechazar revisión de un documento.
      */
-    public function reject(Request $request, string $documentId, string $reviewId): JsonResponse
+    public function reject(RejectDocumentReviewRequest $request, string $documentId, string $reviewId): JsonResponse
     {
         $document = $this->documentService->findOrFail($documentId);
         $this->authorize('review', $document);
 
-        $validated = $request->validate([
-            'rejection_reason' => ['nullable', 'string'],
-        ]);
-
-        $actorId = $request->user()->getAuthIdentifier();
+        $actorId = (string) $request->user()->getAuthIdentifier();
         $updated = $this->documentService->rejectReview(
             $document->id,
             $reviewId,
             $actorId,
-            $validated['rejection_reason'] ?? null,
+            $request->validated('rejection_reason'),
         );
 
         return response()->json(['data' => $updated]);

--- a/backend/app/Http/Controllers/Api/UserController.php
+++ b/backend/app/Http/Controllers/Api/UserController.php
@@ -4,12 +4,16 @@ namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
 use App\Models\JwtUser;
+use App\Services\Contracts\UserDirectoryServiceInterface;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\DB;
 
 class UserController extends Controller
 {
+    public function __construct(
+        private readonly UserDirectoryServiceInterface $userDirectoryService,
+    ) {}
+
     /**
      * GET /api/v1/users?search={term}&per_page={n}
      *
@@ -32,23 +36,7 @@ class UserController extends Controller
             return response()->json(['data' => []]);
         }
 
-        $term = '%' . mb_strtolower($search) . '%';
-
-        $users = DB::table('users')
-            ->where(function ($query) use ($term) {
-                $query->whereRaw('LOWER(name) LIKE ?', [$term])
-                      ->orWhereRaw('LOWER(email) LIKE ?', [$term])
-                      ->orWhereRaw('LOWER(department) LIKE ?', [$term]);
-            })
-            ->select('id', 'name', 'email', 'department')
-            ->limit($perPage)
-            ->get()
-            ->map(static fn (object $u): array => [
-                'id'    => $u->id,
-                'name'  => $u->name,
-                'email' => $u->email,
-                'role'  => $u->department,
-            ]);
+        $users = $this->userDirectoryService->searchUsers($search, $perPage);
 
         return response()->json(['data' => $users]);
     }
@@ -72,29 +60,31 @@ class UserController extends Controller
         $search  = trim((string) $request->get('search', ''));
         $perPage = min((int) $request->get('per_page', 20), 50);
 
-        $query = DB::table('users')
-            ->join('user_permissions', 'users.id', '=', 'user_permissions.user_id')
-            ->where('user_permissions.permission_code', 'templates.review');
+        $users = $this->userDirectoryService->searchTemplateReviewerCandidates($search, $perPage);
 
-        if (mb_strlen($search) >= 2) {
-            $term = '%' . mb_strtolower($search) . '%';
-            $query->where(function ($q) use ($term) {
-                $q->whereRaw('LOWER(users.name) LIKE ?', [$term])
-                  ->orWhereRaw('LOWER(users.email) LIKE ?', [$term])
-                  ->orWhereRaw('LOWER(users.department) LIKE ?', [$term]);
-            });
+        return response()->json(['data' => $users]);
+    }
+
+    /**
+     * GET /api/v1/users/document-reviewer-candidates?search={term}&per_page={n}
+     *
+     * Devuelve los usuarios que tienen el permiso `documents.review` y, por tanto,
+     * pueden ser seleccionados como revisores de documentos en la plantilla.
+     * El front no necesita conocer el código de permiso interno.
+     *
+     * `search` es opcional; si se omite devuelve todos los candidatos (hasta per_page).
+     */
+    public function documentReviewerCandidates(Request $request): JsonResponse
+    {
+        $user = $request->user();
+        if (! $user instanceof JwtUser || ! $user->hasPermission('users.search')) {
+            abort(403, 'No tienes permiso para buscar usuarios.');
         }
 
-        $users = $query
-            ->select('users.id', 'users.name', 'users.email', 'users.department')
-            ->limit($perPage)
-            ->get()
-            ->map(static fn (object $u): array => [
-                'id'    => $u->id,
-                'name'  => $u->name,
-                'email' => $u->email,
-                'role'  => $u->department,
-            ]);
+        $search  = trim((string) $request->get('search', ''));
+        $perPage = min((int) $request->get('per_page', 20), 50);
+
+        $users = $this->userDirectoryService->searchDocumentReviewerCandidates($search, $perPage);
 
         return response()->json(['data' => $users]);
     }

--- a/backend/app/Http/Requests/Documents/ApproveDocumentReviewRequest.php
+++ b/backend/app/Http/Requests/Documents/ApproveDocumentReviewRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Requests\Documents;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ApproveDocumentReviewRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Reglas de validación para la aprobación de una revisión de un documento.
+     * 
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'changelog' => ['nullable', 'string', 'max:5000'],
+        ];
+    }
+}

--- a/backend/app/Http/Requests/Documents/DelegateDocumentRequest.php
+++ b/backend/app/Http/Requests/Documents/DelegateDocumentRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Requests\Documents;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class DelegateDocumentRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'new_owner_id' => ['required', 'string'],
+        ];
+    }
+}

--- a/backend/app/Http/Requests/Documents/RejectDocumentReviewRequest.php
+++ b/backend/app/Http/Requests/Documents/RejectDocumentReviewRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Requests\Documents;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class RejectDocumentReviewRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Reglas de validación para el rechazo de una revisión de un documento.
+     * 
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'rejection_reason' => ['nullable', 'string'],
+        ];
+    }
+}

--- a/backend/app/Providers/AppServiceProvider.php
+++ b/backend/app/Providers/AppServiceProvider.php
@@ -17,6 +17,7 @@ use App\Repositories\Contracts\TemplateRepositoryInterface;
 use App\Repositories\Contracts\TemplateVersionRepositoryInterface;
 use App\Repositories\Contracts\UserPermissionRepositoryInterface;
 use App\Repositories\Contracts\UserProfileRepositoryInterface;
+use App\Repositories\Contracts\UserDirectoryRepositoryInterface;
 use App\Repositories\Eloquent\AcademicHierarchyRepository;
 use App\Repositories\Eloquent\AuditLogRepository;
 use App\Repositories\Eloquent\CommentRepository;
@@ -27,6 +28,7 @@ use App\Repositories\Eloquent\TemplateRepository;
 use App\Repositories\Eloquent\TemplateVersionRepository;
 use App\Repositories\Eloquent\UserPermissionRepository;
 use App\Repositories\Eloquent\UserProfileRepository;
+use App\Repositories\Eloquent\UserDirectoryRepository;
 use App\Services\AcademicHierarchyService;
 use App\Services\AuditLogService;
 use App\Services\CommentService;
@@ -44,6 +46,7 @@ use App\Services\Contracts\SnapshotServiceInterface;
 use App\Services\Contracts\TemplateBlockServiceInterface;
 use App\Services\Contracts\TemplateServiceInterface;
 use App\Services\Contracts\UserProfileServiceInterface;
+use App\Services\Contracts\UserDirectoryServiceInterface;
 use App\Services\DocumentService;
 use App\Services\DashboardService;
 use App\Services\HealthCheckService;
@@ -52,6 +55,7 @@ use App\Services\SnapshotService;
 use App\Services\TemplateBlockService;
 use App\Services\TemplateService;
 use App\Services\UserProfileService;
+use App\Services\UserDirectoryService;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\ServiceProvider;
@@ -69,6 +73,7 @@ class AppServiceProvider extends ServiceProvider
         $this->app->bind(TemplateVersionRepositoryInterface::class, TemplateVersionRepository::class);
         $this->app->bind(CommentRepositoryInterface::class, CommentRepository::class);
         $this->app->bind(UserProfileRepositoryInterface::class, UserProfileRepository::class);
+        $this->app->bind(UserDirectoryRepositoryInterface::class, UserDirectoryRepository::class);
         $this->app->bind(UserPermissionRepositoryInterface::class, UserPermissionRepository::class);
         $this->app->bind(AcademicHierarchyRepositoryInterface::class, AcademicHierarchyRepository::class);
 
@@ -84,6 +89,7 @@ class AppServiceProvider extends ServiceProvider
         $this->app->bind(TemplateBlockServiceInterface::class, TemplateBlockService::class);
         $this->app->bind(HealthCheckServiceInterface::class, HealthCheckService::class);
         $this->app->bind(UserProfileServiceInterface::class, UserProfileService::class);
+        $this->app->bind(UserDirectoryServiceInterface::class, UserDirectoryService::class);
         $this->app->bind(AcademicHierarchyServiceInterface::class, AcademicHierarchyService::class);
     }
 

--- a/backend/app/Repositories/Contracts/UserDirectoryRepositoryInterface.php
+++ b/backend/app/Repositories/Contracts/UserDirectoryRepositoryInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Repositories\Contracts;
+
+interface UserDirectoryRepositoryInterface
+{
+    /**
+     * Busca usuarios por nombre, email o departamento.
+     *
+     * @return list<array{id: string, name: ?string, email: ?string, role: ?string}>
+     */
+    public function searchUsers(string $search, int $limit): array;
+
+    /**
+     * Busca candidatos a revisor con permiso templates.review.
+     *
+     * @return list<array{id: string, name: ?string, email: ?string, role: ?string}>
+     */
+    public function searchTemplateReviewerCandidates(string $search, int $limit): array;
+
+    /**
+     * Busca candidatos a revisor con permiso documents.review.
+     *
+     * @return list<array{id: string, name: ?string, email: ?string, role: ?string}>
+     */
+    public function searchDocumentReviewerCandidates(string $search, int $limit): array;
+}

--- a/backend/app/Repositories/Eloquent/UserDirectoryRepository.php
+++ b/backend/app/Repositories/Eloquent/UserDirectoryRepository.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace App\Repositories\Eloquent;
+
+use App\Repositories\Contracts\UserDirectoryRepositoryInterface;
+use Illuminate\Support\Facades\DB;
+
+class UserDirectoryRepository implements UserDirectoryRepositoryInterface
+{
+    /**
+     * Busca usuarios por nombre, email o departamento.
+     * 
+     * @param string $search
+     * @param int $limit
+     * @return array
+     */
+    public function searchUsers(string $search, int $limit): array
+    {
+        $term = '%' . mb_strtolower($search) . '%';
+
+        return DB::table('users')
+            ->where(function ($query) use ($term) {
+                $query->whereRaw('LOWER(name) LIKE ?', [$term])
+                    ->orWhereRaw('LOWER(email) LIKE ?', [$term])
+                    ->orWhereRaw('LOWER(department) LIKE ?', [$term]);
+            })
+            ->select('id', 'name', 'email', 'department')
+            ->limit($limit)
+            ->get()
+            ->map(static fn (object $u): array => [
+                'id' => (string) $u->id,
+                'name' => $u->name,
+                'email' => $u->email,
+                'role' => $u->department,
+            ])
+            ->values()
+            ->all();
+    }
+
+    /**
+     * Busca candidatos a revisor con permiso templates.review.
+     * 
+     * @param string $search
+     * @param int $limit
+     * @return array
+     */
+    public function searchTemplateReviewerCandidates(string $search, int $limit): array
+    {
+        return $this->searchReviewerCandidatesByPermission('templates.review', $search, $limit);
+    }
+
+    /**
+     * Busca candidatos a revisor con permiso documents.review.
+     * 
+     * @param string $search
+     * @param int $limit
+     * @return array
+     */
+    public function searchDocumentReviewerCandidates(string $search, int $limit): array
+    {
+        return $this->searchReviewerCandidatesByPermission('documents.review', $search, $limit);
+    }
+
+    /**
+     * Busca candidatos a revisor con permiso templates.review o documents.review.
+     * 
+     * @param string $permissionCode
+     * @param string $search
+     * @param int $limit
+     * @return array
+     * @return list<array{id: string, name: ?string, email: ?string, role: ?string}>
+     */
+    private function searchReviewerCandidatesByPermission(string $permissionCode, string $search, int $limit): array
+    {
+        $query = DB::table('users')
+            ->join('user_permissions', 'users.id', '=', 'user_permissions.user_id')
+            ->where('user_permissions.permission_code', $permissionCode);
+
+        if (mb_strlen($search) >= 2) {
+            $term = '%' . mb_strtolower($search) . '%';
+            $query->where(function ($q) use ($term) {
+                $q->whereRaw('LOWER(users.name) LIKE ?', [$term])
+                    ->orWhereRaw('LOWER(users.email) LIKE ?', [$term])
+                    ->orWhereRaw('LOWER(users.department) LIKE ?', [$term]);
+            });
+        }
+
+        return $query
+            ->select('users.id', 'users.name', 'users.email', 'users.department')
+            ->limit($limit)
+            ->get()
+            ->map(static fn (object $u): array => [
+                'id' => (string) $u->id,
+                'name' => $u->name,
+                'email' => $u->email,
+                'role' => $u->department,
+            ])
+            ->values()
+            ->all();
+    }
+}

--- a/backend/app/Services/AuditLogService.php
+++ b/backend/app/Services/AuditLogService.php
@@ -3,6 +3,10 @@
 namespace App\Services;
 
 use App\Models\AuditLog;
+use App\Models\Comment;
+use App\Models\Document;
+use App\Models\JwtUser;
+use App\Models\Template;
 use App\Services\Contracts\AuditLogServiceInterface;
 use App\Repositories\Contracts\AuditLogRepositoryInterface;
 use Illuminate\Pagination\LengthAwarePaginator;
@@ -52,5 +56,65 @@ class AuditLogService implements AuditLogServiceInterface
         int $perPage = 25,
     ): LengthAwarePaginator {
         return $this->auditLogRepository->paginateByEntity($entityType, $entityId, $perPage);
+    }
+
+    /**
+     * Verifica si un usuario tiene acceso a la auditoría de un documento.
+     * 
+     * @param string $documentId
+     * @param JwtUser $user
+     * @return void
+     */
+    public function assertCanAccessDocumentAudit(string $documentId, JwtUser $user): void
+    {
+        if (Document::query()->whereKey($documentId)->exists()) {
+            return;
+        }
+
+        if (! $user->hasPermission('audit.read')) {
+            abort(404);
+        }
+
+        Document::query()->withoutGlobalScopes(['user_access'])->findOrFail($documentId);
+    }
+
+    /**
+     * Verifica si un usuario tiene acceso a la auditoría de una plantilla.
+     * 
+     * @param string $templateId
+     * @param JwtUser $user
+     * @return void
+     */
+    public function assertCanAccessTemplateAudit(string $templateId, JwtUser $user): void
+    {
+        if (Template::query()->whereKey($templateId)->exists()) {
+            return;
+        }
+
+        if (! $user->hasPermission('audit.read')) {
+            abort(404);
+        }
+
+        Template::query()->withoutGlobalScopes(['user_access'])->findOrFail($templateId);
+    }
+
+    /**
+     * Verifica si un usuario tiene acceso a la auditoría de un comentario.
+     * 
+     * @param string $commentId
+     * @param JwtUser $user
+     * @return void
+     */
+    public function assertCanAccessCommentAudit(string $commentId, JwtUser $user): void
+    {
+        if (Comment::query()->whereKey($commentId)->exists()) {
+            return;
+        }
+
+        if (! $user->hasPermission('audit.read')) {
+            abort(404);
+        }
+
+        Comment::query()->withoutGlobalScopes(['user_access'])->findOrFail($commentId);
     }
 }

--- a/backend/app/Services/Contracts/AuditLogServiceInterface.php
+++ b/backend/app/Services/Contracts/AuditLogServiceInterface.php
@@ -3,10 +3,25 @@
 namespace App\Services\Contracts;
 
 use App\Models\AuditLog;
+use App\Models\JwtUser;
 use Illuminate\Pagination\LengthAwarePaginator;
 
 interface AuditLogServiceInterface
 {
+    /**
+     * Registra un nuevo evento de auditoría.
+     * 
+     * @param string $entityType
+     * @param string $entityId
+     * @param string $action
+     * @param string $userId
+     * @param string|null $blockId
+     * @param array|null $previousValue 
+     * @param array|null $newValue
+     * @param string|null $ipAddress
+     * @param string|null $userAgent
+     * @return AuditLog
+     */
     public function record(
         string $entityType,
         string $entityId,
@@ -19,9 +34,44 @@ interface AuditLogServiceInterface
         ?string $userAgent = null,
     ): AuditLog;
 
+    /**
+     * Obtiene el historial de auditoría para una entidad.
+     * 
+     * @param string $entityType
+     * @param string $entityId
+     * @param int $perPage
+     * @return LengthAwarePaginator
+     */
     public function historyFor(
         string $entityType,
         string $entityId,
         int $perPage = 25,
     ): LengthAwarePaginator;
+
+    /**
+     * Verifica si un usuario tiene acceso a la auditoría de un documento.
+     * 
+     * @param string $documentId
+     * @param JwtUser $user
+     * @return void
+     */
+    public function assertCanAccessDocumentAudit(string $documentId, JwtUser $user): void;
+
+    /**
+     * Verifica si un usuario tiene acceso a la auditoría de una plantilla.
+     * 
+     * @param string $templateId
+     * @param JwtUser $user
+     * @return void
+     */
+    public function assertCanAccessTemplateAudit(string $templateId, JwtUser $user): void;
+
+    /**
+     * Verifica si un usuario tiene acceso a la auditoría de un comentario.
+     * 
+     * @param string $commentId
+     * @param JwtUser $user
+     * @return void
+     */
+    public function assertCanAccessCommentAudit(string $commentId, JwtUser $user): void;
 }

--- a/backend/app/Services/Contracts/DocumentServiceInterface.php
+++ b/backend/app/Services/Contracts/DocumentServiceInterface.php
@@ -90,6 +90,22 @@ interface DocumentServiceInterface
     public function findDocumentVersionOrFail(string $documentId, string $versionId): DocumentVersion;
 
     /**
+     * Metadatos de versiones del documento ordenados descendentemente.
+     *
+     * @return list<array{
+     *   id: string,
+     *   document_id: string,
+     *   version_number: int,
+     *   trigger_event: string,
+     *   triggered_by: string,
+     *   changelog: ?string,
+     *   notes: ?string,
+     *   created_at: ?string
+     * }>
+     */
+    public function listDocumentVersions(string $documentId): array;
+
+    /**
      * Rechaza una revisión del documento.
      */
     public function rejectReview(string $documentId, string $reviewId, string $actorId, ?string $reason = null): Document;

--- a/backend/app/Services/Contracts/UserDirectoryServiceInterface.php
+++ b/backend/app/Services/Contracts/UserDirectoryServiceInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Services\Contracts;
+
+interface UserDirectoryServiceInterface
+{
+    /**
+     * Busca usuarios por nombre, email o departamento.
+     *
+     * @return list<array{id: string, name: ?string, email: ?string, role: ?string}>
+     */
+    public function searchUsers(string $search, int $limit): array;
+
+    /**
+     * Busca candidatos a revisor con permiso templates.review.
+     *
+     * @return list<array{id: string, name: ?string, email: ?string, role: ?string}>
+     */
+    public function searchTemplateReviewerCandidates(string $search, int $limit): array;
+
+    /**
+     * Busca candidatos a revisor con permiso documents.review.
+     *
+     * @return list<array{id: string, name: ?string, email: ?string, role: ?string}>
+     */
+    public function searchDocumentReviewerCandidates(string $search, int $limit): array;
+}

--- a/backend/app/Services/DocumentService.php
+++ b/backend/app/Services/DocumentService.php
@@ -826,6 +826,43 @@ class DocumentService implements DocumentServiceInterface
     }
 
     /**
+     * Metadatos de versiones del documento (sin snapshot completo).
+     *
+     * @return list<array{
+     *   id: string,
+     *   document_id: string,
+     *   version_number: int,
+     *   trigger_event: string,
+     *   triggered_by: string,
+     *   changelog: ?string,
+     *   notes: ?string,
+     *   created_at: ?string
+     * }>
+     */
+    public function listDocumentVersions(string $documentId): array
+    {
+        $document = $this->documentRepository->findOrFail($documentId);
+
+        return $document->versions()
+            ->orderByDesc('version_number')
+            ->get()
+            ->map(static function (DocumentVersion $v): array {
+                return [
+                    'id' => $v->id,
+                    'document_id' => $v->document_id,
+                    'version_number' => $v->version_number,
+                    'trigger_event' => $v->trigger_event,
+                    'triggered_by' => $v->triggered_by,
+                    'changelog' => $v->notes,
+                    'notes' => $v->notes,
+                    'created_at' => $v->created_at?->toIso8601String(),
+                ];
+            })
+            ->values()
+            ->all();
+    }
+
+    /**
      * Compara dos valores JSON canónicamente.
      */
     private function documentBlockContentEquals(mixed $a, mixed $b): bool

--- a/backend/app/Services/UserDirectoryService.php
+++ b/backend/app/Services/UserDirectoryService.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Services;
+
+use App\Repositories\Contracts\UserDirectoryRepositoryInterface;
+use App\Services\Contracts\UserDirectoryServiceInterface;
+
+class UserDirectoryService implements UserDirectoryServiceInterface
+{
+    public function __construct(
+        private readonly UserDirectoryRepositoryInterface $repository,
+    ) {}
+
+    /**
+     * Busca usuarios por nombre, email o departamento.
+     * 
+     * @param string $search
+     * @param int $limit
+     * @return array
+     */
+    public function searchUsers(string $search, int $limit): array
+    {
+        return $this->repository->searchUsers($search, $limit);
+    }
+
+    /**
+     * Busca candidatos a revisor con permiso templates.review.
+     * 
+     * @param string $search
+     * @param int $limit
+     * @return array
+     */
+    public function searchTemplateReviewerCandidates(string $search, int $limit): array
+    {
+        return $this->repository->searchTemplateReviewerCandidates($search, $limit);
+    }
+
+    /**
+     * Busca candidatos a revisor con permiso documents.review.
+     * 
+     * @param string $search
+     * @param int $limit
+     * @return array
+     */
+    public function searchDocumentReviewerCandidates(string $search, int $limit): array
+    {
+        return $this->repository->searchDocumentReviewerCandidates($search, $limit);
+    }
+}

--- a/backend/database/data/permissions_mock.php
+++ b/backend/database/data/permissions_mock.php
@@ -16,6 +16,7 @@ return [
     ['code' => 'documents.read', 'name' => 'Documentos — leer', 'description' => 'Ver documentos visibles.'],
     ['code' => 'documents.update', 'name' => 'Documentos — actualizar', 'description' => 'Editar documentos.'],
     ['code' => 'documents.delete', 'name' => 'Documentos — eliminar', 'description' => 'Eliminar documentos.'],
+    ['code' => 'documents.review', 'name' => 'Documentos — revisar', 'description' => 'Puede ser seleccionado como revisor de documentos generados a partir de plantillas y aprobar o rechazar su publicación.'],
 
     ['code' => 'users.search', 'name' => 'Usuarios — buscar', 'description' => 'Búsqueda de usuarios del catálogo (asignación de validadores, compartición, etc.).'],
 

--- a/backend/database/data/user_permissions_mock.php
+++ b/backend/database/data/user_permissions_mock.php
@@ -19,14 +19,17 @@ return [
     ['user_id' => 'ed568442-ece5-4c90-97ca-12c8969bb3a2', 'permission_code' => 'audit.read'],
     ['user_id' => 'ed568442-ece5-4c90-97ca-12c8969bb3a2', 'permission_code' => 'users.search'],
     ['user_id' => 'ed568442-ece5-4c90-97ca-12c8969bb3a2', 'permission_code' => 'templates.review'],
+    ['user_id' => 'ed568442-ece5-4c90-97ca-12c8969bb3a2', 'permission_code' => 'documents.review'],
 
     // Secretaría: lectura plantillas, lectura/edición documentos, búsqueda usuarios
     ['user_id' => '2ead4bf3-574c-41b4-95ca-cac7daed0664', 'permission_code' => 'templates.read'],
+    ['user_id' => '2ead4bf3-574c-41b4-95ca-cac7daed0664', 'permission_code' => 'templates.update'],
     ['user_id' => '2ead4bf3-574c-41b4-95ca-cac7daed0664', 'permission_code' => 'templates.review'],
     ['user_id' => '2ead4bf3-574c-41b4-95ca-cac7daed0664', 'permission_code' => 'documents.read'],
     ['user_id' => '2ead4bf3-574c-41b4-95ca-cac7daed0664', 'permission_code' => 'documents.create'],
     ['user_id' => '2ead4bf3-574c-41b4-95ca-cac7daed0664', 'permission_code' => 'documents.update'],
     ['user_id' => '2ead4bf3-574c-41b4-95ca-cac7daed0664', 'permission_code' => 'users.search'],
+    ['user_id' => '2ead4bf3-574c-41b4-95ca-cac7daed0664', 'permission_code' => 'documents.review'],
 
     // Docentes por etapa: solo lectura catálogo que su JWT permita ver
     ['user_id' => 'cf8bb92a-0417-4a4c-918a-08dd3fd69165', 'permission_code' => 'templates.read'],

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -143,6 +143,7 @@ Route::prefix('v1')->group(function () {
         // Usuarios — búsqueda para asignación de revisores y compartición
         Route::get('/users', [UserController::class, 'index']);
         Route::get('/users/reviewer-candidates', [UserController::class, 'reviewerCandidates']);
+        Route::get('/users/document-reviewer-candidates', [UserController::class, 'documentReviewerCandidates']);
 
         // Dashboard (BFF)
         Route::get('/dashboard', [DashboardController::class, 'index']);

--- a/backend/tests/Feature/UsersSearchApiTest.php
+++ b/backend/tests/Feature/UsersSearchApiTest.php
@@ -98,4 +98,51 @@ class UsersSearchApiTest extends TestCase
         $this->assertIsArray($data);
         $this->assertNotEmpty($data);
     }
+
+    public function test_document_reviewer_candidates_returns_403_without_users_search_permission(): void
+    {
+        $userId = (string) Str::uuid();
+
+        $response = $this->getJson(
+            '/api/v1/users/document-reviewer-candidates',
+            $this->authHeaders($userId, ['documents.create']),
+        );
+
+        $response->assertForbidden();
+    }
+
+    public function test_document_reviewer_candidates_returns_users_with_documents_review_permission(): void
+    {
+        $callerId = (string) Str::uuid();
+        $reviewerId = (string) Str::uuid();
+
+        DB::table('users')->insert([
+            'id' => $reviewerId,
+            'name' => 'Doc Reviewer Candidate',
+            'email' => 'doc.reviewer.candidate@maya.test',
+            'department' => 'Secretaría',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $now = now();
+        DB::table('user_permissions')->insert([
+            'id' => (string) Str::uuid(),
+            'user_id' => $reviewerId,
+            'permission_code' => 'documents.review',
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+
+        $response = $this->getJson(
+            '/api/v1/users/document-reviewer-candidates?search=doc',
+            $this->authHeaders($callerId, ['users.search']),
+        );
+
+        $response->assertOk();
+        $data = $response->json('data');
+        $this->assertIsArray($data);
+        $ids = array_column($data, 'id');
+        $this->assertContains($reviewerId, $ids);
+    }
 }


### PR DESCRIPTION
- Se unifica el contrato de respuesta en mutaciones de documentos: submit, publish, reject y delegate devuelven payload construido con DocumentResource (en lugar de datos crudos del modelo).
- Se extrae la validación inline de delegate a un FormRequest dedicado (DelegateDocumentRequest).
- Se extrae la validación inline de aprobación/rechazo de revisiones a FormRequest dedicados (ApproveDocumentReviewRequest, RejectDocumentReviewRequest) y se actualiza ReviewController para usarlos.
- Se mueve el listado de versiones de documento fuera del controlador: DocumentVersionController::index delega en DocumentService::listDocumentVersions, ampliando el contrato del servicio según corresponda.
- Se mueven las comprobaciones de acceso a auditoría fuera de AuditLogController hacia AuditLogService (métodos de aserción por recurso), dejando el controlador sin consultas directas a modelos para ese flujo.
- Se elimina el acceso directo a BD desde UserController: la búsqueda general y los listados de candidatos pasan por UserDirectoryService + UserDirectoryRepository, con bindings registrados en AppServiceProvider.
- Se añade el endpoint GET /api/v1/users/document-reviewer-candidates (análogo al de plantillas) filtrando candidatos por permiso documents.review, y se registra el permiso en datos mock de permisos/asignaciones para entornos de demo/seed.
- Se amplian tests de API de búsqueda de usuarios para cubrir el nuevo endpoint de candidatos de revisores de documento.
- Se actualiza el registro de rutas en routes/api.php para exponer el nuevo endpoint.