### PR TITLE
Feature/process parent

### DIFF
--- a/backend/app/Models/Process.php
+++ b/backend/app/Models/Process.php
@@ -19,7 +19,7 @@ class Process extends Model
         'name',
         'alias',
         'description',
-        'parent_id',
+        'process_parent_id',
     ];
 
     public function templates(): HasMany
@@ -34,11 +34,11 @@ class Process extends Model
 
     public function parent(): BelongsTo
     {
-        return $this->belongsTo(self::class, 'parent_id');
+        return $this->belongsTo(self::class, 'process_parent_id');
     }
 
     public function children(): HasMany
     {
-        return $this->hasMany(self::class, 'parent_id')->orderBy('code');
+        return $this->hasMany(self::class, 'process_parent_id')->orderBy('code');
     }
 }

--- a/backend/app/Repositories/Contracts/ProcessRepositoryInterface.php
+++ b/backend/app/Repositories/Contracts/ProcessRepositoryInterface.php
@@ -7,7 +7,7 @@ interface ProcessRepositoryInterface
     /**
      * Lista plana de procesos ordenados por código (incluye top-level y sub-procesos).
      *
-     * @return list<array{id: string, code: string, name: string, alias: string, description: string|null, parent_id: string|null}>
+     * @return list<array{id: string, code: string, name: string, alias: string, description: string|null, process_parent_id: string|null}>
      */
     public function all(): array;
 }

--- a/backend/app/Repositories/Eloquent/ProcessRepository.php
+++ b/backend/app/Repositories/Eloquent/ProcessRepository.php
@@ -12,23 +12,23 @@ class ProcessRepository implements ProcessRepositoryInterface
      *
      * El orden por código garantiza que los sub-procesos aparezcan justo
      * después de su padre (PE01, PE01.01, PE01.02, PE02, ...). El frontend
-     * agrupa por `parent_id` para mostrar la jerarquía.
+     * agrupa por `process_parent_id` para mostrar la jerarquía.
      *
-     * @return list<array{id: string, code: string, name: string, alias: string, description: string|null, parent_id: string|null}>
+     * @return list<array{id: string, code: string, name: string, alias: string, description: string|null, process_parent_id: string|null}>
      */
     public function all(): array
     {
         return Process::query()
-            ->select(['id', 'code', 'name', 'alias', 'description', 'parent_id'])
+            ->select(['id', 'code', 'name', 'alias', 'description', 'process_parent_id'])
             ->orderBy('code')
             ->get()
             ->map(static fn (Process $process): array => [
-                'id'          => (string) $process->id,
-                'code'        => (string) $process->code,
-                'name'        => (string) $process->name,
-                'alias'       => (string) $process->alias,
-                'description' => $process->description,
-                'parent_id'   => $process->parent_id,
+                'id'                 => (string) $process->id,
+                'code'               => (string) $process->code,
+                'name'               => (string) $process->name,
+                'alias'              => (string) $process->alias,
+                'description'        => $process->description,
+                'process_parent_id'  => $process->process_parent_id,
             ])
             ->values()
             ->all();

--- a/backend/app/Services/Contracts/ProcessServiceInterface.php
+++ b/backend/app/Services/Contracts/ProcessServiceInterface.php
@@ -7,7 +7,7 @@ interface ProcessServiceInterface
     /**
      * Lista plana de procesos disponibles (top-level + sub-procesos), ordenada por código.
      *
-     * @return list<array{id: string, code: string, name: string, alias: string, description: string|null, parent_id: string|null}>
+     * @return list<array{id: string, code: string, name: string, alias: string, description: string|null, process_parent_id: string|null}>
      */
     public function list(): array;
 }

