### PR TITLE
Corregir reorder atómico de bloques de plantilla

### DIFF
--- a/backend/app/Http/Controllers/Api/TemplateBlockController.php
+++ b/backend/app/Http/Controllers/Api/TemplateBlockController.php
@@ -107,35 +107,8 @@ class TemplateBlockController extends Controller
      */
     public function reorder(ReorderTemplateBlocksRequest $request, string $template): \Illuminate\Http\Response
     {
-        $templateModel = Template::query()->findOrFail($template);
-        $this->authorize('update', $templateModel);
-
         $blockIds = $request->validated('block_ids');
-
-        $blocks = $this->blockService->findBlocksByIdsOrFail($blockIds);
-        $invalid = $blocks->first(fn ($block) => (string) $block->template_id !== $template);
-        if ($invalid !== null) {
-            abort(403, 'No tienes permiso para reordenar bloques fuera de la plantilla indicada.');
-        }
-
-        $userId = (string) Auth::id();
-
-        foreach ($blockIds as $index => $blockId) {
-            $this->blockService->update(
-                blockId: $blockId,
-                dto: new UpdateTemplateBlockDto(
-                    title:               null,
-                    set_title:           false,
-                    default_content:     null,
-                    set_default_content: false,
-                    sort_order:          $index + 1,
-                    set_sort_order:      true,
-                    block_state:         null,
-                    set_block_state:     false,
-                ),
-                userId: $userId,
-            );
-        }
+        $this->blockService->reorderForTemplate($template, $blockIds);
 
         return response()->noContent();
     }

--- a/backend/app/Http/Requests/TemplateBlocks/ReorderTemplateBlocksRequest.php
+++ b/backend/app/Http/Requests/TemplateBlocks/ReorderTemplateBlocksRequest.php
@@ -19,8 +19,8 @@ class ReorderTemplateBlocksRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'block_ids' => ['required', 'array'],
-            'block_ids.*' => ['required', 'string', 'uuid'],
+            'block_ids' => ['required', 'array', 'min:1'],
+            'block_ids.*' => ['required', 'string', 'uuid', 'distinct'],
         ];
     }
 }

--- a/backend/app/Repositories/Contracts/TemplateBlockRepositoryInterface.php
+++ b/backend/app/Repositories/Contracts/TemplateBlockRepositoryInterface.php
@@ -42,4 +42,11 @@ interface TemplateBlockRepositoryInterface
      * @return Collection<int, TemplateBlock>
      */
     public function bulkUpdate(array $ids, array $attributes): Collection;
+
+    /**
+     * Reordena bloques de una plantilla de forma atómica.
+     *
+     * @param  list<string>  $orderedIds
+     */
+    public function reorderForTemplate(string $templateId, array $orderedIds): void;
 }

--- a/backend/app/Repositories/Eloquent/TemplateBlockRepository.php
+++ b/backend/app/Repositories/Eloquent/TemplateBlockRepository.php
@@ -89,4 +89,17 @@ class TemplateBlockRepository implements TemplateBlockRepositoryInterface
 
         return TemplateBlock::whereIn('id', $ids)->get();
     }
+
+    /**
+     * @param  list<string>  $orderedIds
+     */
+    public function reorderForTemplate(string $templateId, array $orderedIds): void
+    {
+        foreach ($orderedIds as $index => $blockId) {
+            TemplateBlock::query()
+                ->where('id', $blockId)
+                ->where('template_id', $templateId)
+                ->update(['sort_order' => $index + 1]);
+        }
+    }
 }

