### PR TITLE
Feature/backend docs plantillas per page

### DIFF
--- a/backend/app/Http/Controllers/Api/TemplateController.php
+++ b/backend/app/Http/Controllers/Api/TemplateController.php
@@ -38,21 +38,18 @@ class TemplateController extends Controller
     ) {}
 
     /**
-     * Listar plantillas (filtros en query; paginación por defecto 10, máx. 100).
+     * Listar plantillas (filtros en query; sin paginación en servidor, como documentos).
      */
     public function index(IndexTemplateRequest $request): AnonymousResourceCollection
     {
-        $paginator = $this->templateService->paginateFiltered(
-            $request->toFilterDto(),
-            $request->perPage(),
-        );
+        $templates = $this->templateService->listFiltered($request->toFilterDto());
 
-        $this->apiTeamEmbedService->embedOnTemplatePaginator(
-            $paginator,
+        $this->apiTeamEmbedService->embedOnTemplates(
+            $templates,
             (string) $request->user()->getAuthIdentifier(),
         );
 
-        return TemplateResource::collection($paginator);
+        return TemplateResource::collection($templates);
     }
 
     /**

--- a/backend/app/Http/Requests/Templates/IndexTemplateRequest.php
+++ b/backend/app/Http/Requests/Templates/IndexTemplateRequest.php
@@ -38,16 +38,7 @@ class IndexTemplateRequest extends FormRequest
             'author_name'      => ['sometimes', 'nullable', 'string', 'max:255'],
             'delivery_deadline' => ['sometimes', 'nullable', 'date'],
             'process_id'       => ['sometimes', 'nullable', 'uuid', 'exists:processes,id'],
-            'per_page'         => ['sometimes', 'integer', 'min:1', 'max:20'],
         ];
-    }
-
-    /**
-     * Obtiene el número de plantillas por página, por defecto 10.
-     */
-    public function perPage(): int
-    {
-        return min(max((int) $this->query('per_page', 10), 1), 100);
     }
 
     /**

--- a/backend/app/Repositories/Contracts/TemplateRepositoryInterface.php
+++ b/backend/app/Repositories/Contracts/TemplateRepositoryInterface.php
@@ -4,7 +4,7 @@ namespace App\Repositories\Contracts;
 
 use App\DTOs\Templates\FilterTemplatesDto;
 use App\Models\Template;
-use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Collection;
 
 interface TemplateRepositoryInterface
 {
@@ -25,9 +25,11 @@ interface TemplateRepositoryInterface
     public function findOrFailWithoutCatalogScope(string $id): Template;
 
     /**
-     * Listado paginado con filtros (sin cargar bloques).
+     * Listado con filtros (sin cargar bloques); sin paginación en servidor.
+     *
+     * @return Collection<int, Template>
      */
-    public function paginateFiltered(FilterTemplatesDto $filters, int $perPage = 10): LengthAwarePaginator;
+    public function listFiltered(FilterTemplatesDto $filters): Collection;
 
     /**
      * Crea una plantilla con los atributos dados.

--- a/backend/app/Repositories/Eloquent/TemplateRepository.php
+++ b/backend/app/Repositories/Eloquent/TemplateRepository.php
@@ -6,7 +6,7 @@ use App\DTOs\Templates\FilterTemplatesDto;
 use App\Models\Template;
 use App\Models\TemplateBlock;
 use App\Repositories\Contracts\TemplateRepositoryInterface;
-use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
@@ -42,9 +42,11 @@ class TemplateRepository implements TemplateRepositoryInterface
     }
 
     /**
-     * Listado paginado con filtros (sin cargar bloques).
+     * Listado con filtros (sin cargar bloques); sin paginación en servidor.
+     *
+     * @return EloquentCollection<int, Template>
      */
-    public function paginateFiltered(FilterTemplatesDto $filters, int $perPage = 10): LengthAwarePaginator
+    public function listFiltered(FilterTemplatesDto $filters): Collection
     {
         $query = Template::query()
             ->select([
@@ -97,13 +99,16 @@ class TemplateRepository implements TemplateRepositoryInterface
             $query->where('templates.process_id', $filters->processId);
         }
 
-        return $query
+        /** @var EloquentCollection<int, Template> $rows */
+        $rows = $query
             ->withExists([
                 'comments as has_review_comments' => fn ($q) => $q->where('resolved', false),
             ])
             ->with('reviewers')
             ->orderByDesc('templates.updated_at')
-            ->paginate($perPage);
+            ->get();
+
+        return $rows;
     }
 
     /**

--- a/backend/app/Services/ApiTeamEmbedService.php
+++ b/backend/app/Services/ApiTeamEmbedService.php
@@ -7,7 +7,6 @@ use App\Models\Template;
 use App\Services\Contracts\ApiTeamEmbedServiceInterface;
 use App\Services\Contracts\TeamReadServiceInterface;
 use App\Support\ApiEmbeddedTeamResponse;
-use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 
 class ApiTeamEmbedService implements ApiTeamEmbedServiceInterface
 {
@@ -37,14 +36,6 @@ class ApiTeamEmbedService implements ApiTeamEmbedServiceInterface
         foreach ($templates as $template) {
             $this->embedOnTemplate($template, $viewerUserId);
         }
-    }
-
-    /**
-     * Resuelve el equipo visible para las plantillas paginadas y lo deja listo para {@see \App\Http\Resources\TemplateResource}.
-     */
-    public function embedOnTemplatePaginator(LengthAwarePaginator $paginator, string $viewerUserId): void
-    {
-        $this->embedOnTemplates($paginator->items(), $viewerUserId);
     }
 
     /**

--- a/backend/app/Services/Contracts/ApiTeamEmbedServiceInterface.php
+++ b/backend/app/Services/Contracts/ApiTeamEmbedServiceInterface.php
@@ -4,7 +4,6 @@ namespace App\Services\Contracts;
 
 use App\Models\Document;
 use App\Models\Template;
-use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 
 interface ApiTeamEmbedServiceInterface
 {
@@ -17,11 +16,6 @@ interface ApiTeamEmbedServiceInterface
      * Resuelve el equipo visible para las plantillas y lo deja listo para {@see \App\Http\Resources\TemplateResource}.
      */
     public function embedOnTemplates(iterable $templates, string $viewerUserId): void;
-
-    /**
-     * Resuelve el equipo visible para las plantillas paginadas y lo deja listo para {@see \App\Http\Resources\TemplateResource}.
-     */
-    public function embedOnTemplatePaginator(LengthAwarePaginator $paginator, string $viewerUserId): void;
 
     /**
      * Resuelve el equipo según la plantilla del documento y lo deja listo para {@see \App\Http\Resources\DocumentResource}.

--- a/backend/app/Services/Contracts/TemplateServiceInterface.php
+++ b/backend/app/Services/Contracts/TemplateServiceInterface.php
@@ -8,7 +8,6 @@ use App\DTOs\Templates\SyncUsersDto;
 use App\DTOs\Templates\UpdateTemplateDto;
 use App\Models\Template;
 use App\Models\TemplateVersion;
-use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Collection;
 
 interface TemplateServiceInterface
@@ -60,9 +59,11 @@ interface TemplateServiceInterface
     public function listPublishedVersions(string $templateId): Collection;
 
     /**
-     * Listado paginado con filtros (10 ítems por defecto; máximo 100 según IndexTemplateRequest).
+     * Listado con filtros visible para el usuario (sin paginación en servidor).
+     *
+     * @return Collection<int, Template>
      */
-    public function paginateFiltered(FilterTemplatesDto $filters, int $perPage = 10): LengthAwarePaginator;
+    public function listFiltered(FilterTemplatesDto $filters): Collection;
 
     /**
      * Crea una plantilla con los atributos dados.

--- a/backend/app/Services/TemplateService.php
+++ b/backend/app/Services/TemplateService.php
@@ -12,7 +12,6 @@ use App\Models\TemplateVersion;
 use App\Repositories\Contracts\TemplateRepositoryInterface;
 use App\Repositories\Contracts\TemplateVersionRepositoryInterface;
 use App\Services\Contracts\TemplateServiceInterface;
-use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
 use RuntimeException;
@@ -119,11 +118,11 @@ class TemplateService implements TemplateServiceInterface
     }
 
     /**
-     * Listado paginado con filtros (10 ítems por defecto en request).
+     * Listado con filtros (sin paginación en servidor; el front pagina en cliente).
      */
-    public function paginateFiltered(FilterTemplatesDto $filters, int $perPage = 10): LengthAwarePaginator
+    public function listFiltered(FilterTemplatesDto $filters): Collection
     {
-        return $this->templateRepository->paginateFiltered($filters, $perPage);
+        return $this->templateRepository->listFiltered($filters);
     }
 
     /**

--- a/backend/tests/Feature/TemplatesApiTest.php
+++ b/backend/tests/Feature/TemplatesApiTest.php
@@ -267,7 +267,7 @@ class TemplatesApiTest extends TestCase
             ->assertJsonValidationErrors(['process_id']);
     }
 
-    public function test_index_filters_by_status_and_visibility_and_respects_per_page_max(): void
+    public function test_index_filters_by_status_and_visibility(): void
     {
         $userId = (string) Str::uuid();
         $headers = $this->authHeaders($userId);
@@ -318,9 +318,6 @@ class TemplatesApiTest extends TestCase
             ->assertOk()
             ->assertJsonCount(1, 'data')
             ->assertJsonPath('data.0.id', $t2);
-
-        $this->getJson('/api/v1/templates?per_page=101', $headers)
-            ->assertUnprocessable();
     }
 
     public function test_index_includes_has_review_comments_flag(): void

--- a/frontend/src/api/templates.ts
+++ b/frontend/src/api/templates.ts
@@ -41,11 +41,6 @@ export type UpdateTemplatePayload = {
 
 function buildListQuery(filters: TemplateListFilters): string {
   const q = new URLSearchParams();
-  const perPage = filters.per_page ?? 20;
-  q.set('per_page', String(Math.min(Math.max(perPage, 1), 20)));
-  if (filters.page != null && filters.page > 0) {
-    q.set('page', String(filters.page));
-  }
   if (filters.visibility_level) {
     q.set('visibility_level', filters.visibility_level);
   }

--- a/frontend/src/api/templates.ts
+++ b/frontend/src/api/templates.ts
@@ -20,7 +20,6 @@ export type CreateTemplatePayload = {
   study_id?: string | null;
   module_id?: string | null;
   team_id?: string | null;
-  process_id: string;
   review_stages?: number;
   review_mode?: ReviewMode;
 };

--- a/frontend/src/features/templates/clientTemplatePagination.ts
+++ b/frontend/src/features/templates/clientTemplatePagination.ts
@@ -1,0 +1,20 @@
+import type { TemplatesListMeta } from '../../types/templates';
+
+/** Paginación en cliente sobre la lista completa devuelta por la API. */
+export function sliceTemplatesPage<T>(items: T[], page: number, perPage: number): T[] {
+  const p = Math.max(1, page);
+  const pp = Math.max(1, perPage);
+  return items.slice((p - 1) * pp, p * pp);
+}
+
+export function buildTemplatesListMeta(total: number, page: number, perPage: number): TemplatesListMeta {
+  const pp = Math.max(1, perPage);
+  const lastPage = Math.max(1, Math.ceil(total / pp));
+  const current = Math.min(Math.max(1, page), lastPage);
+  return {
+    current_page: current,
+    last_page: lastPage,
+    per_page: pp,
+    total,
+  };
+}

--- a/frontend/src/features/templates/hooks/useTemplates.ts
+++ b/frontend/src/features/templates/hooks/useTemplates.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { ApiHttpError } from '../../../api/http';
 import {
   cloneTemplate as cloneTemplateRequest,
@@ -9,6 +9,7 @@ import {
 } from '../../../api/templates';
 import type { CreateTemplatePayload, UpdateTemplatePayload } from '../../../api/templates';
 import type { Template, TemplateListFilters, TemplatesListMeta } from '../../../types/templates';
+import { buildTemplatesListMeta, sliceTemplatesPage } from '../clientTemplatePagination';
 
 function formatActionError(err: unknown): string {
   if (err instanceof ApiHttpError) {
@@ -33,39 +34,65 @@ function formatActionError(err: unknown): string {
 const DEFAULT_PER_PAGE = 20;
 
 /**
- * Listado y mutaciones de plantillas normativas (filtros + paginación acotada a 20).
+ * Listado y mutaciones de plantillas normativas.
+ * La API devuelve el catálogo completo (filtrado); la paginación es en cliente.
  *
  * @param processId Si se aporta, se aplica como filtro `process_id` permanente
  *   (no se expone en el panel de filtros — viene del contexto de la URL).
  */
 export function useTemplates(processId?: string) {
-  const [templates, setTemplates] = useState<Template[]>([]);
-  const [meta, setMeta] = useState<TemplatesListMeta | null>(null);
+  const [fullList, setFullList] = useState<Template[]>([]);
   const [filters, setFilters] = useState<TemplateListFilters>({ per_page: DEFAULT_PER_PAGE });
   const [loading, setLoading] = useState(true);
   const [listError, setListError] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
   const [actionInfo, setActionInfo] = useState<string | null>(null);
 
+  const filtersForApi = useMemo(() => {
+    const { page: _page, per_page: _perPage, ...rest } = filters;
+    return {
+      ...rest,
+      ...(processId ? { process_id: processId } : {}),
+    };
+  }, [
+    filters.visibility_level,
+    filters.status,
+    filters.study_type_id,
+    filters.study_id,
+    filters.module_id,
+    filters.team_id,
+    filters.author_name,
+    filters.delivery_deadline,
+    filters.process_id,
+    processId,
+  ]);
+
+  const page = filters.page ?? 1;
+  const perPage = filters.per_page ?? DEFAULT_PER_PAGE;
+
+  const templates = useMemo(
+    () => sliceTemplatesPage(fullList, page, perPage),
+    [fullList, page, perPage],
+  );
+
+  const meta = useMemo(
+    () => buildTemplatesListMeta(fullList.length, page, perPage),
+    [fullList.length, page, perPage],
+  );
+
   const load = useCallback(async () => {
     try {
       setListError(null);
       setLoading(true);
-      const res = await fetchTemplates({
-        ...filters,
-        per_page: filters.per_page ?? DEFAULT_PER_PAGE,
-        ...(processId ? { process_id: processId } : {}),
-      });
-      setTemplates(res.data);
-      setMeta(res.meta);
+      const res = await fetchTemplates(filtersForApi);
+      setFullList(res.data);
     } catch (e) {
       setListError(formatActionError(e));
-      setTemplates([]);
-      setMeta(null);
+      setFullList([]);
     } finally {
       setLoading(false);
     }
-  }, [filters, processId]);
+  }, [filtersForApi]);
 
   useEffect(() => {
     void load();

--- a/frontend/src/pages/NuevaProgramacionSelectorPage.tsx
+++ b/frontend/src/pages/NuevaProgramacionSelectorPage.tsx
@@ -1,8 +1,12 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { fetchTemplates } from '../api/templates';
+import {
+  buildTemplatesListMeta,
+  sliceTemplatesPage,
+} from '../features/templates/clientTemplatePagination';
 import { VISIBILITY_OPTIONS, visibilityLabel } from '../features/templates/constants';
-import type { Template, TemplateListFilters, TemplatesListMeta, TemplateVisibilityLevel } from '../types/templates';
+import type { Template, TemplateListFilters, TemplateVisibilityLevel } from '../types/templates';
 import {
   DataTable,
   DatePicker,
@@ -79,8 +83,7 @@ export function NuevaProgramacionSelectorPage() {
     status: 'published',
     per_page: pageSize,
   });
-  const [templates, setTemplates] = useState<Template[]>([]);
-  const [meta, setMeta] = useState<TemplatesListMeta | null>(null);
+  const [allTemplates, setAllTemplates] = useState<Template[]>([]);
   const [loading, setLoading] = useState(true);
   const [listError, setListError] = useState<string | null>(null);
   const [authorInput, setAuthorInput] = useState('');
@@ -93,19 +96,19 @@ export function NuevaProgramacionSelectorPage() {
       setListError(null);
       try {
         const res = await fetchTemplates({
-          ...filters,
           status: 'published',
+          visibility_level: filters.visibility_level,
+          author_name: filters.author_name,
+          delivery_deadline: filters.delivery_deadline,
           ...(selectedProcessId ? { process_id: selectedProcessId } : {}),
         });
         if (!cancelled) {
-          setTemplates(res.data);
-          setMeta(res.meta);
+          setAllTemplates(res.data);
         }
       } catch (e) {
         if (!cancelled) {
           setListError(e instanceof Error ? e.message : 'No se pudieron cargar las plantillas.');
-          setTemplates([]);
-          setMeta(null);
+          setAllTemplates([]);
         }
       } finally {
         if (!cancelled) setLoading(false);
@@ -113,7 +116,25 @@ export function NuevaProgramacionSelectorPage() {
     };
     void load();
     return () => { cancelled = true; };
-  }, [filters, selectedProcessId]);
+  }, [
+    filters.visibility_level,
+    filters.author_name,
+    filters.delivery_deadline,
+    selectedProcessId,
+  ]);
+
+  const listPage = filters.page ?? 1;
+  const listPerPage = filters.per_page ?? pageSize;
+
+  const templates = useMemo(
+    () => sliceTemplatesPage(allTemplates, listPage, listPerPage),
+    [allTemplates, listPage, listPerPage],
+  );
+
+  const meta = useMemo(
+    () => buildTemplatesListMeta(allTemplates.length, listPage, listPerPage),
+    [allTemplates.length, listPage, listPerPage],
+  );
 
   useEffect(() => {
     if (filters.per_page !== pageSize) {

--- a/frontend/src/types/templates.ts
+++ b/frontend/src/types/templates.ts
@@ -49,9 +49,10 @@ export type TemplatesListMeta = {
   total: number;
 };
 
+/** El backend devuelve solo `data`; la `meta` de paginación se calcula en cliente. */
 export type TemplatesListResponse = {
   data: Template[];
-  meta: TemplatesListMeta;
+  meta?: TemplatesListMeta;
 };
 
 export type TemplateListFilters = {


### PR DESCRIPTION
- El endpoint GET /api/v1/templates deja de paginar en servidor y devuelve todo el conjunto de plantillas que el usuario puede ver según filtros y permisos (igual filosofía que el listado de documentos).
- Se eliminan per_page y la lógica asociada del IndexTemplateRequest.
- El repositorio/servicio exponen listFiltered en lugar de paginateFiltered.
- Se simplifica ApiTeamEmbedService eliminando embedOnTemplatePaginator (se usa embedOnTemplates sobre la colección).
- En el frontend, la paginación (tamaño de página, página actual y texto tipo “X–Y de Z”) se calcula en cliente con utilidades compartidas y ajustes en useTemplates y NuevaProgramacionSelectorPage.
- Los tests de listado de plantillas se actualizan (ya no se valida el rechazo de per_page excesivo).