### PR TITLE
feat(dashboard): add urgency and upcoming due metrics to dashboard cards

### DIFF
--- a/backend/app/Services/DashboardService.php
+++ b/backend/app/Services/DashboardService.php
@@ -25,10 +25,51 @@ class DashboardService implements DashboardServiceInterface
         $documentReviewInbox = $this->documentRepository->listPendingDocumentReviewInboxForUser($userId);
 
         return [
-            'stats' => [],
+            'stats' => [
+                'documents_critical' => $this->countCritical($documentReviewInbox->all()),
+                'documents_high' => $this->countHigh($documentReviewInbox->all()),
+                'templates_critical' => $this->countCritical($templateReviewInbox->all()),
+                'templates_high' => $this->countHigh($templateReviewInbox->all()),
+            ],
             'recent_documents' => [],
             'template_review_inbox' => $templateReviewInbox->all(),
             'document_review_inbox' => $documentReviewInbox->all(),
         ];
+    }
+
+    /**
+     * Cuenta las items con severidad crítica.
+     * 
+     * @param  list<array<string, mixed>>  $items
+     */
+    private function countCritical(array $items): int
+    {
+        return count(array_filter($items, static function (array $item): bool {
+            $days = $item['days_remaining'] ?? null;
+            if (! is_numeric($days)) {
+                return false;
+            }
+
+            return (float) $days <= 7.0;
+        }));
+    }
+
+    /**
+     * Cuenta las items con severidad alta.
+     * 
+     * @param  list<array<string, mixed>>  $items
+     */
+    private function countHigh(array $items): int
+    {
+        return count(array_filter($items, static function (array $item): bool {
+            $days = $item['days_remaining'] ?? null;
+            if (! is_numeric($days)) {
+                return false;
+            }
+
+            $value = (float) $days;
+
+            return $value > 7.0 && $value <= 30.0;
+        }));
     }
 }

--- a/backend/tests/Feature/DashboardApiTest.php
+++ b/backend/tests/Feature/DashboardApiTest.php
@@ -207,7 +207,10 @@ class DashboardApiTest extends TestCase
         $response = $this->getJson('/api/v1/dashboard', $headers);
  
         $response->assertOk()
-            ->assertJsonPath('data.stats', [])
+            ->assertJsonPath('data.stats.documents_critical', 0)
+            ->assertJsonPath('data.stats.documents_high', 0)
+            ->assertJsonPath('data.stats.templates_critical', 2)
+            ->assertJsonPath('data.stats.templates_high', 0)
             ->assertJsonPath('data.recent_documents', [])
             ->assertJsonCount(0, 'data.document_review_inbox')
             ->assertJsonCount(3, 'data.template_review_inbox')
@@ -295,6 +298,10 @@ class DashboardApiTest extends TestCase
 
         $r1 = $this->getJson('/api/v1/dashboard', $headers);
         $r1->assertOk()
+            ->assertJsonPath('data.stats.documents_critical', 1)
+            ->assertJsonPath('data.stats.documents_high', 0)
+            ->assertJsonPath('data.stats.templates_critical', 0)
+            ->assertJsonPath('data.stats.templates_high', 0)
             ->assertJsonCount(1, 'data.document_review_inbox')
             ->assertJsonPath('data.document_review_inbox.0.document_id', $documentId)
             ->assertJsonPath('data.document_review_inbox.0.review_stage', 1);
@@ -303,6 +310,10 @@ class DashboardApiTest extends TestCase
         $headersRev2 = $this->authHeaders($rev2);
         $r2 = $this->getJson('/api/v1/dashboard', $headersRev2);
         $r2->assertOk()
+            ->assertJsonPath('data.stats.documents_critical', 0)
+            ->assertJsonPath('data.stats.documents_high', 0)
+            ->assertJsonPath('data.stats.templates_critical', 0)
+            ->assertJsonPath('data.stats.templates_high', 0)
             ->assertJsonCount(0, 'data.document_review_inbox');
     }
 }