--- a/backend/app/Services/Contracts/TemplateBlockServiceInterface.php
+++ b/backend/app/Services/Contracts/TemplateBlockServiceInterface.php
@@ -34,6 +34,13 @@ interface TemplateBlockServiceInterface
     public function findBlocksByIdsOrFail(array $ids): Collection;
 
     /**
+     * Reordena todos los bloques de una plantilla de forma atómica.
+     *
+     * @param  list<string>  $orderedBlockIds
+     */
+    public function reorderForTemplate(string $templateId, array $orderedBlockIds): void;
+
+    /**
      * Crea un nuevo bloque para una plantilla.
      * 
      * @param  string  $templateId

--- a/backend/app/Services/TemplateBlockService.php
+++ b/backend/app/Services/TemplateBlockService.php
@@ -13,6 +13,7 @@ use App\Services\Contracts\TemplateBlockServiceInterface;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\ValidationException;
 
 class TemplateBlockService implements TemplateBlockServiceInterface
@@ -72,6 +73,50 @@ class TemplateBlockService implements TemplateBlockServiceInterface
         }
 
         return $blocks;
+    }
+
+    /**
+     * @param  list<string>  $orderedBlockIds
+     */
+    public function reorderForTemplate(string $templateId, array $orderedBlockIds): void
+    {
+        if ($orderedBlockIds === []) {
+            throw ValidationException::withMessages([
+                'block_ids' => ['Debes enviar al menos un bloque para reordenar.'],
+            ]);
+        }
+
+        if (count($orderedBlockIds) !== count(array_unique($orderedBlockIds))) {
+            throw ValidationException::withMessages([
+                'block_ids' => ['La lista de bloques no puede contener IDs duplicados.'],
+            ]);
+        }
+
+        $template = $this->templateRepository->findOrFail($templateId);
+        $this->assertUserMayUpdateTemplate($template);
+
+        $currentBlocks = $this->blockRepository->allForTemplate($templateId);
+        $currentIds = $currentBlocks->pluck('id')->map(static fn ($id): string => (string) $id)->all();
+
+        if (count($currentIds) !== count($orderedBlockIds)) {
+            throw ValidationException::withMessages([
+                'block_ids' => ['Debes enviar todos los bloques de la plantilla.'],
+            ]);
+        }
+
+        sort($currentIds);
+        $incomingIds = $orderedBlockIds;
+        sort($incomingIds);
+
+        if ($currentIds !== $incomingIds) {
+            throw ValidationException::withMessages([
+                'block_ids' => ['La lista enviada no coincide con los bloques reales de la plantilla.'],
+            ]);
+        }
+
+        DB::transaction(function () use ($templateId, $orderedBlockIds): void {
+            $this->blockRepository->reorderForTemplate($templateId, $orderedBlockIds);
+        });
     }
 
     /**

--- a/backend/tests/Feature/TemplateBlocksApiTest.php
+++ b/backend/tests/Feature/TemplateBlocksApiTest.php
@@ -175,5 +175,56 @@ class TemplateBlocksApiTest extends TestCase
             'type' => 'paragraph',
         ], $readerHeaders)->assertForbidden();
     }
+
+    public function test_reorder_requires_all_template_blocks(): void
+    {
+        $userId = (string) Str::uuid();
+        $headers = $this->authHeaders($userId);
+        [$templateId, $firstBlockId] = $this->seedTemplateAndBlock($userId);
+        $secondBlockId = (string) Str::uuid();
+
+        TemplateBlock::query()->forceCreate([
+            'id' => $secondBlockId,
+            'template_id' => $templateId,
+            'title' => 'Bloque 2',
+            'default_content' => null,
+            'block_state' => 'editable',
+            'sort_order' => 1,
+        ]);
+
+        $this->patchJson("/api/v1/templates/{$templateId}/blocks/reorder", [
+            'block_ids' => [$firstBlockId],
+        ], $headers)
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors(['block_ids']);
+    }
+
+    public function test_reorder_updates_sort_order_atomically_for_full_set(): void
+    {
+        $userId = (string) Str::uuid();
+        $headers = $this->authHeaders($userId);
+        [$templateId, $firstBlockId] = $this->seedTemplateAndBlock($userId);
+        $secondBlockId = (string) Str::uuid();
+
+        TemplateBlock::query()->forceCreate([
+            'id' => $secondBlockId,
+            'template_id' => $templateId,
+            'title' => 'Bloque 2',
+            'default_content' => null,
+            'block_state' => 'editable',
+            'sort_order' => 1,
+        ]);
+
+        $this->patchJson("/api/v1/templates/{$templateId}/blocks/reorder", [
+            'block_ids' => [$secondBlockId, $firstBlockId],
+        ], $headers)->assertNoContent();
+
+        $orders = TemplateBlock::query()
+            ->where('template_id', $templateId)
+            ->pluck('sort_order', 'id');
+
+        $this->assertSame(1, $orders[$secondBlockId]);
+        $this->assertSame(2, $orders[$firstBlockId]);
+    }
 }
 


### PR DESCRIPTION
- Se movió la lógica de reordenamiento de bloques a la capa de servicio, manteniendo el controlador delgado.
- Se implementó validación estricta de `block_ids` (sin duplicados y con set completo de bloques de la plantilla).
- Se ejecuta el reorder dentro de una transacción para evitar estados parciales.
- Se añadieron pruebas de API para cubrir:
  - error por set incompleto,
  - caso exitoso de reorder.