### PR TITLE
Feature/fix backend comments

### DIFF
--- a/backend/app/Http/Controllers/Api/CommentController.php
+++ b/backend/app/Http/Controllers/Api/CommentController.php
@@ -56,6 +56,9 @@ class CommentController extends Controller
             $doc = $this->documentService->findOrFail($documentId);
             $this->authorize('comment', $doc);
             $this->assertOptionalProcessContextMatches((string) $doc->process_id);
+            if ($this->isDocumentCommentsLocked($doc)) {
+                return response()->json(['data' => []]);
+            }
 
             return response()->json([
                 'data' => $this->commentService->listForResource(
@@ -107,6 +110,9 @@ class CommentController extends Controller
             $doc = $this->documentService->findOrFail($documentId);
             $this->authorize('comment', $doc);
             $this->assertOptionalProcessContextMatches((string) $doc->process_id);
+            if ($this->isDocumentCommentsLocked($doc)) {
+                abort(404);
+            }
 
             $comment = $this->commentService->createForResource(
                 commentableType: Document::class,
@@ -196,6 +202,9 @@ class CommentController extends Controller
             $model = $this->documentService->findOrFail((string) $comment->commentable_id);
             $this->authorize('comment', $model);
             $this->assertOptionalProcessContextMatches((string) $model->process_id);
+            if ($this->isDocumentCommentsLocked($model)) {
+                abort(404);
+            }
             return;
         }
 
@@ -207,5 +216,10 @@ class CommentController extends Controller
     private function isTemplateCommentsLocked(Template $template): bool
     {
         return $template->publishedVersions()->exists();
+    }
+
+    private function isDocumentCommentsLocked(Document $document): bool
+    {
+        return $document->versions()->exists();
     }
 }

--- a/backend/app/Http/Controllers/Api/CommentController.php
+++ b/backend/app/Http/Controllers/Api/CommentController.php
@@ -39,6 +39,9 @@ class CommentController extends Controller
             $model = $this->templateService->findOrFailWithoutCatalogScope($templateId);
             $this->authorize('comment', $model);
             $this->assertOptionalProcessContextMatches((string) $model->process_id);
+            if ($this->isTemplateCommentsLocked($model)) {
+                return response()->json(['data' => []]);
+            }
 
             return response()->json([
                 'data' => $this->commentService->listForResource(
@@ -82,6 +85,9 @@ class CommentController extends Controller
             $model = $this->templateService->findOrFailWithoutCatalogScope($templateId);
             $this->authorize('comment', $model);
             $this->assertOptionalProcessContextMatches((string) $model->process_id);
+            if ($this->isTemplateCommentsLocked($model)) {
+                abort(404);
+            }
 
             $comment = $this->commentService->createForResource(
                 commentableType: Template::class,
@@ -180,6 +186,9 @@ class CommentController extends Controller
             $model = $this->templateService->findOrFailWithoutCatalogScope((string) $comment->commentable_id);
             $this->authorize('comment', $model);
             $this->assertOptionalProcessContextMatches((string) $model->process_id);
+            if ($this->isTemplateCommentsLocked($model)) {
+                abort(404);
+            }
             return;
         }
 
@@ -193,5 +202,10 @@ class CommentController extends Controller
         if (! $isAllowed) {
             abort(422, 'Tipo de recurso de comentario no soportado.');
         }
+    }
+
+    private function isTemplateCommentsLocked(Template $template): bool
+    {
+        return $template->publishedVersions()->exists();
     }
 }

--- a/backend/app/Http/Controllers/Api/CommentController.php
+++ b/backend/app/Http/Controllers/Api/CommentController.php
@@ -37,20 +37,30 @@ class CommentController extends Controller
 
         if ($templateId) {
             $model = $this->templateService->findOrFailWithoutCatalogScope($templateId);
-            if (! Gate::forUser($request->user())->allows('view', $model)) {
-                abort(404);
-            }
+            $this->authorize('comment', $model);
             $this->assertOptionalProcessContextMatches((string) $model->process_id);
 
-            return response()->json(['data' => $this->commentService->listForTemplate($templateId)]);
+            return response()->json([
+                'data' => $this->commentService->listForResource(
+                    Template::class,
+                    (string) $model->id,
+                    (int) ($model->version ?? 1),
+                ),
+            ]);
         }
 
         if ($documentId) {
             $doc = $this->documentService->findOrFail($documentId);
-            $this->authorize('view', $doc);
+            $this->authorize('comment', $doc);
             $this->assertOptionalProcessContextMatches((string) $doc->process_id);
 
-            return response()->json(['data' => []]);
+            return response()->json([
+                'data' => $this->commentService->listForResource(
+                    Document::class,
+                    (string) $doc->id,
+                    (int) ($doc->current_version ?? 1),
+                ),
+            ]);
         }
 
         return response()->json(['data' => []]);
@@ -65,24 +75,45 @@ class CommentController extends Controller
         $documentId = $request->route('document');
         $blockableId = $request->blockableId();
         $parentId = $request->parentId();
+        $body = $request->commentBody();
+        $authorId = (string) Auth::id();
 
         if ($templateId) {
             $model = $this->templateService->findOrFailWithoutCatalogScope($templateId);
-            if (! Gate::forUser($request->user())->allows('view', $model)) {
-                abort(404);
-            }
+            $this->authorize('comment', $model);
             $this->assertOptionalProcessContextMatches((string) $model->process_id);
 
-            $comment = $this->commentService->createForTemplate($templateId, (string) Auth::id(), $validated);
+            $comment = $this->commentService->createForResource(
+                commentableType: Template::class,
+                commentableId: (string) $model->id,
+                commentableVersion: (int) ($model->version ?? 1),
+                blockableType: $blockableId !== null ? TemplateBlock::class : null,
+                blockableId: $blockableId,
+                parentId: $parentId,
+                authorId: $authorId,
+                body: $body,
+            );
+
             return response()->json(['data' => $comment], 201);
         }
 
         if ($documentId) {
             $doc = $this->documentService->findOrFail($documentId);
-            $this->authorize('view', $doc);
+            $this->authorize('comment', $doc);
             $this->assertOptionalProcessContextMatches((string) $doc->process_id);
 
-            return response()->json(['message' => 'Not implemented for documents'], 501);
+            $comment = $this->commentService->createForResource(
+                commentableType: Document::class,
+                commentableId: (string) $doc->id,
+                commentableVersion: (int) ($doc->current_version ?? 1),
+                blockableType: $blockableId !== null ? DocumentBlock::class : null,
+                blockableId: $blockableId,
+                parentId: $parentId,
+                authorId: $authorId,
+                body: $body,
+            );
+
+            return response()->json(['data' => $comment], 201);
         }
 
         return response()->json(['message' => 'Resource not found'], 404);
@@ -94,9 +125,7 @@ class CommentController extends Controller
     public function show(Request $request, string $comment): JsonResponse
     {
         $commentModel = $this->commentService->findOrFail($comment);
-        $document     = $this->documentService->findOrFail($commentModel->document_id);
-        $this->authorize('view', $document);
-        $this->assertOptionalProcessContextMatches((string) $document->process_id);
+        $this->authorizeViewForCommentable($commentModel);
 
         return response()->json(['data' => $commentModel]);
     }
@@ -107,9 +136,7 @@ class CommentController extends Controller
     public function update(Request $request, string $comment): JsonResponse
     {
         $commentModel = $this->commentService->findOrFail($comment);
-        $document     = $this->documentService->findOrFail($commentModel->document_id);
-        $this->authorize('view', $document);
-        $this->assertOptionalProcessContextMatches((string) $document->process_id);
+        $this->authorizeViewForCommentable($commentModel);
 
         return response()->json(['message' => 'Not implemented'], 501);
     }
@@ -120,9 +147,8 @@ class CommentController extends Controller
     public function destroy(Request $request, string $comment): JsonResponse
     {
         $commentModel = $this->commentService->findOrFail($comment);
-        $document     = $this->documentService->findOrFail($commentModel->document_id);
-        $this->authorize('view', $document);
-        $this->assertOptionalProcessContextMatches((string) $document->process_id);
+        $this->authorizeViewForCommentable($commentModel);
+        $this->authorize('delete', $commentModel);
 
         $this->commentService->delete($comment);
 
@@ -135,19 +161,7 @@ class CommentController extends Controller
     public function resolve(Request $request, string $comment): JsonResponse
     {
         $commentModel = $this->commentService->findOrFail($comment);
-        
-        // Autorización basada en el recurso al que pertenece el comentario
-        if ($commentModel->template_id) {
-            $model = $this->templateService->findOrFailWithoutCatalogScope((string) $commentModel->template_id);
-            if (! Gate::forUser($request->user())->allows('view', $model)) {
-                abort(404);
-            }
-            $this->assertOptionalProcessContextMatches((string) $model->process_id);
-        } elseif ($commentModel->document_id) {
-            $model = $this->documentService->findOrFail($commentModel->document_id);
-            $this->authorize('view', $model);
-            $this->assertOptionalProcessContextMatches((string) $model->process_id);
-        }
+        $this->authorizeViewForCommentable($commentModel);
 
         $resolved = $this->commentService->resolve($comment, (string) Auth::id());
         return response()->json(['data' => $resolved]);
@@ -156,7 +170,7 @@ class CommentController extends Controller
     /**
      * Autorizar vista para un comentario.
      */
-    private function authorizeViewForCommentable(Request $request, Comment $comment): void
+    private function authorizeViewForCommentable(Comment $comment): void
     {
         $commentableType = ltrim((string) $comment->commentable_type, '\\');
         $isAllowed = collect(Comment::ALLOWED_COMMENTABLE_TYPES)
@@ -165,12 +179,14 @@ class CommentController extends Controller
         if ($commentableType === Template::class || is_a($commentableType, Template::class, true)) {
             $model = $this->templateService->findOrFailWithoutCatalogScope((string) $comment->commentable_id);
             $this->authorize('comment', $model);
+            $this->assertOptionalProcessContextMatches((string) $model->process_id);
             return;
         }
 
         if ($commentableType === Document::class || is_a($commentableType, Document::class, true)) {
             $model = $this->documentService->findOrFail((string) $comment->commentable_id);
             $this->authorize('comment', $model);
+            $this->assertOptionalProcessContextMatches((string) $model->process_id);
             return;
         }
 

--- a/backend/app/Http/Requests/Comments/StoreCommentRequest.php
+++ b/backend/app/Http/Requests/Comments/StoreCommentRequest.php
@@ -19,13 +19,37 @@ class StoreCommentRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'body' => 'required|string',
+            'body' => 'nullable|string|max:5000',
             'parent_id' => 'nullable|uuid|exists:comments,id',
-            'blockable_id' => 'nullable|string',
-            // Compatibilidad temporal durante la unificación del frontend.
-            'template_block_id' => 'nullable|string',
-            'document_block_id' => 'nullable|string',
+            'blockable_id' => 'nullable|uuid',
         ];
+    }
+
+    /**
+     * Prepara la validación.
+     */
+    protected function prepareForValidation(): void
+    {
+        if ($this->has('body')) {
+            $this->merge([
+                'body' => trim((string) $this->input('body')),
+            ]);
+        }
+    }
+
+    /**
+     * Valida el bloque.
+     */
+    public function withValidator($validator): void
+    {
+        $validator->after(function ($validator): void {
+            if (
+                $this->filled('template_block_id')
+                || $this->filled('document_block_id')
+            ) {
+                $validator->errors()->add('blockable_id', 'Usa blockable_id como único identificador de bloque.');
+            }
+        });
     }
 
     /**
@@ -50,9 +74,7 @@ class StoreCommentRequest extends FormRequest
      */
     public function blockableId(): ?string
     {
-        $value = $this->validated('blockable_id')
-            ?? $this->validated('template_block_id')
-            ?? $this->validated('document_block_id');
+        $value = $this->validated('blockable_id');
 
         return is_string($value) && $value !== '' ? $value : null;
     }

--- a/backend/app/Services/AuditLogService.php
+++ b/backend/app/Services/AuditLogService.php
@@ -151,10 +151,15 @@ class AuditLogService implements AuditLogServiceInterface
     {
         $comment = Comment::query()
             ->withoutGlobalScopes(['user_access'])
-            ->with(['document', 'template'])
+            ->with('commentable')
             ->findOrFail($commentId);
 
-        $processId = $comment->document?->process_id ?? $comment->template?->process_id;
+        $commentable = $comment->commentable;
+        $processId = null;
+
+        if ($commentable instanceof Document || $commentable instanceof Template) {
+            $processId = $commentable->process_id;
+        }
 
         return is_string($processId) ? $processId : null;
     }

--- a/backend/tests/Feature/GlobalScopesIsolationTest.php
+++ b/backend/tests/Feature/GlobalScopesIsolationTest.php
@@ -7,6 +7,7 @@ use App\Models\Comment;
 use App\Models\Document;
 use App\Models\Team;
 use App\Models\Template;
+use App\Models\TemplateVersion;
 use Database\Seeders\PermissionsSeeder;
 use Maya\Auth\Contracts\JwksServiceInterface;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -369,6 +370,63 @@ class GlobalScopesIsolationTest extends TestCase
             ->assertJsonPath('data.0.id', $commentId)
             ->assertJsonPath('data.0.commentable_type', Document::class)
             ->assertJsonPath('data.0.commentable_id', $documentId);
+    }
+
+    public function test_template_comments_are_hidden_and_blocked_after_first_publish(): void
+    {
+        $userA = 'user-a-uuid-123';
+        [$templateId] = $this->seedTemplateAndDocument($userA);
+        $tokenA = $this->buildAuthTokensForUser($userA);
+        $commentId = (string) Str::uuid();
+
+        Comment::query()->forceCreate([
+            'id'                  => $commentId,
+            'commentable_type'    => Template::class,
+            'commentable_id'      => $templateId,
+            'commentable_version' => 1,
+            'blockable_type'      => null,
+            'blockable_id'        => null,
+            'parent_id'           => null,
+            'author_id'           => $userA,
+            'body'                => 'Comentario previo a publicar',
+            'resolved'            => false,
+            'resolved_by'         => null,
+            'resolved_at'         => null,
+        ]);
+
+        TemplateVersion::query()->forceCreate([
+            'id'             => (string) Str::uuid(),
+            'template_id'    => $templateId,
+            'version_number' => 1,
+            'blocks_snapshot'=> [],
+            'changelog'      => 'Publicacion inicial',
+            'published_by'   => $userA,
+            'published_at'   => now(),
+        ]);
+
+        $this->getJson(
+            "/api/v1/templates/{$templateId}/comments",
+            ['Authorization' => 'Bearer '.$tokenA],
+        )
+            ->assertOk()
+            ->assertJsonPath('data', []);
+
+        $this->getJson(
+            "/api/v1/comments/{$commentId}",
+            ['Authorization' => 'Bearer '.$tokenA],
+        )->assertNotFound();
+
+        $this->postJson(
+            "/api/v1/templates/{$templateId}/comments",
+            ['body' => 'Nuevo comentario bloqueado'],
+            ['Authorization' => 'Bearer '.$tokenA],
+        )->assertNotFound();
+
+        $this->patchJson(
+            "/api/v1/comments/{$commentId}/resolve",
+            [],
+            ['Authorization' => 'Bearer '.$tokenA],
+        )->assertNotFound();
     }
 
     /**

--- a/backend/tests/Feature/GlobalScopesIsolationTest.php
+++ b/backend/tests/Feature/GlobalScopesIsolationTest.php
@@ -308,6 +308,69 @@ class GlobalScopesIsolationTest extends TestCase
             ->assertJsonValidationErrors(['parent_id']);
     }
 
+    public function test_owner_can_create_and_resolve_template_comment_with_polymorphic_contract(): void
+    {
+        $userA = 'user-a-uuid-123';
+        [$templateId] = $this->seedTemplateAndDocument($userA);
+        $tokenA = $this->buildAuthTokensForUser($userA);
+
+        $create = $this->postJson(
+            "/api/v1/templates/{$templateId}/comments",
+            [
+                'body' => 'Comentario para validar flujo',
+            ],
+            ['Authorization' => 'Bearer '.$tokenA],
+        );
+
+        $create->assertCreated()
+            ->assertJsonPath('data.commentable_type', Template::class)
+            ->assertJsonPath('data.commentable_id', $templateId)
+            ->assertJsonPath('data.commentable_version', 1);
+
+        $commentId = (string) $create->json('data.id');
+
+        $this->patchJson(
+            "/api/v1/comments/{$commentId}/resolve",
+            [],
+            ['Authorization' => 'Bearer '.$tokenA],
+        )
+            ->assertOk()
+            ->assertJsonPath('data.resolved', true)
+            ->assertJsonPath('data.resolved_by', $userA);
+    }
+
+    public function test_owner_can_list_document_comments_with_polymorphic_contract(): void
+    {
+        $userA = 'user-a-uuid-123';
+        [, $documentId] = $this->seedTemplateAndDocument($userA);
+        $tokenA = $this->buildAuthTokensForUser($userA);
+        $commentId = (string) Str::uuid();
+
+        Comment::query()->forceCreate([
+            'id'                  => $commentId,
+            'commentable_type'    => Document::class,
+            'commentable_id'      => $documentId,
+            'commentable_version' => 1,
+            'blockable_type'      => null,
+            'blockable_id'        => null,
+            'parent_id'           => null,
+            'author_id'           => $userA,
+            'body'                => 'Comentario documento',
+            'resolved'            => false,
+            'resolved_by'         => null,
+            'resolved_at'         => null,
+        ]);
+
+        $this->getJson(
+            "/api/v1/documents/{$documentId}/comments",
+            ['Authorization' => 'Bearer '.$tokenA],
+        )
+            ->assertOk()
+            ->assertJsonPath('data.0.id', $commentId)
+            ->assertJsonPath('data.0.commentable_type', Document::class)
+            ->assertJsonPath('data.0.commentable_id', $documentId);
+    }
+
     /**
      * Test de Fail-Closed: Un usuario no autenticado no debe ver NADA
      */

--- a/backend/tests/Feature/GlobalScopesIsolationTest.php
+++ b/backend/tests/Feature/GlobalScopesIsolationTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use App\Enums\TemplateVisibilityLevel;
 use App\Models\Comment;
 use App\Models\Document;
+use App\Models\DocumentVersion;
 use App\Models\Team;
 use App\Models\Template;
 use App\Models\TemplateVersion;
@@ -427,6 +428,84 @@ class GlobalScopesIsolationTest extends TestCase
             [],
             ['Authorization' => 'Bearer '.$tokenA],
         )->assertNotFound();
+    }
+
+    public function test_document_comments_are_hidden_and_blocked_after_first_publish(): void
+    {
+        $userA = 'user-a-uuid-123';
+        [, $documentId] = $this->seedTemplateAndDocument($userA);
+        $tokenA = $this->buildAuthTokensForUser($userA);
+        $commentId = (string) Str::uuid();
+
+        Comment::query()->forceCreate([
+            'id'                  => $commentId,
+            'commentable_type'    => Document::class,
+            'commentable_id'      => $documentId,
+            'commentable_version' => 1,
+            'blockable_type'      => null,
+            'blockable_id'        => null,
+            'parent_id'           => null,
+            'author_id'           => $userA,
+            'body'                => 'Comentario previo a publicar doc',
+            'resolved'            => false,
+            'resolved_by'         => null,
+            'resolved_at'         => null,
+        ]);
+
+        DocumentVersion::query()->forceCreate([
+            'id'             => (string) Str::uuid(),
+            'document_id'    => $documentId,
+            'version_number' => 1,
+            'trigger_event'  => 'published',
+            'triggered_by'   => $userA,
+            'snapshot_data'  => ['document' => ['id' => $documentId]],
+            'notes'          => 'Publicacion inicial documento',
+            'is_immutable'   => true,
+            'created_at'     => now(),
+        ]);
+
+        $this->getJson(
+            "/api/v1/documents/{$documentId}/comments",
+            ['Authorization' => 'Bearer '.$tokenA],
+        )
+            ->assertOk()
+            ->assertJsonPath('data', []);
+
+        $this->getJson(
+            "/api/v1/comments/{$commentId}",
+            ['Authorization' => 'Bearer '.$tokenA],
+        )->assertNotFound();
+
+        $this->postJson(
+            "/api/v1/documents/{$documentId}/comments",
+            ['body' => 'Nuevo comentario bloqueado'],
+            ['Authorization' => 'Bearer '.$tokenA],
+        )->assertNotFound();
+
+        $this->patchJson(
+            "/api/v1/comments/{$commentId}/resolve",
+            [],
+            ['Authorization' => 'Bearer '.$tokenA],
+        )->assertNotFound();
+    }
+
+    public function test_comment_store_rejects_multiple_block_identifiers(): void
+    {
+        $userA = 'user-a-uuid-123';
+        [$templateId] = $this->seedTemplateAndDocument($userA);
+        $tokenA = $this->buildAuthTokensForUser($userA);
+
+        $this->postJson(
+            "/api/v1/templates/{$templateId}/comments",
+            [
+                'body' => 'Comentario invalido por bloque ambiguo',
+                'blockable_id' => (string) Str::uuid(),
+                'template_block_id' => (string) Str::uuid(),
+            ],
+            ['Authorization' => 'Bearer '.$tokenA],
+        )
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['blockable_id']);
     }
 
     /**


### PR DESCRIPTION
- Se consolidó el módulo de comentarios al contrato polimórfico real (commentable_type/commentable_id/commentable_version) y se eliminaron caminos legacy en el request (template_block_id / document_block_id), dejando blockable_id como identificador único de bloque.
- Se reforzó CommentController para aplicar reglas de visibilidad y acceso coherentes por recurso comentable, incluyendo bloqueo/ocultación de comentarios cuando la plantilla o el documento ya tienen publicación.
- Se añadieron/regresaron pruebas en GlobalScopesIsolationTest para cubrir los escenarios críticos de comentarios (resolución polimórfica, ocultación y bloqueo post-publicación).