### PR TITLE
test: fix merge conflicts and process_id in feature API tests

### DIFF
--- a/backend/tests/Feature/DocumentShareApiTest.php
+++ b/backend/tests/Feature/DocumentShareApiTest.php
@@ -290,11 +290,7 @@ class DocumentShareApiTest extends TestCase
 
         $this->patchJson("/api/v1/documents/{$ctx['documentId']}", [
             'title' => 'Nuevo título',
-<<<<<<< HEAD
-            'delivery_deadline' => now()->addDays(7)->format('Y-m-d'),
-=======
             'delivery_deadline' => now()->addDay()->toDateString(),
->>>>>>> origin/feature/unic_components
         ], $hCollab)->assertForbidden();
     }
 

--- a/backend/tests/Feature/DocumentsModuleCreationApiTest.php
+++ b/backend/tests/Feature/DocumentsModuleCreationApiTest.php
@@ -237,12 +237,8 @@ class DocumentsModuleCreationApiTest extends TestCase
         $response = $this->postJson('/api/v1/documents/create-from-module', [
             'module_id' => 'MOD-1',
             'template_version_id' => $version->id,
-<<<<<<< HEAD
-            'delivery_deadline' => now()->addDays(7)->format('Y-m-d'),
-=======
             'delivery_deadline' => now()->addDay()->toDateString(),
             'process_id' => '00000000-0000-0000-0000-000000000001',
->>>>>>> origin/feature/unic_components
         ], $headers);
 
         $response->assertCreated()
@@ -287,12 +283,8 @@ class DocumentsModuleCreationApiTest extends TestCase
 
         $this->postJson('/api/v1/documents/create-from-module', [
             'module_id' => 'MOD-1',
-<<<<<<< HEAD
-            'delivery_deadline' => now()->addDays(7)->format('Y-m-d'),
-=======
             'delivery_deadline' => now()->addDay()->toDateString(),
             'process_id' => '00000000-0000-0000-0000-000000000001',
->>>>>>> origin/feature/unic_components
         ], $headers)
             ->assertUnprocessable()
             ->assertJsonValidationErrors(['template_version_id']);
@@ -315,12 +307,8 @@ class DocumentsModuleCreationApiTest extends TestCase
         $first = $this->postJson('/api/v1/documents/create-from-module', [
             'module_id' => 'MOD-1',
             'template_version_id' => $version->id,
-<<<<<<< HEAD
-            'delivery_deadline' => now()->addDays(7)->format('Y-m-d'),
-=======
             'delivery_deadline' => now()->addDay()->toDateString(),
             'process_id' => '00000000-0000-0000-0000-000000000001',
->>>>>>> origin/feature/unic_components
         ], $headers)->assertCreated();
 
         // Forzamos antigüedad para validar orden sin depender del reloj del sistema.
@@ -331,12 +319,8 @@ class DocumentsModuleCreationApiTest extends TestCase
         $second = $this->postJson('/api/v1/documents/create-from-module', [
             'module_id' => 'MOD-1',
             'template_version_id' => $version->id,
-<<<<<<< HEAD
-            'delivery_deadline' => now()->addDays(7)->format('Y-m-d'),
-=======
             'delivery_deadline' => now()->addDay()->toDateString(),
             'process_id' => '00000000-0000-0000-0000-000000000001',
->>>>>>> origin/feature/unic_components
         ], $headers)->assertCreated();
 
         $list = $this->getJson('/api/v1/documents', $headers)

--- a/backend/tests/Feature/GlobalScopesIsolationTest.php
+++ b/backend/tests/Feature/GlobalScopesIsolationTest.php
@@ -381,7 +381,10 @@ class GlobalScopesIsolationTest extends TestCase
     {
         $userA = 'user-a-uuid-123';
         [$templateId] = $this->seedTemplateAndDocument($userA);
-        $this->assertSame('draft', (string) Template::query()->whereKey($templateId)->value('status'));
+        $this->assertSame(
+            'draft',
+            (string) Template::withoutGlobalScopes()->whereKey($templateId)->value('status'),
+        );
         $tokenA = $this->buildAuthTokensForUser($userA);
         $commentId = (string) Str::uuid();
 
@@ -457,7 +460,7 @@ class GlobalScopesIsolationTest extends TestCase
             'resolved_at'         => null,
         ]);
 