--- a/backend/app/Services/ProcessService.php
+++ b/backend/app/Services/ProcessService.php
@@ -12,7 +12,7 @@ class ProcessService implements ProcessServiceInterface
     ) {}
 
     /**
-     * @return list<array{id: string, code: string, name: string, alias: string, description: string|null, parent_id: string|null}>
+     * @return list<array{id: string, code: string, name: string, alias: string, description: string|null, process_parent_id: string|null}>
      */
     public function list(): array
     {

--- a/backend/database/data/processes_mock.php
+++ b/backend/database/data/processes_mock.php
@@ -4,8 +4,8 @@
  * Mapa de procesos del CEEDCV.
  *
  * Estructura jerárquica:
- *   - Procesos top-level (parent_id = null) — códigos PE0X / PC0X / PS0X
- *   - Subprocesos (parent_id = uuid del proceso padre) — códigos PE0X.0Y / etc.
+ *   - Procesos top-level (process_parent_id = null) — códigos PE0X / PC0X / PS0X
+ *   - Subprocesos (process_parent_id = uuid del proceso padre) — códigos PE0X.0Y / etc.
  *
  * UUIDs deterministas. Convención del último segmento (XX|YY|ZZWW):
  *   XX = sección (00=PE Estratégicos, 10=PC Clave, 20=PS Soporte)
@@ -26,72 +26,72 @@ $processes = [];
 
 /* ── PE — Procesos Estratégicos ──────────────────────────────────────────── */
 
-$processes[] = ['id' => $uid('000100'), 'code' => 'PE01', 'name' => 'Planificación estratégica',                                  'alias' => 'pe01_planificacion_estrategica',          'parent_id' => null];
-$processes[] = ['id' => $uid('000101'), 'code' => 'PE01.01', 'name' => 'Análisis de contexto',                                    'alias' => 'pe01_01_analisis_contexto',               'parent_id' => $uid('000100')];
-$processes[] = ['id' => $uid('000102'), 'code' => 'PE01.02', 'name' => 'Planificación y seguimiento de objetivos',                'alias' => 'pe01_02_planificacion_seguimiento_obj',   'parent_id' => $uid('000100')];
+$processes[] = ['id' => $uid('000100'), 'code' => 'PE01', 'name' => 'Planificación estratégica',                                  'alias' => 'pe01_planificacion_estrategica',          'process_parent_id' => null];
+$processes[] = ['id' => $uid('000101'), 'code' => 'PE01.01', 'name' => 'Análisis de contexto',                                    'alias' => 'pe01_01_analisis_contexto',               'process_parent_id' => $uid('000100')];
+$processes[] = ['id' => $uid('000102'), 'code' => 'PE01.02', 'name' => 'Planificación y seguimiento de objetivos',                'alias' => 'pe01_02_planificacion_seguimiento_obj',   'process_parent_id' => $uid('000100')];
 
-$processes[] = ['id' => $uid('000200'), 'code' => 'PE02', 'name' => 'Mejora continua',                                            'alias' => 'pe02_mejora_continua',                    'parent_id' => null];
-$processes[] = ['id' => $uid('000201'), 'code' => 'PE02.01', 'name' => 'Gestión documental',                                      'alias' => 'pe02_01_gestion_documental',              'parent_id' => $uid('000200')];
-$processes[] = ['id' => $uid('000202'), 'code' => 'PE02.02', 'name' => 'Satisfacción de partes interesadas',                      'alias' => 'pe02_02_satisfaccion_partes',             'parent_id' => $uid('000200')];
-$processes[] = ['id' => $uid('000203'), 'code' => 'PE02.03', 'name' => 'Seguimiento y medición',                                  'alias' => 'pe02_03_seguimiento_medicion',            'parent_id' => $uid('000200')];
-$processes[] = ['id' => $uid('000204'), 'code' => 'PE02.04', 'name' => 'No conformidades',                                        'alias' => 'pe02_04_no_conformidades',                'parent_id' => $uid('000200')];
-$processes[] = ['id' => $uid('000205'), 'code' => 'PE02.05', 'name' => 'Auditorías',                                              'alias' => 'pe02_05_auditorias',                      'parent_id' => $uid('000200')];
+$processes[] = ['id' => $uid('000200'), 'code' => 'PE02', 'name' => 'Mejora continua',                                            'alias' => 'pe02_mejora_continua',                    'process_parent_id' => null];
+$processes[] = ['id' => $uid('000201'), 'code' => 'PE02.01', 'name' => 'Gestión documental',                                      'alias' => 'pe02_01_gestion_documental',              'process_parent_id' => $uid('000200')];
+$processes[] = ['id' => $uid('000202'), 'code' => 'PE02.02', 'name' => 'Satisfacción de partes interesadas',                      'alias' => 'pe02_02_satisfaccion_partes',             'process_parent_id' => $uid('000200')];
+$processes[] = ['id' => $uid('000203'), 'code' => 'PE02.03', 'name' => 'Seguimiento y medición',                                  'alias' => 'pe02_03_seguimiento_medicion',            'process_parent_id' => $uid('000200')];
+$processes[] = ['id' => $uid('000204'), 'code' => 'PE02.04', 'name' => 'No conformidades',                                        'alias' => 'pe02_04_no_conformidades',                'process_parent_id' => $uid('000200')];
+$processes[] = ['id' => $uid('000205'), 'code' => 'PE02.05', 'name' => 'Auditorías',                                              'alias' => 'pe02_05_auditorias',                      'process_parent_id' => $uid('000200')];
 
-$processes[] = ['id' => $uid('000300'), 'code' => 'PE03', 'name' => 'Comunicación',                                               'alias' => 'pe03_comunicacion',                       'parent_id' => null];
-$processes[] = ['id' => $uid('000301'), 'code' => 'PE03.01', 'name' => 'Comunicación interna',                                    'alias' => 'pe03_01_comunicacion_interna',            'parent_id' => $uid('000300')];
-$processes[] = ['id' => $uid('000302'), 'code' => 'PE03.02', 'name' => 'Comunicación externa',                                    'alias' => 'pe03_02_comunicacion_externa',            'parent_id' => $uid('000300')];
+$processes[] = ['id' => $uid('000300'), 'code' => 'PE03', 'name' => 'Comunicación',                                               'alias' => 'pe03_comunicacion',                       'process_parent_id' => null];
+$processes[] = ['id' => $uid('000301'), 'code' => 'PE03.01', 'name' => 'Comunicación interna',                                    'alias' => 'pe03_01_comunicacion_interna',            'process_parent_id' => $uid('000300')];
+$processes[] = ['id' => $uid('000302'), 'code' => 'PE03.02', 'name' => 'Comunicación externa',                                    'alias' => 'pe03_02_comunicacion_externa',            'process_parent_id' => $uid('000300')];
 
-$processes[] = ['id' => $uid('000400'), 'code' => 'PE04', 'name' => 'Innovación, internacionalización y responsabilidad social', 'alias' => 'pe04_innovacion_internacional_rs',        'parent_id' => null];
+$processes[] = ['id' => $uid('000400'), 'code' => 'PE04', 'name' => 'Innovación, internacionalización y responsabilidad social', 'alias' => 'pe04_innovacion_internacional_rs',        'process_parent_id' => null];
 
 /* ── PC — Procesos Clave ─────────────────────────────────────────────────── */
 
 // PC01 mantiene el UUID legacy (PROG_DID) para compatibilidad con seeders de templates/documents.
 $pc01 = '33333333-3333-3333-3333-333333333301';
-$processes[] = ['id' => $pc01,           'code' => 'PC01', 'name' => 'Diseño curricular y planificación docente',                'alias' => 'pc01_diseno_curricular',                  'parent_id' => null];
-$processes[] = ['id' => $uid('010101'), 'code' => 'PC01.01', 'name' => 'Actividades extraescolares y complementarias',           'alias' => 'pc01_01_actividades_extraescolares',      'parent_id' => $pc01];
+$processes[] = ['id' => $pc01,           'code' => 'PC01', 'name' => 'Diseño curricular y planificación docente',                'alias' => 'pc01_diseno_curricular',                  'process_parent_id' => null];
+$processes[] = ['id' => $uid('010101'), 'code' => 'PC01.01', 'name' => 'Actividades extraescolares y complementarias',           'alias' => 'pc01_01_actividades_extraescolares',      'process_parent_id' => $pc01];
 
-$processes[] = ['id' => $uid('010200'), 'code' => 'PC02', 'name' => 'Recursos de aprendizaje',                                    'alias' => 'pc02_recursos_aprendizaje',               'parent_id' => null];
-$processes[] = ['id' => $uid('010201'), 'code' => 'PC02.01', 'name' => 'Materiales educativos digitales',                         'alias' => 'pc02_01_materiales_digitales',            'parent_id' => $uid('010200')];
-$processes[] = ['id' => $uid('010202'), 'code' => 'PC02.02', 'name' => 'Equipamiento TIC',                                        'alias' => 'pc02_02_equipamiento_tic',                'parent_id' => $uid('010200')];
-$processes[] = ['id' => $uid('010203'), 'code' => 'PC02.03', 'name' => 'Aulas virtuales',                                         'alias' => 'pc02_03_aulas_virtuales',                 'parent_id' => $uid('010200')];
+$processes[] = ['id' => $uid('010200'), 'code' => 'PC02', 'name' => 'Recursos de aprendizaje',                                    'alias' => 'pc02_recursos_aprendizaje',               'process_parent_id' => null];
+$processes[] = ['id' => $uid('010201'), 'code' => 'PC02.01', 'name' => 'Materiales educativos digitales',                         'alias' => 'pc02_01_materiales_digitales',            'process_parent_id' => $uid('010200')];
+$processes[] = ['id' => $uid('010202'), 'code' => 'PC02.02', 'name' => 'Equipamiento TIC',                                        'alias' => 'pc02_02_equipamiento_tic',                'process_parent_id' => $uid('010200')];
+$processes[] = ['id' => $uid('010203'), 'code' => 'PC02.03', 'name' => 'Aulas virtuales',                                         'alias' => 'pc02_03_aulas_virtuales',                 'process_parent_id' => $uid('010200')];
 
-$processes[] = ['id' => $uid('010300'), 'code' => 'PC03', 'name' => 'Orientación educativa y profesional',                        'alias' => 'pc03_orientacion_educativa',              'parent_id' => null];
-$processes[] = ['id' => $uid('010301'), 'code' => 'PC03.01', 'name' => 'Servicio de información y orientación profesional',       'alias' => 'pc03_01_servicio_orientacion',            'parent_id' => $uid('010300')];
+$processes[] = ['id' => $uid('010300'), 'code' => 'PC03', 'name' => 'Orientación educativa y profesional',                        'alias' => 'pc03_orientacion_educativa',              'process_parent_id' => null];
+$processes[] = ['id' => $uid('010301'), 'code' => 'PC03.01', 'name' => 'Servicio de información y orientación profesional',       'alias' => 'pc03_01_servicio_orientacion',            'process_parent_id' => $uid('010300')];
 
-$processes[] = ['id' => $uid('010400'), 'code' => 'PC04', 'name' => 'Inclusión educativa',                                        'alias' => 'pc04_inclusion_educativa',                'parent_id' => null];
-$processes[] = ['id' => $uid('010401'), 'code' => 'PC04.01', 'name' => 'Atención domiciliaria',                                   'alias' => 'pc04_01_atencion_domiciliaria',           'parent_id' => $uid('010400')];
-$processes[] = ['id' => $uid('010402'), 'code' => 'PC04.02', 'name' => 'Entidades vinculadas',                                    'alias' => 'pc04_02_entidades_vinculadas',            'parent_id' => $uid('010400')];
+$processes[] = ['id' => $uid('010400'), 'code' => 'PC04', 'name' => 'Inclusión educativa',                                        'alias' => 'pc04_inclusion_educativa',                'process_parent_id' => null];
+$processes[] = ['id' => $uid('010401'), 'code' => 'PC04.01', 'name' => 'Atención domiciliaria',                                   'alias' => 'pc04_01_atencion_domiciliaria',           'process_parent_id' => $uid('010400')];
+$processes[] = ['id' => $uid('010402'), 'code' => 'PC04.02', 'name' => 'Entidades vinculadas',                                    'alias' => 'pc04_02_entidades_vinculadas',            'process_parent_id' => $uid('010400')];
 
-$processes[] = ['id' => $uid('010500'), 'code' => 'PC05', 'name' => 'Acción tutorial',                                            'alias' => 'pc05_accion_tutorial',                    'parent_id' => null];
-$processes[] = ['id' => $uid('010600'), 'code' => 'PC06', 'name' => 'Práctica docente',                                           'alias' => 'pc06_practica_docente',                   'parent_id' => null];
-$processes[] = ['id' => $uid('010700'), 'code' => 'PC07', 'name' => 'Evaluación del aprendizaje',                                 'alias' => 'pc07_evaluacion_aprendizaje',             'parent_id' => null];
-$processes[] = ['id' => $uid('010800'), 'code' => 'PC08', 'name' => 'Formación en empresas',                                      'alias' => 'pc08_formacion_empresas',                 'parent_id' => null];
-$processes[] = ['id' => $uid('010900'), 'code' => 'PC09', 'name' => 'Igualdad y convivencia',                                     'alias' => 'pc09_igualdad_convivencia',               'parent_id' => null];
-$processes[] = ['id' => $uid('011000'), 'code' => 'PC10', 'name' => 'Pruebas libres',                                             'alias' => 'pc10_pruebas_libres',                     'parent_id' => null];
+$processes[] = ['id' => $uid('010500'), 'code' => 'PC05', 'name' => 'Acción tutorial',                                            'alias' => 'pc05_accion_tutorial',                    'process_parent_id' => null];
+$processes[] = ['id' => $uid('010600'), 'code' => 'PC06', 'name' => 'Práctica docente',                                           'alias' => 'pc06_practica_docente',                   'process_parent_id' => null];
+$processes[] = ['id' => $uid('010700'), 'code' => 'PC07', 'name' => 'Evaluación del aprendizaje',                                 'alias' => 'pc07_evaluacion_aprendizaje',             'process_parent_id' => null];
+$processes[] = ['id' => $uid('010800'), 'code' => 'PC08', 'name' => 'Formación en empresas',                                      'alias' => 'pc08_formacion_empresas',                 'process_parent_id' => null];
+$processes[] = ['id' => $uid('010900'), 'code' => 'PC09', 'name' => 'Igualdad y convivencia',                                     'alias' => 'pc09_igualdad_convivencia',               'process_parent_id' => null];
+$processes[] = ['id' => $uid('011000'), 'code' => 'PC10', 'name' => 'Pruebas libres',                                             'alias' => 'pc10_pruebas_libres',                     'process_parent_id' => null];
 
 /* ── PS — Procesos Soporte ───────────────────────────────────────────────── */
 
-$processes[] = ['id' => $uid('020100'), 'code' => 'PS01', 'name' => 'Gestión administrativa',                                     'alias' => 'ps01_gestion_administrativa',             'parent_id' => null];
-$processes[] = ['id' => $uid('020101'), 'code' => 'PS01.01', 'name' => 'Matrícula FPA',                                           'alias' => 'ps01_01_matricula_fpa',                   'parent_id' => $uid('020100')];
-$processes[] = ['id' => $uid('020102'), 'code' => 'PS01.02', 'name' => 'Matrícula Bachillerato',                                  'alias' => 'ps01_02_matricula_bachillerato',          'parent_id' => $uid('020100')];
-$processes[] = ['id' => $uid('020103'), 'code' => 'PS01.03', 'name' => 'Matrícula FP',                                            'alias' => 'ps01_03_matricula_fp',                    'parent_id' => $uid('020100')];
-$processes[] = ['id' => $uid('020104'), 'code' => 'PS01.04', 'name' => 'Certificación, titulación y expedientes',                 'alias' => 'ps01_04_certificacion_titulacion',        'parent_id' => $uid('020100')];
-$processes[] = ['id' => $uid('020105'), 'code' => 'PS01.05', 'name' => 'Certificados de aprovechamiento FPA',                     'alias' => 'ps01_05_certificados_aprovechamiento_fpa','parent_id' => $uid('020100')];
+$processes[] = ['id' => $uid('020100'), 'code' => 'PS01', 'name' => 'Gestión administrativa',                                     'alias' => 'ps01_gestion_administrativa',             'process_parent_id' => null];
+$processes[] = ['id' => $uid('020101'), 'code' => 'PS01.01', 'name' => 'Matrícula FPA',                                           'alias' => 'ps01_01_matricula_fpa',                   'process_parent_id' => $uid('020100')];
+$processes[] = ['id' => $uid('020102'), 'code' => 'PS01.02', 'name' => 'Matrícula Bachillerato',                                  'alias' => 'ps01_02_matricula_bachillerato',          'process_parent_id' => $uid('020100')];
+$processes[] = ['id' => $uid('020103'), 'code' => 'PS01.03', 'name' => 'Matrícula FP',                                            'alias' => 'ps01_03_matricula_fp',                    'process_parent_id' => $uid('020100')];
+$processes[] = ['id' => $uid('020104'), 'code' => 'PS01.04', 'name' => 'Certificación, titulación y expedientes',                 'alias' => 'ps01_04_certificacion_titulacion',        'process_parent_id' => $uid('020100')];
+$processes[] = ['id' => $uid('020105'), 'code' => 'PS01.05', 'name' => 'Certificados de aprovechamiento FPA',                     'alias' => 'ps01_05_certificados_aprovechamiento_fpa','process_parent_id' => $uid('020100')];
 
-$processes[] = ['id' => $uid('020200'), 'code' => 'PS02', 'name' => 'Gestión RRHH',                                               'alias' => 'ps02_gestion_rrhh',                       'parent_id' => null];
-$processes[] = ['id' => $uid('020201'), 'code' => 'PS02.01', 'name' => 'Acogida del personal',                                    'alias' => 'ps02_01_acogida_personal',                'parent_id' => $uid('020200')];
-$processes[] = ['id' => $uid('020202'), 'code' => 'PS02.02', 'name' => 'Formación',                                               'alias' => 'ps02_02_formacion',                       'parent_id' => $uid('020200')];
-$processes[] = ['id' => $uid('020203'), 'code' => 'PS02.03', 'name' => 'Competencia',                                             'alias' => 'ps02_03_competencia',                     'parent_id' => $uid('020200')];
-$processes[] = ['id' => $uid('020204'), 'code' => 'PS02.04', 'name' => 'Gestión de horarios',                                     'alias' => 'ps02_04_gestion_horarios',                'parent_id' => $uid('020200')];
-$processes[] = ['id' => $uid('020205'), 'code' => 'PS02.05', 'name' => 'Ausencias y guardias',                                    'alias' => 'ps02_05_ausencias_guardias',              'parent_id' => $uid('020200')];
-$processes[] = ['id' => $uid('020206'), 'code' => 'PS02.06', 'name' => 'Alumnado en prácticas',                                   'alias' => 'ps02_06_alumnado_practicas',              'parent_id' => $uid('020200')];
-$processes[] = ['id' => $uid('020207'), 'code' => 'PS02.07', 'name' => 'Prevención de riesgos laborales',                         'alias' => 'ps02_07_prevencion_riesgos',              'parent_id' => $uid('020200')];
+$processes[] = ['id' => $uid('020200'), 'code' => 'PS02', 'name' => 'Gestión RRHH',                                               'alias' => 'ps02_gestion_rrhh',                       'process_parent_id' => null];
+$processes[] = ['id' => $uid('020201'), 'code' => 'PS02.01', 'name' => 'Acogida del personal',                                    'alias' => 'ps02_01_acogida_personal',                'process_parent_id' => $uid('020200')];
+$processes[] = ['id' => $uid('020202'), 'code' => 'PS02.02', 'name' => 'Formación',                                               'alias' => 'ps02_02_formacion',                       'process_parent_id' => $uid('020200')];
+$processes[] = ['id' => $uid('020203'), 'code' => 'PS02.03', 'name' => 'Competencia',                                             'alias' => 'ps02_03_competencia',                     'process_parent_id' => $uid('020200')];
+$processes[] = ['id' => $uid('020204'), 'code' => 'PS02.04', 'name' => 'Gestión de horarios',                                     'alias' => 'ps02_04_gestion_horarios',                'process_parent_id' => $uid('020200')];
+$processes[] = ['id' => $uid('020205'), 'code' => 'PS02.05', 'name' => 'Ausencias y guardias',                                    'alias' => 'ps02_05_ausencias_guardias',              'process_parent_id' => $uid('020200')];
+$processes[] = ['id' => $uid('020206'), 'code' => 'PS02.06', 'name' => 'Alumnado en prácticas',                                   'alias' => 'ps02_06_alumnado_practicas',              'process_parent_id' => $uid('020200')];
+$processes[] = ['id' => $uid('020207'), 'code' => 'PS02.07', 'name' => 'Prevención de riesgos laborales',                         'alias' => 'ps02_07_prevencion_riesgos',              'process_parent_id' => $uid('020200')];
 
-$processes[] = ['id' => $uid('020300'), 'code' => 'PS03', 'name' => 'Gestión de infraestructuras y equipamiento de soporte',     'alias' => 'ps03_infraestructuras_equipamiento',      'parent_id' => null];
-$processes[] = ['id' => $uid('020301'), 'code' => 'PS03.01', 'name' => 'Mantenimiento y renovación de equipos',                   'alias' => 'ps03_01_mantenimiento_renovacion',        'parent_id' => $uid('020300')];
+$processes[] = ['id' => $uid('020300'), 'code' => 'PS03', 'name' => 'Gestión de infraestructuras y equipamiento de soporte',     'alias' => 'ps03_infraestructuras_equipamiento',      'process_parent_id' => null];
+$processes[] = ['id' => $uid('020301'), 'code' => 'PS03.01', 'name' => 'Mantenimiento y renovación de equipos',                   'alias' => 'ps03_01_mantenimiento_renovacion',        'process_parent_id' => $uid('020300')];
 
-$processes[] = ['id' => $uid('020500'), 'code' => 'PS05', 'name' => 'Protección de datos y seguridad de la información',         'alias' => 'ps05_proteccion_datos',                   'parent_id' => null];
-$processes[] = ['id' => $uid('020600'), 'code' => 'PS06', 'name' => 'Gestión económica y compras',                                'alias' => 'ps06_gestion_economica_compras',          'parent_id' => null];
+$processes[] = ['id' => $uid('020500'), 'code' => 'PS05', 'name' => 'Protección de datos y seguridad de la información',         'alias' => 'ps05_proteccion_datos',                   'process_parent_id' => null];
+$processes[] = ['id' => $uid('020600'), 'code' => 'PS06', 'name' => 'Gestión económica y compras',                                'alias' => 'ps06_gestion_economica_compras',          'process_parent_id' => null];
 
 return [
     'processes' => array_map(static fn (array $p): array => $p + ['description' => null], $processes),

--- a/backend/database/migrations/0001_00_00_000001_000002_create_processes_table.php
+++ b/backend/database/migrations/0001_00_00_000001_000002_create_processes_table.php
@@ -14,16 +14,15 @@ return new class extends Migration
             $table->string('name');
             $table->string('alias');
             $table->text('description')->nullable();
-            $table->uuid('parent_id')->nullable();
-            $table->index('parent_id');
+            $table->uuid('process_parent_id')->nullable();
             $table->timestamps();
+
+            $table->index('process_parent_id');
         });
 