--- a/frontend/src/api/dashboard.ts
+++ b/frontend/src/api/dashboard.ts
@@ -27,7 +27,12 @@ export type DocumentReviewInboxItem = {
 };
 
 export type DashboardPayload = {
-  stats: unknown[];
+  stats: {
+    documents_critical: number;
+    documents_high: number;
+    templates_critical: number;
+    templates_high: number;
+  };
   recent_documents: unknown[];
   template_review_inbox: TemplateReviewInboxItem[];
   document_review_inbox: DocumentReviewInboxItem[];

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,6 +1,6 @@
 import { type MouseEvent, useEffect, useState } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
-import { fetchDashboard, type DocumentReviewInboxItem, type TemplateReviewInboxItem } from '../api/dashboard';
+import { fetchDashboard, type DashboardPayload, type DocumentReviewInboxItem, type TemplateReviewInboxItem } from '../api/dashboard';
 import { Button, Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../ui';
 
 /**
@@ -9,28 +9,28 @@ import { Button, Table, TableBody, TableCell, TableHead, TableHeader, TableRow }
  */
 const STATS = [
   {
-    key: 'total_documents',
-    label: 'Total documentos',
+    key: 'documents_critical',
+    label: 'Documentos urgentes (<= 7 días)',
     value: '—',
-    colorClass: 'bg-odoo-purple/10 dark:bg-odoo-purple/40 text-odoo-purple-d dark:text-white border-odoo-purple/20 dark:border-odoo-purple/50',
+    colorClass: 'bg-danger/10 dark:bg-danger/20 text-danger-dark dark:text-danger border-danger/20 dark:border-danger/40',
   },
   {
-    key: 'uploaded_today',
-    label: 'Subidos hoy',
+    key: 'documents_high',
+    label: 'Documentos próximos (8-30 días)',
     value: '—',
-    colorClass: 'bg-odoo-teal/10 dark:bg-odoo-teal/40 text-odoo-teal-d dark:text-white border-odoo-teal/20 dark:border-odoo-teal/50',
+    colorClass: 'bg-warning-light/20 dark:bg-warning-dark/40 text-warning-dark dark:text-white border-warning/20 dark:border-warning/50',
   },
   {
-    key: 'pending_reviews',
-    label: 'Pendientes revisión',
+    key: 'templates_critical',
+    label: 'Plantillas urgentes (<= 7 días)',
     value: '—',
-    colorClass: 'bg-warning-light dark:bg-warning-dark/50 text-warning-dark dark:text-white border-warning/20 dark:border-warning/50',
+    colorClass: 'bg-danger/10 dark:bg-danger/20 text-danger-dark dark:text-danger border-danger/20 dark:border-danger/40',
   },
   {
-    key: 'archived',
-    label: 'Archivados',
+    key: 'templates_high',
+    label: 'Plantillas próximas (8-30 días)',
     value: '—',
-    colorClass: 'bg-ui-body dark:bg-ui-dark-card text-text-secondary dark:text-text-dark-secondary border-ui-border dark:border-ui-dark-border',
+    colorClass: 'bg-warning-light/20 dark:bg-warning-dark/40 text-warning-dark dark:text-white border-warning/20 dark:border-warning/50',
   },
 ] as const;
 
@@ -43,6 +43,12 @@ export function DashboardPage() {
   const location = useLocation();
   const [templateInbox, setTemplateInbox] = useState<TemplateReviewInboxItem[]>([]);
   const [documentInbox, setDocumentInbox] = useState<DocumentReviewInboxItem[]>([]);
+  const [dashboardStats, setDashboardStats] = useState<DashboardPayload['stats']>({
+    documents_critical: 0,
+    documents_high: 0,
+    templates_critical: 0,
+    templates_high: 0,
+  });
   const [isLoadingInbox, setIsLoadingInbox] = useState(false);
   const [validationBanner, setValidationBanner] = useState<string | null>(null);
 
@@ -54,6 +60,7 @@ export function DashboardPage() {
         if (!isMounted) return;
         setTemplateInbox(data.template_review_inbox ?? []);
         setDocumentInbox(data.document_review_inbox ?? []);
+        setDashboardStats(data.stats);
       })
       .finally(() => {
         if (!isMounted) return;
@@ -74,6 +81,7 @@ export function DashboardPage() {
       .then((data) => {
         setTemplateInbox(data.template_review_inbox ?? []);
         setDocumentInbox(data.document_review_inbox ?? []);
+        setDashboardStats(data.stats);
       })
       .finally(() => {
         setIsLoadingInbox(false);
@@ -118,10 +126,8 @@ export function DashboardPage() {
   };
 
   const stats = STATS.map((stat) => {
-    if (stat.key === 'pending_reviews') {
-      return { ...stat, value: String(templateInbox.length + documentInbox.length) };
-    }
-    return stat;
+    const key = stat.key as keyof DashboardPayload['stats'];
+    return { ...stat, value: String(dashboardStats[key] ?? 0) };
   });
 
   return (
@@ -144,7 +150,7 @@ export function DashboardPage() {
         </div>
       )}
 
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
+      <div className="grid grid-cols-1 md:grid-cols-4 gap-4 mb-6">
         {stats.map((s) => (
           <div
             key={s.key}


### PR DESCRIPTION
- Se calculan en backend cuatro métricas para dashboard (documentos y plantillas urgentes/proximidad).
- Se expone el nuevo objeto stats en el payload del endpoint.
- Se tipa el contrato en frontend y se muestran las 4 tarjetas en una fila, con severidad visual consistente.
- Se actualizan pruebas de API para cubrir el nuevo contrato.