### PR TITLE
fix(templates): show creator in reviewer candidate search

### DIFF
--- a/frontend/src/features/templates/components/TemplateWizard.tsx
+++ b/frontend/src/features/templates/components/TemplateWizard.tsx
@@ -419,7 +419,6 @@ export function TemplateWizard({ template: templateProp, initialTemplate, proces
         )}
         {step === 'users' && (
           <WizardStep3Users
-            templateCreatedBy={template?.created_by ?? null}
             validators={validators}
             onValidatorsChange={(v) => { setValidators(v); setUsersDirty(true); }}
             validationType={validationType}

--- a/frontend/src/features/templates/components/WizardStep3Users.tsx
+++ b/frontend/src/features/templates/components/WizardStep3Users.tsx
@@ -335,8 +335,6 @@ function UserAddPanel({
 // ── Main component ────────────────────────────────────────────────────────────
 
 type Props = {
-  /** Creador de la plantilla: no se ofrece en los listados de candidatos a validador (SoD). */
-  templateCreatedBy?: string | null;
   validators: ValidatorEntry[];
   onValidatorsChange: (validators: ValidatorEntry[]) => void;
   validationType: 'libre' | 'ordenada';
@@ -348,7 +346,6 @@ type Props = {
 };
 
 export function WizardStep3Users({
-  templateCreatedBy = null,
   validators,
   onValidatorsChange,
   validationType,
@@ -386,14 +383,13 @@ export function WizardStep3Users({
     const timer = setTimeout(() => {
       setSearchingTemplate(true);
       setSearchErrorTemplate(null);
-      const exclude = templateCreatedBy?.trim() || undefined;
-      searchTemplateReviewerCandidates(q, exclude)
+      searchTemplateReviewerCandidates(q)
         .then((res) => setSearchResultsTemplate(res.data))
         .catch(() => setSearchErrorTemplate('No se pudo completar la búsqueda. Inténtalo de nuevo.'))
         .finally(() => setSearchingTemplate(false));
     }, 300);
     return () => clearTimeout(timer);
-  }, [searchQueryTemplate, canSearchUsers, templateCreatedBy]);
+  }, [searchQueryTemplate, canSearchUsers]);
 
   useEffect(() => {
     if (!canSearchUsers) {
@@ -408,14 +404,13 @@ export function WizardStep3Users({
     const timer = setTimeout(() => {
       setSearchingDocument(true);
       setSearchErrorDocument(null);
-      const exclude = templateCreatedBy?.trim() || undefined;
-      searchDocumentReviewerCandidates(q, exclude)
+      searchDocumentReviewerCandidates(q)
         .then((res) => setSearchResultsDocument(res.data))
         .catch(() => setSearchErrorDocument('No se pudo completar la búsqueda. Inténtalo de nuevo.'))
         .finally(() => setSearchingDocument(false));
     }, 300);
     return () => clearTimeout(timer);
-  }, [searchQueryDocument, canSearchUsers, templateCreatedBy]);
+  }, [searchQueryDocument, canSearchUsers]);
 
   const handleAddToTemplate = (user: User) => {
     if (!validators.some((v) => v.userId === user.id)) {

--- a/frontend/src/features/templates/components/__tests__/WizardStep3Users.test.tsx
+++ b/frontend/src/features/templates/components/__tests__/WizardStep3Users.test.tsx
@@ -161,16 +161,15 @@ describe('WizardStep3Users', () => {
     ]);
   });
 
-  it('pasa exclude_user_id al buscar candidatos si hay templateCreatedBy', async () => {
-    renderWithProfile(
-      <WizardStep3Users {...defaultProps} validators={[]} templateCreatedBy="creator-uuid" />,
-    );
+  it('no excluye al creador: la búsqueda de candidatos no envía exclude_user_id', async () => {
+    renderWithProfile(<WizardStep3Users {...defaultProps} validators={[]} />);
 
     const searchInputs = screen.getAllByPlaceholderText('Filtrar usuarios...');
     fireEvent.change(searchInputs[0], { target: { value: 'ab' } });
 
     await waitFor(() => {
-      expect(searchTemplateReviewerCandidates).toHaveBeenCalledWith('ab', 'creator-uuid');
+      expect(searchTemplateReviewerCandidates).toHaveBeenCalledWith('ab', undefined);
+      expect(searchDocumentReviewerCandidates).toHaveBeenCalledWith('ab', undefined);
     });
   });
 });


### PR DESCRIPTION
Dejar de enviar exclude_user_id con el creador al buscar candidatos a revisor para alinear con la regla de negocio actual.