-        // FK self-referencial: la añadimos después de crear la tabla porque
-        // Postgres exige que la unique/PK de la columna referenciada exista
-        // antes de aceptar la FK (no se puede en el mismo CREATE TABLE).
+        // FK self-referencial
         Schema::table('processes', function (Blueprint $table): void {
-            $table->foreign('parent_id')
+            $table->foreign('process_parent_id')
                 ->references('id')
                 ->on('processes')
                 ->nullOnDelete();

--- a/backend/database/seeders/ProcessesSeeder.php
+++ b/backend/database/seeders/ProcessesSeeder.php
@@ -23,7 +23,7 @@ class ProcessesSeeder extends Seeder
         $now = Carbon::now();
 
         $rows = array_map(static function (array $row) use ($now): array {
-            $row['parent_id']   ??= null;
+            $row['process_parent_id'] ??= null;
             $row['description'] ??= null;
             $row['created_at']  ??= $now;
             $row['updated_at']  ??= $now;
@@ -31,16 +31,16 @@ class ProcessesSeeder extends Seeder
             return $row;
         }, $data);
 
-        // Insertamos primero los procesos top-level (parent_id = null) para
+        // Insertamos primero los procesos top-level (process_parent_id = null) para
         // que la FK no falle al upsertar los subprocesos.
-        $top  = array_values(array_filter($rows, static fn (array $r): bool => $r['parent_id'] === null));
-        $subs = array_values(array_filter($rows, static fn (array $r): bool => $r['parent_id'] !== null));
+        $top  = array_values(array_filter($rows, static fn (array $r): bool => $r['process_parent_id'] === null));
+        $subs = array_values(array_filter($rows, static fn (array $r): bool => $r['process_parent_id'] !== null));
 
         if ($top !== []) {
             DB::table('processes')->upsert(
                 $top,
                 ['id'],
-                ['code', 'name', 'alias', 'description', 'parent_id', 'updated_at'],
+                ['code', 'name', 'alias', 'description', 'process_parent_id', 'updated_at'],
             );
         }
 
@@ -48,7 +48,7 @@ class ProcessesSeeder extends Seeder
             DB::table('processes')->upsert(
                 $subs,
                 ['id'],
-                ['code', 'name', 'alias', 'description', 'parent_id', 'updated_at'],
+                ['code', 'name', 'alias', 'description', 'process_parent_id', 'updated_at'],
             );
         }
     }

