### PR TITLE
Feature/mostrar proceso seleccionado

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -33,8 +33,8 @@ function AppRoutes() {
         <Route path="/dashboard" element={<DashboardPage />} />
         <Route path="/procesos" element={<ProcesosPage />} />
         <Route path="/procesos/:processId" element={<ProcesosPage />} />
-        <Route path="/nueva-programacion" element={<NuevaProgramacionSelectorPage />} />
-        <Route path="/nueva-programacion/:templateId/wizard" element={<DocumentEditorPage />} />
+        <Route path="/documentos/nuevo" element={<NuevaProgramacionSelectorPage />} />
+        <Route path="/documentos/nuevo/:templateId/wizard" element={<DocumentEditorPage />} />
         <Route path="/documents/:documentId/editor" element={<DocumentEditorPage />} />
         <Route path="/documents/:documentId/validate" element={<DocumentValidationPage />} />
         <Route path="/documents/:documentId" element={<DocumentPreviewPage />} />

--- a/frontend/src/components/DocumentsContent.test.tsx
+++ b/frontend/src/components/DocumentsContent.test.tsx
@@ -238,7 +238,7 @@ describe('DocumentsContent creation flow', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Nueva Programación' }));
 
     await waitFor(() =>
-      expect(mockNavigate).toHaveBeenCalledWith('/nueva-programacion/tpl-1/wizard', {
+      expect(mockNavigate).toHaveBeenCalledWith('/documentos/nuevo/tpl-1/wizard', {
         state: { moduleId: 'm1' },
       }),
     );
@@ -302,7 +302,7 @@ describe('DocumentsContent creation flow', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Nueva Programación' }));
 
     await waitFor(() =>
-      expect(mockNavigate).toHaveBeenCalledWith('/nueva-programacion', {
+      expect(mockNavigate).toHaveBeenCalledWith('/documentos/nuevo', {
         state: { moduleId: 'm1' },
       }),
     );
@@ -346,7 +346,7 @@ describe('DocumentsContent creation flow', () => {
       expect(screen.getByRole('button', { name: 'Nueva Programación' })).toHaveProperty('disabled', false),
     );
     fireEvent.click(screen.getByRole('button', { name: 'Nueva Programación' }));
-    expect(mockNavigate).toHaveBeenCalledWith('/nueva-programacion', {
+    expect(mockNavigate).toHaveBeenCalledWith('/documentos/nuevo', {
       state: { moduleId: 'm1' },
     });
   });

--- a/frontend/src/components/DocumentsContent.tsx
+++ b/frontend/src/components/DocumentsContent.tsx
@@ -335,12 +335,12 @@ export function DocumentsContent() {
     if (creationMode === 'none') return;
     if (creationMode === 'auto') {
       const templateId = creationOptions[0]?.template_id;
-      navigate(`/nueva-programacion/${templateId}/wizard`, {
+      navigate(`/documentos/nuevo/${templateId}/wizard`, {
         state: { moduleId: selectedModuleId }
       });
       return;
     }
-    navigate('/nueva-programacion', {
+    navigate('/documentos/nuevo', {
       state: { moduleId: selectedModuleId }
     });
   };

--- a/frontend/src/features/documents/components/DocumentWizard.tsx
+++ b/frontend/src/features/documents/components/DocumentWizard.tsx
@@ -22,6 +22,7 @@ import {
   type DocumentReview,
 } from '../../../api/documents';
 import { ApiHttpError } from '../../../api/http';
+import { fetchProcesses } from '../../../api/processes';
 import { fetchTemplate } from '../../../api/templates';
 import { fetchMe, searchDocumentReviewerCandidates, searchUsers } from '../../../api/users';
 import { useAutoSave } from '../../../hooks/useAutoSave';
@@ -248,11 +249,13 @@ export function DocumentWizard({ documentId, templateId, mode = 'edit' }: Props)
   const [rejectReason, setRejectReason] = useState('');
   const [localContent, setLocalContent] = useState<unknown>(null);
   const [showClearBlockConfirm, setShowClearBlockConfirm] = useState(false);
+  const [processSubtitle, setProcessSubtitle] = useState<string | null>(null);
   const activeBlockRef = useRef<DocumentDisplayBlock | null>(null);
 
   const isValidateMode = mode === 'validate';
   const isDraft = !detail || detail.status === 'draft';
   const returnToSummary = (location.state as { step?: string } | null)?.step === 'summary';
+  const locationProcessId = (location.state as { processId?: string } | null)?.processId;
 
   const reload = useCallback(async () => {
     if (!documentId) return;
@@ -606,6 +609,31 @@ export function DocumentWizard({ documentId, templateId, mode = 'edit' }: Props)
       cancelled = true;
     };
   }, [detail?.template_id, templateId]);
+
+  useEffect(() => {
+    const effectiveProcessId = template?.process_id ?? locationProcessId ?? null;
+    if (!effectiveProcessId) {
+      setProcessSubtitle(null);
+      return;
+    }
+    let cancelled = false;
+    void fetchProcesses()
+      .then((res) => {
+        if (cancelled) return;
+        const selectedProcess = res.data.find((p) => p.id === effectiveProcessId) ?? null;
+        if (!selectedProcess) {
+          setProcessSubtitle(null);
+          return;
+        }
+        setProcessSubtitle(`Proceso: ${selectedProcess.code} — ${selectedProcess.name}`);
+      })
+      .catch(() => {
+        if (!cancelled) setProcessSubtitle(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [locationProcessId, template?.process_id]);
 
   const canEditBlocks = isDraft && activeBlock !== null && activeBlockUiState !== 'locked';
   const canClearOptionalBlock = isDraft && activeBlock !== null && activeBlockUiState === 'optional';
@@ -987,7 +1015,7 @@ export function DocumentWizard({ documentId, templateId, mode = 'edit' }: Props)
     <>
     <WizardShell<Step>
       title={detail?.title || 'Nueva programación'}
-      subtitle={detail?.title ? 'Editar programación' : undefined}
+      subtitle={processSubtitle ?? (detail?.title ? 'Editar programación' : undefined)}
       onBack={handleWizardBack}
       backLabel={isValidateMode ? 'Volver al panel principal' : 'Volver'}
       actions={headerActions}

--- a/frontend/src/features/documents/components/DocumentWizard.tsx
+++ b/frontend/src/features/documents/components/DocumentWizard.tsx
@@ -1007,7 +1007,7 @@ export function DocumentWizard({ documentId, templateId, mode = 'edit' }: Props)
     } else if (documentId) {
       navigate(`/documents/${documentId}`);
     } else {
-      navigate('/nueva-programacion');
+      navigate('/documentos/nuevo');
     }
   };
 
@@ -1048,7 +1048,7 @@ export function DocumentWizard({ documentId, templateId, mode = 'edit' }: Props)
                     </span>
                     <button
                       type="button"
-                      onClick={() => navigate('/nueva-programacion')}
+                      onClick={() => navigate('/documentos/nuevo')}
                       className="text-xs text-odoo-purple dark:text-odoo-dark-purple hover:underline cursor-pointer shrink-0"
                     >
                       Cambiar plantilla

--- a/frontend/src/features/templates/components/TemplateWizard.tsx
+++ b/frontend/src/features/templates/components/TemplateWizard.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo, useRef, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { WizardShell, type WizardStepDef } from '../../../components/wizard/WizardShell';
+import { fetchProcesses } from '../../../api/processes';
 import type { Template, TemplateVisibilityLevel } from '../../../types/templates';
 import type { ReviewMode } from '../../../types/templates';
 import {
@@ -71,6 +72,7 @@ export function TemplateWizard({ template: templateProp, initialTemplate, proces
   const [comments, setComments] = useState<any[]>([]);
   const [blocksCount, setBlocksCount] = useState(0);
   const [blocksLoading, setBlocksLoading] = useState(true);
+  const [processSubtitle, setProcessSubtitle] = useState<string | null>(null);
 
   useEffect(() => {
     if (initial?.id && initial?.has_review_comments) {
@@ -79,6 +81,31 @@ export function TemplateWizard({ template: templateProp, initialTemplate, proces
         .catch(console.error);
     }
   }, [initial?.id, initial?.has_review_comments]);
+
+  useEffect(() => {
+    const effectiveProcessId = processId ?? template?.process_id ?? initial?.process_id ?? null;
+    if (!effectiveProcessId) {
+      setProcessSubtitle(null);
+      return;
+    }
+    let cancelled = false;
+    void fetchProcesses()
+      .then((res) => {
+        if (cancelled) return;
+        const selectedProcess = res.data.find((p) => p.id === effectiveProcessId) ?? null;
+        if (!selectedProcess) {
+          setProcessSubtitle(null);
+          return;
+        }
+        setProcessSubtitle(`Proceso: ${selectedProcess.code} — ${selectedProcess.name}`);
+      })
+      .catch(() => {
+        if (!cancelled) setProcessSubtitle(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [initial?.process_id, processId, template?.process_id]);
 
   const handleResolveComment = async (commentId: string) => {
     try {
@@ -443,7 +470,7 @@ export function TemplateWizard({ template: templateProp, initialTemplate, proces
     <>
     <WizardShell<Step>
       title={template ? template.name : 'Nueva plantilla'}
-      subtitle={template ? 'Editar plantilla' : undefined}
+      subtitle={processSubtitle ?? (template ? 'Editar plantilla' : undefined)}
       onBack={handleBackArrow}
       actions={headerActions}
       steps={stepsData}

--- a/frontend/src/pages/NuevaProgramacionPreviewPage.tsx
+++ b/frontend/src/pages/NuevaProgramacionPreviewPage.tsx
@@ -62,7 +62,7 @@ export function NuevaProgramacionPreviewPage() {
       <header className="sticky top-0 z-10 bg-ui-card dark:bg-ui-dark-card border-b border-ui-border dark:border-ui-dark-border flex items-center gap-3 px-6 h-[52px]">
         <button
           type="button"
-          onClick={() => navigate('/nueva-programacion')}
+          onClick={() => navigate('/documentos/nuevo')}
           className="shrink-0 flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-bold text-text-secondary dark:text-text-dark-secondary bg-ui-body dark:bg-ui-dark-bg hover:bg-ui-border dark:hover:bg-ui-dark-border transition-colors cursor-pointer"
         >
           ← Seleccionar plantilla
@@ -91,7 +91,7 @@ export function NuevaProgramacionPreviewPage() {
                 type="button"
                 variant="primary"
                 size="sm"
-                onClick={() => navigate(`/nueva-programacion/${templateId}/wizard`)}
+                onClick={() => navigate(`/documentos/nuevo/${templateId}/wizard`)}
               >
                 Usar plantilla
               </Button>

--- a/frontend/src/pages/NuevaProgramacionSelectorPage.tsx
+++ b/frontend/src/pages/NuevaProgramacionSelectorPage.tsx
@@ -216,6 +216,7 @@ export function NuevaProgramacionSelectorPage() {
               selectionMode: true,
               backTo: '/nueva-programacion',
               moduleId: selectedModuleId,
+              processId: selectedProcessId,
             },
           })
         }

--- a/frontend/src/pages/NuevaProgramacionSelectorPage.tsx
+++ b/frontend/src/pages/NuevaProgramacionSelectorPage.tsx
@@ -240,7 +240,7 @@ export function NuevaProgramacionSelectorPage() {
           navigate(`/templates/${t.id}`, {
             state: {
               selectionMode: true,
-              backTo: '/nueva-programacion',
+              backTo: '/documentos/nuevo',
               moduleId: selectedModuleId,
               processId: selectedProcessId,
             },

--- a/frontend/src/pages/NuevaProgramacionSelectorPage.tsx
+++ b/frontend/src/pages/NuevaProgramacionSelectorPage.tsx
@@ -1,12 +1,14 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { fetchTemplates } from '../api/templates';
+import { fetchProcesses } from '../api/processes';
 import {
   buildTemplatesListMeta,
   sliceTemplatesPage,
 } from '../features/templates/clientTemplatePagination';
 import { VISIBILITY_OPTIONS, visibilityLabel } from '../features/templates/constants';
 import type { Template, TemplateListFilters, TemplateVisibilityLevel } from '../types/templates';
+import type { Process } from '../types/processes';
 import {
   DataTable,
   DatePicker,
@@ -74,6 +76,7 @@ export function NuevaProgramacionSelectorPage() {
   const locationState = location.state as { moduleId?: string; processId?: string } | null;
   const selectedModuleId = locationState?.moduleId;
   const selectedProcessId = locationState?.processId;
+  const [process, setProcess] = useState<Process | null>(null);
 
   const { hiddenIds, toggleHidden, sortBy, setSortBy, pageSize, setPageSize } = useTablePreferences({
     storageKey: 'maya:dms:nueva-programacion-selector',
@@ -88,6 +91,25 @@ export function NuevaProgramacionSelectorPage() {
   const [listError, setListError] = useState<string | null>(null);
   const [authorInput, setAuthorInput] = useState('');
   const authorDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (!selectedProcessId) {
+      setProcess(null);
+      return;
+    }
+    let cancelled = false;
+    void fetchProcesses()
+      .then((res) => {
+        if (cancelled) return;
+        setProcess(res.data.find((p) => p.id === selectedProcessId) ?? null);
+      })
+      .catch(() => {
+        if (!cancelled) setProcess(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedProcessId]);
 
   useEffect(() => {
     let cancelled = false;
@@ -183,8 +205,12 @@ export function NuevaProgramacionSelectorPage() {
   return (
     <div className="min-h-full overflow-y-auto p-6 space-y-4">
       <PageTitle
-        title="Nueva Programación"
-        subtitle="Selecciona una plantilla"
+        title="Nuevo Documento"
+        subtitle={
+          process
+            ? `Proceso: ${process.code} — ${process.name} · Selecciona una plantilla`
+            : 'Selecciona una plantilla'
+        }
         onBack={() => navigate('/procesos', { state: { tab: 'documents' } })}
         backLabel="Documentos"
       />

--- a/frontend/src/pages/ProcesosPage.tsx
+++ b/frontend/src/pages/ProcesosPage.tsx
@@ -69,7 +69,7 @@ export function ProcesosPage() {
               size="sm"
               onClick={() => navigate('/nueva-programacion', { state: navState })}
             >
-              Nueva Programación
+              Nuevo Documento
             </Button>
           )
         }

--- a/frontend/src/pages/ProcesosPage.tsx
+++ b/frontend/src/pages/ProcesosPage.tsx
@@ -67,7 +67,7 @@ export function ProcesosPage() {
               type="button"
               variant="primary"
               size="sm"
-              onClick={() => navigate('/nueva-programacion', { state: navState })}
+              onClick={() => navigate('/documentos/nuevo', { state: navState })}
             >
               Nuevo Documento
             </Button>

--- a/frontend/src/pages/TemplatePreviewPage.tsx
+++ b/frontend/src/pages/TemplatePreviewPage.tsx
@@ -58,7 +58,7 @@ export function TemplatePreviewPage() {
     processId?: string;
   } | null;
   const selectionMode = locationState?.selectionMode === true;
-  const backTo = locationState?.backTo ?? '/nueva-programacion';
+  const backTo = locationState?.backTo ?? '/documentos/nuevo';
   const { profile, hasPermission } = useUserProfile();
 
   const [template, setTemplate] = useState<Template | null>(null);
@@ -216,7 +216,7 @@ export function TemplatePreviewPage() {
             type="button"
             variant="primary"
             size="sm"
-            onClick={() => navigate(`/nueva-programacion/${id}/wizard`, {
+            onClick={() => navigate(`/documentos/nuevo/${id}/wizard`, {
               state: { moduleId: locationState?.moduleId, processId: locationState?.processId },
             })}
           >

--- a/frontend/src/pages/TemplatePreviewPage.tsx
+++ b/frontend/src/pages/TemplatePreviewPage.tsx
@@ -51,7 +51,12 @@ export function TemplatePreviewPage() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const location = useLocation();
-  const locationState = location.state as { selectionMode?: boolean; backTo?: string; moduleId?: string } | null;
+  const locationState = location.state as {
+    selectionMode?: boolean;
+    backTo?: string;
+    moduleId?: string;
+    processId?: string;
+  } | null;
   const selectionMode = locationState?.selectionMode === true;
   const backTo = locationState?.backTo ?? '/nueva-programacion';
   const { profile, hasPermission } = useUserProfile();
@@ -212,7 +217,7 @@ export function TemplatePreviewPage() {
             variant="primary"
             size="sm"
             onClick={() => navigate(`/nueva-programacion/${id}/wizard`, {
-              state: { moduleId: locationState?.moduleId },
+              state: { moduleId: locationState?.moduleId, processId: locationState?.processId },
             })}
           >
             Usar plantilla


### PR DESCRIPTION
- Se muestra el proceso seleccionado en el subtítulo superior al crear plantillas y documentos.
- Se unificó la terminología de creación en vistas de procesos y selector:
      - botón: “Nuevo Documento”
      - header del selector: “Nuevo Documento”
- Se actualizó la ruta de creación en frontend de /nueva-programacion a /documentos/nuevo incluyendo su variante con plantilla (/:templateId/wizard) y todas las navegaciones asociadas.