-        Template::query()->whereKey($templateId)->update(['status' => 'published']);
+        Template::withoutGlobalScopes()->whereKey($templateId)->update(['status' => 'published']);
 
         $this->getJson(
             "/api/v1/templates/{$templateId}/comments",
@@ -482,7 +485,10 @@ class GlobalScopesIsolationTest extends TestCase
     {
         $userA = 'user-a-uuid-123';
         [, $documentId] = $this->seedTemplateAndDocument($userA);
-        $this->assertSame('draft', (string) Document::query()->whereKey($documentId)->value('status'));
+        $this->assertSame(
+            'draft',
+            (string) Document::withoutGlobalScopes()->whereKey($documentId)->value('status'),
+        );
         $tokenA = $this->buildAuthTokensForUser($userA);
         $commentId = (string) Str::uuid();
 
@@ -560,7 +566,7 @@ class GlobalScopesIsolationTest extends TestCase
             'resolved_at'         => null,
         ]);
 
-        Document::query()->whereKey($documentId)->update(['status' => 'published']);
+        Document::withoutGlobalScopes()->whereKey($documentId)->update(['status' => 'published']);
 
         $this->getJson(
             "/api/v1/documents/{$documentId}/comments",

--- a/backend/tests/Feature/TemplatesApiTest.php
+++ b/backend/tests/Feature/TemplatesApiTest.php
@@ -180,12 +180,8 @@ class TemplatesApiTest extends TestCase
         $create = $this->postJson('/api/v1/templates', [
             'name' => 'Plantilla personal',
             'description' => 'Desc',
-<<<<<<< HEAD
-            'delivery_deadline' => now()->addDays(7)->format('Y-m-d'),
-=======
             'delivery_deadline' => now()->addDay()->toDateString(),
             'process_id' => '00000000-0000-0000-0000-000000000001',
->>>>>>> origin/feature/unic_components
         ], $headers);
 
         $create->assertCreated()
@@ -223,12 +219,8 @@ class TemplatesApiTest extends TestCase
         $this->postJson('/api/v1/templates', [
             'name' => 'Global prohibida',
             'visibility_level' => TemplateVisibilityLevel::Global->value,
-<<<<<<< HEAD
-            'delivery_deadline' => now()->addDays(7)->format('Y-m-d'),
-=======
             'delivery_deadline' => now()->addDay()->toDateString(),
             'process_id' => '00000000-0000-0000-0000-000000000001',
->>>>>>> origin/feature/unic_components
         ], $headers)->assertForbidden();
     }
 
@@ -241,12 +233,8 @@ class TemplatesApiTest extends TestCase
         $this->postJson('/api/v1/templates', [
             'name' => 'Plantilla global',
             'visibility_level' => TemplateVisibilityLevel::Global->value,
-<<<<<<< HEAD
-            'delivery_deadline' => now()->addDays(7)->format('Y-m-d'),
-=======
             'delivery_deadline' => now()->addDay()->toDateString(),
             'process_id' => '00000000-0000-0000-0000-000000000001',
->>>>>>> origin/feature/unic_components
         ], $headers)
             ->assertCreated()
             ->assertJsonPath('data.visibility_level', TemplateVisibilityLevel::Global->value);
@@ -413,12 +401,8 @@ class TemplatesApiTest extends TestCase
         $this->postJson('/api/v1/templates', [
             'name' => 'Sin estudio',
             'visibility_level' => TemplateVisibilityLevel::Study->value,
-<<<<<<< HEAD
-            'delivery_deadline' => now()->addDays(7)->format('Y-m-d'),
-=======
             'delivery_deadline' => now()->addDay()->toDateString(),
             'process_id' => '00000000-0000-0000-0000-000000000001',
->>>>>>> origin/feature/unic_components
         ], $headers)->assertUnprocessable();
     }
 
@@ -610,12 +594,8 @@ class TemplatesApiTest extends TestCase
             'name' => 'Por grupo',
             'visibility_level' => TemplateVisibilityLevel::Team->value,
             'team_id' => $gid,
-<<<<<<< HEAD
-            'delivery_deadline' => now()->addDays(7)->format('Y-m-d'),
-=======
             'delivery_deadline' => now()->addDay()->toDateString(),
             'process_id' => '00000000-0000-0000-0000-000000000001',
->>>>>>> origin/feature/unic_components
         ], $headers)->assertCreated()->assertJsonPath('data.team_id', $gid);
     }
 


### PR DESCRIPTION
- Elimina restos de merge y unifica fechas límite en pruebas
- Añade process_id en creación de plantillas y create-from-module
- En tests de comentarios, consultas/updates de estado sin global scope