--- a/frontend/src/components/layout/SidebarProcesos.tsx
+++ b/frontend/src/components/layout/SidebarProcesos.tsx
@@ -44,7 +44,7 @@ const CHEVRON = (
 type ProcessNode = Process & { children: Process[] };
 
 /**
- * Agrupa procesos planos por `parent_id`. Procesos top-level conservan el orden
+ * Agrupa procesos planos por `process_parent_id`. Procesos top-level conservan el orden
  * de entrada (que viene ordenado por código desde el backend) y los hijos se
  * ordenan también por código.
  */
@@ -59,8 +59,8 @@ function buildTree(processes: Process[]): ProcessNode[] {
 
   for (const p of processes) {
     const node = byId.get(p.id)!;
-    if (p.parent_id) {
-      const parent = byId.get(p.parent_id);
+    if (p.process_parent_id) {
+      const parent = byId.get(p.process_parent_id);
       if (parent) parent.children.push(node);
       else roots.push(node); // Huérfano: tratar como top-level por seguridad
     } else {

--- a/frontend/src/types/processes.ts
+++ b/frontend/src/types/processes.ts
@@ -2,8 +2,8 @@
  * Proceso del catálogo (FK desde templates y documents).
  *
  * Estructura jerárquica de 2 niveles:
- *   - Top-level: `parent_id === null` (códigos PE0X, PC0X, PS0X)
- *   - Sub-procesos: `parent_id` apunta al top-level (códigos PE0X.0Y, etc.)
+ *   - Top-level: `process_parent_id === null` (códigos PE0X, PC0X, PS0X)
+ *   - Sub-procesos: `process_parent_id` apunta al proceso padre (códigos PE0X.0Y, etc.)
  */
 export type Process = {
   id: string;
@@ -11,5 +11,5 @@ export type Process = {
   name: string;
   alias: string;
   description: string | null;
-  parent_id: string | null;
+  process_parent_id: string | null;
 };


### PR DESCRIPTION
- Base de datos: la tabla processes se define desde la migración inicial con la columna process_parent_id (nullable, índice, FK self-reference con ON DELETE SET NULL).
- Modelo y dominio: el modelo Process y la capa repository/service exponen y utilizan process_parent_id de forma coherente con el esquema.
- Datos: el mock de procesos y ProcessesSeeder cargan la jerarquía usando process_parent_id, con inserción en dos fases (top-level y subprocesos) para respetar la FK.

- Frontend: tipos y SidebarProcesos construyen el árbol a partir de process_parent_id y mantienen la navegación por id de proceso en /procesos/:processId.

Se debe hacer las migraciones de nuevo: docker compose exec backend php artisan migrate:fresh --seed