### PR TITLE
Feature/errores panel

### DIFF
--- a/backend/app/Repositories/Eloquent/TemplateRepository.php
+++ b/backend/app/Repositories/Eloquent/TemplateRepository.php
@@ -196,12 +196,29 @@ class TemplateRepository implements TemplateRepositoryInterface
      */
     public function listPendingReviewInboxForUser(string $userId): Collection
     {
+        $minPendingByTemplate = DB::table('template_reviewers as tr_min')
+            ->select('tr_min.template_id')
+            ->selectRaw('MIN(tr_min.stage) as min_stage')
+            ->where('tr_min.status', 'pending')
+            ->groupBy('tr_min.template_id');
+
         $rows = DB::table('template_reviewers')
             ->join('templates', 'templates.id', '=', 'template_reviewers.template_id')
             ->leftJoin('users as author_user', 'author_user.id', '=', 'templates.created_by')
+            ->leftJoinSub($minPendingByTemplate, 'ts', function ($join) {
+                $join->on('ts.template_id', '=', 'templates.id');
+            })
             ->where('template_reviewers.user_id', $userId)
             ->where('template_reviewers.status', 'pending')
             ->where('templates.status', 'in_review')
+            ->where(function ($q) {
+                $q->whereNull('templates.review_mode')
+                    ->orWhere('templates.review_mode', 'parallel')
+                    ->orWhere(function ($q2) {
+                        $q2->where('templates.review_mode', 'sequential')
+                            ->whereColumn('template_reviewers.stage', 'ts.min_stage');
+                    });
+            })
             ->orderByRaw('CASE WHEN templates.delivery_deadline IS NULL THEN 1 ELSE 0 END ASC')
             ->orderBy('templates.delivery_deadline', 'asc')
             ->orderBy('templates.updated_at', 'desc')

--- a/backend/tests/Feature/DashboardApiTest.php
+++ b/backend/tests/Feature/DashboardApiTest.php
@@ -355,4 +355,69 @@ class DashboardApiTest extends TestCase
             ->assertJsonPath('data.stats.templates_high', 0)
             ->assertJsonCount(0, 'data.document_review_inbox');
     }
+
+    public function test_dashboard_template_review_inbox_respects_sequential_stage(): void
+    {
+        $rev1 = (string) Str::uuid();
+        $rev2 = (string) Str::uuid();
+        $headersRev2 = $this->authHeaders($rev2);
+
+        $templateId = (string) Str::uuid();
+        $ownerId = (string) Str::uuid();
+
+        Template::query()->forceCreate([
+            'id' => $templateId,
+            'name' => 'Plantilla secuencial dashboard',
+            'description' => null,
+            'visibility_level' => TemplateVisibilityLevel::Personal->value,
+            'delivery_deadline' => now()->addDays(2),
+            'study_type_id' => null,
+            'study_id' => null,
+            'module_id' => null,
+            'team_id' => null,
+            'created_by' => $ownerId,
+            'status' => 'in_review',
+            'version' => 1,
+            'review_stages' => 2,
+            'review_mode' => 'sequential',
+        ]);
+
+        \DB::table('template_reviewers')->insert([
+            [
+                'id' => (string) Str::uuid(),
+                'template_id' => $templateId,
+                'user_id' => $rev1,
+                'stage' => 1,
+                'status' => 'pending',
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+            [
+                'id' => (string) Str::uuid(),
+                'template_id' => $templateId,
+                'user_id' => $rev2,
+                'stage' => 2,
+                'status' => 'pending',
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+        ]);
+
+        $blocked = $this->getJson('/api/v1/dashboard', $headersRev2);
+        $blocked->assertOk()
+            ->assertJsonCount(0, 'data.template_review_inbox')
+            ->assertJsonPath('data.stats.templates_critical', 0)
+            ->assertJsonPath('data.stats.templates_high', 0);
+
+        \DB::table('template_reviewers')
+            ->where('template_id', $templateId)
+            ->where('user_id', $rev1)
+            ->update(['status' => 'approved', 'updated_at' => now()]);
+
+        $unblocked = $this->getJson('/api/v1/dashboard', $headersRev2);
+        $unblocked->assertOk()
+            ->assertJsonCount(1, 'data.template_review_inbox')
+            ->assertJsonPath('data.template_review_inbox.0.template_id', $templateId)
+            ->assertJsonPath('data.template_review_inbox.0.review_stage', 2);
+    }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
-import { lazy, Suspense, useEffect } from 'react';
-import { Route, Routes, Navigate } from 'react-router-dom';
+import { lazy, Suspense, useEffect, useRef } from 'react';
+import { Route, Routes, Navigate, useLocation, useNavigate } from 'react-router-dom';
 import i18n from './i18n';
 import { AppLayout } from '@maya/shared-layout-react';
 import { NotificationsBell, SidebarFavorites } from '@maya/shared-sidebar-react';
@@ -29,7 +29,7 @@ function AppRoutes() {
   return (
     <Suspense fallback={<div className="p-8">Cargando...</div>}>
       <Routes>
-        <Route path="/" element={<Navigate to="/procesos" replace />} />
+        <Route path="/" element={<Navigate to="/dashboard" replace />} />
         <Route path="/dashboard" element={<DashboardPage />} />
         <Route path="/procesos" element={<ProcesosPage />} />
         <Route path="/procesos/:processId" element={<ProcesosPage />} />
@@ -95,12 +95,24 @@ function Main() {
 
 function App() {
   const { isLoading, isAuthenticated, login } = useAuth();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const wasAuthenticatedRef = useRef(false);
 
   useEffect(() => {
     if (!isLoading && !isAuthenticated) {
       login();
     }
   }, [isLoading, isAuthenticated, login]);
+
+  useEffect(() => {
+    if (isLoading) return;
+    const wasAuthenticated = wasAuthenticatedRef.current;
+    if (!wasAuthenticated && isAuthenticated && location.pathname !== '/dashboard') {
+      navigate('/dashboard', { replace: true });
+    }
+    wasAuthenticatedRef.current = isAuthenticated;
+  }, [isAuthenticated, isLoading, location.pathname, navigate]);
 
   if (isLoading) {
     return (

--- a/frontend/src/features/dashboard/widgets/PendingValidationsWidget.tsx
+++ b/frontend/src/features/dashboard/widgets/PendingValidationsWidget.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 import { fetchDashboard } from '../../../api/dashboard';
 
 /** Widget StatCard: nº de documentos pendientes de validación del usuario. */
 export default function PendingValidationsWidget() {
-  const navigate = useNavigate();
+  const [activeFilter, setActiveFilter] = useState<'all' | 'template' | 'document'>('all');
   const [count, setCount] = useState<number | null>(null);
+  const [documentCount, setDocumentCount] = useState<number>(0);
+  const [templateCount, setTemplateCount] = useState<number>(0);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
 
@@ -16,6 +17,8 @@ export default function PendingValidationsWidget() {
         if (!mounted) return;
         const pendingDocuments = data.document_review_inbox?.length ?? 0;
         const pendingTemplates = data.template_review_inbox?.length ?? 0;
+        setDocumentCount(pendingDocuments);
+        setTemplateCount(pendingTemplates);
         setCount(pendingDocuments + pendingTemplates);
       })
       .catch(() => {
@@ -31,24 +34,66 @@ export default function PendingValidationsWidget() {
     };
   }, []);
 
-  const handleClick = () => navigate('/documents');
+  const emitFilter = (filter: 'all' | 'template' | 'document') => {
+    setActiveFilter(filter);
+    window.dispatchEvent(
+      new CustomEvent('maya:dms:pending-validations-filter-change', {
+        detail: { filter },
+      }),
+    );
+  };
 
   return (
-    <button
-      type="button"
-      onClick={handleClick}
-      className="w-full h-full flex flex-col items-start justify-center text-left rounded-xl bg-gradient-to-br from-odoo-purple/15 via-odoo-purple/5 to-transparent dark:from-odoo-dark-teal/25 dark:via-odoo-dark-teal/10 dark:to-transparent p-4 hover:from-odoo-purple/25 dark:hover:from-odoo-dark-teal/40 transition-colors"
-      aria-label="Ver documentos pendientes de validación"
-    >
-      <span className="text-xs uppercase tracking-wide font-medium text-text-secondary dark:text-text-dark-secondary">
-        Pendientes de validar
-      </span>
-      <span className="mt-1 text-4xl font-bold tabular-nums bg-gradient-to-br from-odoo-purple to-odoo-purple-d dark:from-odoo-dark-teal dark:to-odoo-dark-teal-d bg-clip-text text-transparent">
-        {loading ? '…' : error ? '—' : (count ?? 0)}
-      </span>
-      <span className="mt-1 text-xs text-text-muted dark:text-text-dark-muted">
-        {error ? 'Datos no disponibles' : 'Documentos en tu bandeja'}
-      </span>
-    </button>
+    <div className="w-full h-full rounded-xl bg-gradient-to-br from-odoo-purple/15 via-odoo-purple/5 to-transparent dark:from-odoo-dark-teal/25 dark:via-odoo-dark-teal/10 dark:to-transparent p-4">
+      <div className="flex items-baseline gap-2">
+        <span className="text-xs uppercase tracking-wide font-medium text-text-secondary dark:text-text-dark-secondary">
+          Pendientes de validar
+        </span>
+        <button
+          type="button"
+          onClick={() => emitFilter('all')}
+          disabled={loading}
+          className="text-4xl font-bold tabular-nums bg-gradient-to-br from-odoo-purple to-odoo-purple-d dark:from-odoo-dark-teal dark:to-odoo-dark-teal-d bg-clip-text text-transparent leading-none enabled:cursor-pointer disabled:opacity-70"
+          aria-label="Mostrar todos los pendientes de validar"
+          title="Mostrar todos"
+        >
+          {loading ? '…' : error ? '—' : (count ?? 0)}
+        </button>
+      </div>
+      {error ? (
+        <span className="mt-1 text-xs text-text-muted dark:text-text-dark-muted">
+          Datos no disponibles
+        </span>
+      ) : (
+        <div className="mt-2 flex flex-col gap-1.5 text-xs">
+          <button
+            type="button"
+            onClick={() => emitFilter('template')}
+            disabled={loading || templateCount === 0}
+            className={[
+              'text-left disabled:opacity-60 disabled:cursor-not-allowed',
+              activeFilter === 'template'
+                ? 'text-text-primary dark:text-text-dark-primary font-semibold'
+                : 'text-text-muted dark:text-text-dark-muted enabled:hover:text-text-primary dark:enabled:hover:text-text-dark-primary',
+            ].join(' ')}
+          >
+            Plantillas: {loading ? '…' : templateCount}
+          </button>
+          <button
+            type="button"
+            onClick={() => emitFilter('document')}
+            disabled={loading || documentCount === 0}
+            className={[
+              'text-left disabled:opacity-60 disabled:cursor-not-allowed',
+              activeFilter === 'document'
+                ? 'text-text-primary dark:text-text-dark-primary font-semibold'
+                : 'text-text-muted dark:text-text-dark-muted enabled:hover:text-text-primary dark:enabled:hover:text-text-dark-primary',
+            ].join(' ')}
+          >
+            Documentos: {loading ? '…' : documentCount}
+          </button>
+        </div>
+      )}
+    </div>
   );
 }

--- a/frontend/src/features/dashboard/widgets/PendingValidationsWidget.tsx
+++ b/frontend/src/features/dashboard/widgets/PendingValidationsWidget.tsx
@@ -14,7 +14,9 @@ export default function PendingValidationsWidget() {
     fetchDashboard()
       .then((data) => {
         if (!mounted) return;
-        setCount(data.document_review_inbox?.length ?? 0);
+        const pendingDocuments = data.document_review_inbox?.length ?? 0;
+        const pendingTemplates = data.template_review_inbox?.length ?? 0;
+        setCount(pendingDocuments + pendingTemplates);
       })
       .catch(() => {
         if (!mounted) return;

--- a/frontend/src/features/dashboard/widgets/RecentDocumentsWidget.tsx
+++ b/frontend/src/features/dashboard/widgets/RecentDocumentsWidget.tsx
@@ -1,25 +1,59 @@
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { fetchDocuments } from '../../../api/documents';
-import type { Document } from '../../../types/documents';
+import { fetchDashboard, type DocumentReviewInboxItem, type TemplateReviewInboxItem } from '../../../api/dashboard';
 
-/** Widget compacto: últimos 5 documentos ordenados por updated_at desc. */
+type PendingReviewItem =
+  | {
+      kind: 'template';
+      id: string;
+      title: string;
+      daysRemaining: number | null;
+    }
+  | {
+      kind: 'document';
+      id: string;
+      title: string;
+      daysRemaining: number | null;
+    };
+
+/** Widget compacto: pendientes de validar (plantillas + documentos). */
 export default function RecentDocumentsWidget() {
-  const [documents, setDocuments] = useState<Document[]>([]);
+  const [filter, setFilter] = useState<'all' | 'template' | 'document'>('all');
+  const [items, setItems] = useState<PendingReviewItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
 
   useEffect(() => {
     let mounted = true;
-    fetchDocuments()
+    fetchDashboard()
       .then((data) => {
         if (!mounted) return;
-        const sorted = [...data].sort((a, b) => {
-          const ta = a.updated_at ? new Date(a.updated_at).getTime() : 0;
-          const tb = b.updated_at ? new Date(b.updated_at).getTime() : 0;
-          return tb - ta;
-        });
-        setDocuments(sorted.slice(0, 5));
+        const templateItems: PendingReviewItem[] = (data.template_review_inbox ?? []).map(
+          (item: TemplateReviewInboxItem) => ({
+            kind: 'template',
+            id: item.template_id,
+            title: item.title?.trim() || 'Plantilla sin título',
+            daysRemaining: item.days_remaining ?? null,
+          }),
+        );
+        const documentItems: PendingReviewItem[] = (data.document_review_inbox ?? []).map(
+          (item: DocumentReviewInboxItem) => ({
+            kind: 'document',
+            id: item.document_id,
+            title: item.title?.trim() || 'Documento sin título',
+            daysRemaining: item.days_remaining ?? null,
+          }),
+        );
+        const merged = [...templateItems, ...documentItems]
+          .sort((a, b) => {
+            const da = a.daysRemaining;
+            const db = b.daysRemaining;
+            if (da == null && db == null) return a.title.localeCompare(b.title);
+            if (da == null) return 1;
+            if (db == null) return -1;
+            return da - db;
+          });
+        setItems(merged);
         setError(null);
       })
       .catch((err) => {
@@ -35,16 +69,23 @@ export default function RecentDocumentsWidget() {
     };
   }, []);
 
-  const formatRelative = (iso?: string | null) => {
-    if (!iso) return '—';
-    const date = new Date(iso);
-    const diffMs = Date.now() - date.getTime();
-    const days = Math.floor(diffMs / 86_400_000);
-    if (days <= 0) return 'hoy';
-    if (days === 1) return 'ayer';
-    if (days < 7) return `hace ${days} días`;
-    if (days < 30) return `hace ${Math.floor(days / 7)} sem.`;
-    return date.toLocaleDateString('es-ES');
+  useEffect(() => {
+    const handleFilterChange = (event: Event) => {
+      const customEvent = event as CustomEvent<{ filter?: 'all' | 'template' | 'document' }>;
+      const nextFilter = customEvent.detail?.filter ?? 'all';
+      setFilter(nextFilter);
+    };
+    window.addEventListener('maya:dms:pending-validations-filter-change', handleFilterChange as EventListener);
+    return () => {
+      window.removeEventListener('maya:dms:pending-validations-filter-change', handleFilterChange as EventListener);
+    };
+  }, []);
+
+  const formatRemaining = (daysRemaining: number | null): string => {
+    if (daysRemaining == null) return '—';
+    if (daysRemaining < 0) return `Vencido (${Math.abs(daysRemaining)}d)`;
+    if (daysRemaining === 0) return 'Vence hoy';
+    return `${daysRemaining}d`;
   };
 
   if (loading) {
@@ -63,27 +104,50 @@ export default function RecentDocumentsWidget() {
     );
   }
 
-  if (documents.length === 0) {
+  if (items.length === 0) {
     return (
       <p className="text-sm text-text-secondary dark:text-text-dark-secondary py-4 text-center">
-        No hay documentos recientes.
+        No tienes pendientes de validación.
+      </p>
+    );
+  }
+
+  const visibleItems =
+    filter === 'all' ? items : items.filter((item) => item.kind === filter);
+
+  if (visibleItems.length === 0) {
+    return (
+      <p className="text-sm text-text-secondary dark:text-text-dark-secondary py-4 text-center">
+        No hay pendientes para ese filtro.
       </p>
     );
   }
 
   return (
     <ul className="divide-y divide-ui-border-l dark:divide-ui-dark-border">
-      {documents.map((doc) => (
-        <li key={doc.id}>
+      {visibleItems.map((item) => (
+        <li key={`${item.kind}:${item.id}`}>
           <Link
-            to={`/documents/${doc.id}`}
+            to={item.kind === 'template' ? `/templates/${item.id}/review` : `/documents/${item.id}/validate`}
             className="flex items-center justify-between gap-3 py-2 px-1 hover:bg-ui-body dark:hover:bg-ui-dark-bg rounded transition-colors"
           >
-            <span className="text-sm font-medium text-text-primary dark:text-text-dark-primary truncate">
-              {doc.title?.trim() || 'Sin título'}
+            <span className="min-w-0 flex items-center gap-2">
+              <span
+                className={[
+                  'shrink-0 inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wide',
+                  item.kind === 'template'
+                    ? 'bg-odoo-purple/10 text-odoo-purple'
+                    : 'bg-odoo-teal/10 text-odoo-teal',
+                ].join(' ')}
+              >
+                {item.kind === 'template' ? 'TPL' : 'DOC'}
+              </span>
+              <span className="text-sm font-medium text-text-primary dark:text-text-dark-primary truncate">
+                {item.title}
+              </span>
             </span>
             <span className="text-xs text-text-muted dark:text-text-dark-muted shrink-0 tabular-nums">
-              {formatRelative(doc.updated_at)}
+              {formatRemaining(item.daysRemaining)}
             </span>
           </Link>
         </li>

--- a/frontend/src/features/dashboard/widgets/registry.ts
+++ b/frontend/src/features/dashboard/widgets/registry.ts
@@ -6,7 +6,7 @@ import PendingValidationsWidget from './PendingValidationsWidget';
 export const WIDGET_REGISTRY: WidgetRegistry = {
   'recent-documents': {
     id: 'recent-documents',
-    titleKey: 'dashboard.widgets.recentDocuments',
+    titleKey: 'dashboard.widgets.pendingValidations',
     defaultSize: { w: 6, h: 4 },
     minSize: { w: 4, h: 3 },
     component: RecentDocumentsWidget,

--- a/frontend/src/features/templates/components/TemplateReviewView.tsx
+++ b/frontend/src/features/templates/components/TemplateReviewView.tsx
@@ -6,8 +6,10 @@ import { visibilityLabel } from '../constants';
 import { BlockContentHtml } from './BlockContentHtml';
 import { Button, ConfirmDialog } from '@maya/shared-ui-react';
 import { approveTemplateReview, rejectTemplateReview } from '../../../api/templates';
+import { fetchProcesses } from '../../../api/processes';
 import { apiFetchJson } from '../../../api/http';
 import { useAuth } from '@maya/shared-auth-react';
+import type { Process } from '../../../types/processes';
 
 type Props = {
   template: Template;
@@ -70,6 +72,7 @@ export function TemplateReviewView({ template }: Props) {
   // Modales
   const [showRejectModal, setShowRejectModal] = useState(false);
   const [showNoCommentsWarning, setShowNoCommentsWarning] = useState(false);
+  const [processLabel, setProcessLabel] = useState<string | null>(null);
 
   // Estado de la barra lateral: 'comments' | 'info' | null
   const [sidebarMode, setSidebarMode] = useState<'comments' | 'info' | null>(null);
@@ -84,6 +87,30 @@ export function TemplateReviewView({ template }: Props) {
     // Cargar comentarios iniciales
     void loadComments();
   }, [template.id]);
+
+  useEffect(() => {
+    if (!template.process_id) {
+      setProcessLabel(null);
+      return;
+    }
+    let cancelled = false;
+    void fetchProcesses()
+      .then((res) => {
+        if (cancelled) return;
+        const process = res.data.find((p: Process) => p.id === template.process_id) ?? null;
+        if (!process) {
+          setProcessLabel(null);
+          return;
+        }
+        setProcessLabel(`Proceso: ${process.code} — ${process.name}`);
+      })
+      .catch(() => {
+        if (!cancelled) setProcessLabel(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [template.process_id]);
 
   const loadComments = async () => {
     try {
@@ -170,6 +197,11 @@ export function TemplateReviewView({ template }: Props) {
             <p className="text-xs text-text-muted uppercase tracking-widest font-black truncate max-w-[200px]">
               {template.name}
             </p>
+                            {processLabel && (
+                              <p className="text-[11px] text-text-muted mt-0.5 truncate max-w-[420px]">
+                                {processLabel}
+                              </p>
+                            )}
           </div>
         </div>
 

--- a/frontend/src/pages/DocumentPreviewPage.tsx
+++ b/frontend/src/pages/DocumentPreviewPage.tsx
@@ -1,10 +1,20 @@
 import { useEffect, useState } from 'react';
 import { Link, useLocation, useNavigate, useParams } from 'react-router-dom';
-import { fetchDocument, submitDocumentForReview, deleteDocument } from '../api/documents';
+import {
+  fetchDocument,
+  fetchDocumentReviews,
+  submitDocumentForReview,
+  deleteDocument,
+  approveDocumentReview,
+  rejectDocumentReview,
+  type DocumentReview,
+} from '../api/documents';
+import { fetchTemplate } from '../api/templates';
+import { fetchMe } from '../api/users';
 import { normalizeBlockContentForEditor } from '../features/documents/lib/normalizeBlockContent';
 import type { DocumentDetail, DocumentDisplayBlock } from '../types/documents';
 import { visibilityLabel } from '../features/templates/constants';
-import { Button, ConfirmDialog, statusBadgeClass } from '@maya/shared-ui-react';
+import { Button, ConfirmDialog, TextArea, statusBadgeClass } from '@maya/shared-ui-react';
 import { FavoriteButton } from '../components/FavoriteButton';
 import { VersionHistoryPanel } from '../components/VersionHistoryPanel';
 import { useUserProfile } from '../features/user-profile';
@@ -30,11 +40,45 @@ function formatDate(iso: string | null | undefined): string {
   return iso.slice(0, 10);
 }
 
-export function DocumentPreviewPage() {
+const DOCUMENT_REJECT_REASON_MIN_LEN = 5;
+
+function pickActionableDocumentReview(
+  reviews: DocumentReview[],
+  reviewerUserId: string,
+  reviewMode: 'sequential' | 'parallel',
+): DocumentReview | null {
+  const pending = reviews.filter((r) => r.status === 'pending');
+  if (pending.length === 0) return null;
+  const mine = pending.filter((r) => r.reviewer_id === reviewerUserId);
+  if (mine.length === 0) return null;
+  if (reviewMode !== 'sequential') return mine[0] ?? null;
+  const minStage = Math.min(...pending.map((r) => r.stage));
+  return mine.find((r) => r.stage === minStage) ?? null;
+}
+
+function validationSuccessBannerMessage(
+  updated: { title: string; status: string },
+  action: 'approve' | 'reject',
+): string {
+  if (action === 'reject') {
+    return 'Rechazo registrado. El documento ha vuelto a borrador para que el titular pueda corregirlo.';
+  }
+  if (updated.status === 'published') {
+    return `Validación realizada. El documento «${updated.title}» ha sido publicado.`;
+  }
+  return 'Validación realizada. Este documento se ha pasado al siguiente validador.';
+}
+
+type Props = {
+  mode?: 'preview' | 'validate';
+};
+
+export function DocumentPreviewPage({ mode = 'preview' }: Props = {}) {
   const { documentId } = useParams<{ documentId: string }>();
   const navigate = useNavigate();
   const location = useLocation();
   const { profile } = useUserProfile();
+  const isValidateMode = mode === 'validate';
 
   const [detail, setDetail] = useState<DocumentDetail | null>(null);
   const [loading, setLoading] = useState(true);
@@ -45,6 +89,13 @@ export function DocumentPreviewPage() {
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [deleteLoading, setDeleteLoading] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [validationReviewLoading, setValidationReviewLoading] = useState(false);
+  const [validationSetupError, setValidationSetupError] = useState<string | null>(null);
+  const [actionableReviewId, setActionableReviewId] = useState<string | null>(null);
+  const [validateConfirm, setValidateConfirm] = useState<null | 'approve' | 'reject'>(null);
+  const [validationActionLoading, setValidationActionLoading] = useState(false);
+  const [validationModalError, setValidationModalError] = useState<string | null>(null);
+  const [rejectReason, setRejectReason] = useState('');
 
   useEffect(() => {
     if (!documentId) {
@@ -83,6 +134,10 @@ export function DocumentPreviewPage() {
     : 'Volver';
 
   const handleBack = () => {
+    if (isValidateMode) {
+      navigate('/dashboard');
+      return;
+    }
     if (cameFromSummary && documentId) {
       if (cameFromValidate) {
         navigate(`/documents/${documentId}/validate`);
@@ -96,6 +151,56 @@ export function DocumentPreviewPage() {
 
   const isDraft = detail?.status === 'draft';
   const isOwner = profile?.id === detail?.owner_id || profile?.id === detail?.created_by;
+
+  useEffect(() => {
+    if (!isValidateMode) {
+      setValidationReviewLoading(false);
+      setValidationSetupError(null);
+      setActionableReviewId(null);
+      return;
+    }
+    if (!detail || detail.status !== 'in_review') return;
+
+    let cancelled = false;
+    setValidationReviewLoading(true);
+    setValidationSetupError(null);
+    setActionableReviewId(null);
+
+    void (async () => {
+      try {
+        const [reviews, meRes, templateResp] = await Promise.all([
+          fetchDocumentReviews(detail.id),
+          fetchMe(),
+          fetchTemplate(detail.template_id),
+        ]);
+        if (cancelled) return;
+        const reviewMode = templateResp.data.review_mode === 'sequential' ? 'sequential' : 'parallel';
+        const actionable = pickActionableDocumentReview(reviews, meRes.data.id, reviewMode);
+        if (!actionable) {
+          setValidationSetupError(
+            'No tienes una revisión pendiente que puedas tramitar para este documento.',
+          );
+          setActionableReviewId(null);
+        } else {
+          setActionableReviewId(actionable.id);
+          setValidationSetupError(null);
+        }
+      } catch (e) {
+        if (!cancelled) {
+          setValidationSetupError(
+            e instanceof Error ? e.message : 'No se pudo cargar la información de validación.',
+          );
+          setActionableReviewId(null);
+        }
+      } finally {
+        if (!cancelled) setValidationReviewLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isValidateMode, detail?.id, detail?.status, detail?.template_id]);
 
   const handleDelete = async () => {
     if (!documentId) return;
@@ -124,6 +229,54 @@ export function DocumentPreviewPage() {
     }
   };
 
+  const handleApproveValidation = async () => {
+    if (!documentId || !actionableReviewId) {
+      setValidationModalError('Faltan datos críticos para procesar la revisión.');
+      return;
+    }
+    setValidationModalError(null);
+    setValidationActionLoading(true);
+    try {
+      const updated = await approveDocumentReview(documentId, actionableReviewId, null);
+      setValidateConfirm(null);
+      navigate('/dashboard', {
+        state: { documentValidationBanner: validationSuccessBannerMessage(updated, 'approve') },
+      });
+    } catch (e) {
+      setValidationModalError(e instanceof Error ? e.message : 'No se pudo aprobar la revisión.');
+    } finally {
+      setValidationActionLoading(false);
+    }
+  };
+
+  const handleRejectValidation = async () => {
+    if (!documentId || !actionableReviewId) {
+      setValidationModalError('Faltan datos críticos para procesar la revisión.');
+      return;
+    }
+    const reason = rejectReason.trim();
+    if (reason.length < DOCUMENT_REJECT_REASON_MIN_LEN) {
+      setValidationModalError(
+        `Indica un motivo de rechazo de al menos ${DOCUMENT_REJECT_REASON_MIN_LEN} caracteres (obligatorio).`,
+      );
+      return;
+    }
+    setValidationModalError(null);
+    setValidationActionLoading(true);
+    try {
+      const updated = await rejectDocumentReview(documentId, actionableReviewId, reason);
+      setValidateConfirm(null);
+      setRejectReason('');
+      navigate('/dashboard', {
+        state: { documentValidationBanner: validationSuccessBannerMessage(updated, 'reject') },
+      });
+    } catch (e) {
+      setValidationModalError(e instanceof Error ? e.message : 'No se pudo rechazar la revisión.');
+    } finally {
+      setValidationActionLoading(false);
+    }
+  };
+
   const headerActions = detail ? (
     <>
       <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${statusBadgeClass(detail.status)}`}>
@@ -136,7 +289,7 @@ export function DocumentPreviewPage() {
       <Button type="button" variant="outline" size="sm" onClick={() => setShowHistory(true)}>
         Historial
       </Button>
-      {isDraft && isOwner && (
+      {!isValidateMode && isDraft && isOwner && (
         <Button
           type="button"
           variant="outline"
@@ -147,14 +300,14 @@ export function DocumentPreviewPage() {
           Eliminar
         </Button>
       )}
-      {isDraft && isOwner && documentId && (
+      {!isValidateMode && isDraft && isOwner && documentId && (
         <Link to={`/documents/${documentId}/editor`}>
           <Button type="button" size="sm" variant="outline">
             Editar
           </Button>
         </Link>
       )}
-      {isDraft && isOwner && (
+      {!isValidateMode && isDraft && isOwner && (
         <Button
           type="button"
           variant="primary"
@@ -165,6 +318,34 @@ export function DocumentPreviewPage() {
         >
           Enviar a validar
         </Button>
+      )}
+      {isValidateMode && (
+        <>
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            disabled={!actionableReviewId || validationReviewLoading}
+            onClick={() => {
+              setValidationModalError(null);
+              setValidateConfirm('reject');
+            }}
+          >
+            Rechazar
+          </Button>
+          <Button
+            type="button"
+            variant="primary"
+            size="sm"
+            disabled={!actionableReviewId || validationReviewLoading}
+            onClick={() => {
+              setValidationModalError(null);
+              setValidateConfirm('approve');
+            }}
+          >
+            Aprobar
+          </Button>
+        </>
       )}
     </>
   ) : null;
@@ -189,6 +370,137 @@ export function DocumentPreviewPage() {
     nodes: blockContentForPreview(b),
   }));
 
+  if (isValidateMode) {
+    return (
+      <>
+        <div className="flex flex-col h-full bg-ui-preview-bg dark:bg-ui-dark-bg/50">
+          <div className="shrink-0 px-6 py-3 bg-white dark:bg-ui-dark-card border-b border-ui-border dark:border-ui-dark-border flex items-center justify-between shadow-md z-20">
+            <div className="flex items-center gap-3 min-w-0">
+              <button
+                onClick={() => navigate('/dashboard')}
+                className="w-8 h-8 rounded-full flex items-center justify-center hover:bg-ui-body dark:hover:bg-ui-dark-bg text-text-secondary transition-colors"
+              >
+                ←
+              </button>
+              <div className="min-w-0">
+                <h2 className="text-sm font-bold text-text-primary dark:text-text-dark-primary">
+                  Validación de Documento
+                </h2>
+                <p className="text-xs text-text-muted uppercase tracking-widest font-black truncate max-w-[320px]">
+                  {detail?.title ?? 'Documento'}
+                </p>
+              </div>
+            </div>
+            <div className="flex items-center gap-2">
+              <Button
+                type="button"
+                variant="outlineWarning"
+                size="sm"
+                disabled={!actionableReviewId || validationReviewLoading}
+                onClick={() => {
+                  setValidationModalError(null);
+                  setValidateConfirm('reject');
+                }}
+                className="text-xs font-black uppercase tracking-wider"
+              >
+                Rechazar validación
+              </Button>
+              <Button
+                type="button"
+                variant="primary"
+                size="sm"
+                disabled={!actionableReviewId || validationReviewLoading}
+                onClick={() => {
+                  setValidationModalError(null);
+                  setValidateConfirm('approve');
+                }}
+                className="text-xs font-black uppercase tracking-wider px-6"
+              >
+                Validar y aprobar
+              </Button>
+            </div>
+          </div>
+
+          {validationSetupError && !validationReviewLoading && (
+            <div className="mx-6 mt-4 p-3 rounded-lg border border-danger/30 bg-danger/5 text-xs text-danger-dark font-bold">
+              ⚠ {validationSetupError}
+            </div>
+          )}
+          {validationReviewLoading && (
+            <div className="mx-6 mt-4 p-3 rounded-lg border border-ui-border dark:border-ui-dark-border text-xs text-text-muted">
+              Cargando datos de validación…
+            </div>
+          )}
+          {error && !loading && (
+            <div className="mx-6 mt-4 p-3 rounded-lg border border-danger/30 bg-danger/5 text-xs text-danger-dark font-bold">
+              ⚠ {error}
+            </div>
+          )}
+
+          <div className="flex-1 overflow-y-auto p-8 scroll-smooth custom-scrollbar">
+            <article
+              className="mx-auto bg-white dark:bg-ui-card shadow-2xl rounded-sm transition-all duration-300"
+              style={{ maxWidth: '850px', minHeight: '100%', padding: '60px 70px' }}
+            >
+              {!loading && !error && detail ? (
+                <PaperBlocksArticle
+                  title={detail.title}
+                  blocks={articleBlocks}
+                  emptyMessage="Este documento no tiene bloques."
+                />
+              ) : (
+                <p className="text-sm text-text-muted dark:text-text-dark-muted">Cargando documento…</p>
+              )}
+            </article>
+          </div>
+        </div>
+
+        <ConfirmDialog
+          open={validateConfirm === 'approve'}
+          title="Confirmar aprobación"
+          description="Se registrará tu aprobación. Si eres el último validador pendiente, el documento pasará a publicado."
+          confirmLabel="Aprobar"
+          error={validationModalError}
+          loading={validationActionLoading}
+          onCancel={() => {
+            setValidateConfirm(null);
+            setValidationModalError(null);
+          }}
+          onConfirm={() => void handleApproveValidation()}
+        />
+        <ConfirmDialog
+          open={validateConfirm === 'reject'}
+          title="Confirmar rechazo"
+          description={
+            <div className="space-y-2 text-left">
+              <p className="text-sm text-text-secondary dark:text-text-dark-secondary">
+                El documento volverá a borrador para que el titular pueda corregirlo. El resto de validadores dejarán
+                de tener esta revisión asignada.
+              </p>
+              <TextArea
+                fieldSize="comfortable"
+                rows={3}
+                value={rejectReason}
+                onChange={(e) => setRejectReason(e.target.value)}
+                placeholder={`Motivo del rechazo (obligatorio, mín. ${DOCUMENT_REJECT_REASON_MIN_LEN} caracteres)`}
+              />
+            </div>
+          }
+          confirmLabel="Rechazar"
+          variant="danger"
+          error={validationModalError}
+          loading={validationActionLoading}
+          onCancel={() => {
+            setValidateConfirm(null);
+            setValidationModalError(null);
+            setRejectReason('');
+          }}
+          onConfirm={() => void handleRejectValidation()}
+        />
+      </>
+    );
+  }
+
   return (
     <>
       <PaperPreviewLayout
@@ -206,6 +518,12 @@ export function DocumentPreviewPage() {
         )}
         {actionError && (
           <p className="text-sm text-warning-dark dark:text-warning-light mb-4">{actionError}</p>
+        )}
+        {isValidateMode && validationSetupError && !validationReviewLoading && (
+          <p className="text-sm text-warning-dark dark:text-warning-light mb-4">{validationSetupError}</p>
+        )}
+        {isValidateMode && validationReviewLoading && (
+          <p className="text-sm text-text-muted dark:text-text-dark-muted mb-4">Cargando datos de validación…</p>
         )}
         {!loading && !error && detail && (
           <PaperBlocksArticle

--- a/frontend/src/pages/DocumentPreviewPage.tsx
+++ b/frontend/src/pages/DocumentPreviewPage.tsx
@@ -10,6 +10,7 @@ import {
   type DocumentReview,
 } from '../api/documents';
 import { fetchTemplate } from '../api/templates';
+import { fetchProcesses } from '../api/processes';
 import { fetchMe } from '../api/users';
 import { normalizeBlockContentForEditor } from '../features/documents/lib/normalizeBlockContent';
 import type { DocumentDetail, DocumentDisplayBlock } from '../types/documents';
@@ -20,6 +21,7 @@ import { VersionHistoryPanel } from '../components/VersionHistoryPanel';
 import { useUserProfile } from '../features/user-profile';
 import { PaperPreviewLayout } from '../features/documents/components/PaperPreviewLayout';
 import { PaperBlocksArticle, type PaperArticleBlock } from '../features/documents/components/PaperBlocksArticle';
+import type { Process } from '../types/processes';
 
 // Estado: clases en `statusBadgeClass` (módulo `@maya/shared-ui-react/badges`).
 
@@ -96,6 +98,7 @@ export function DocumentPreviewPage({ mode = 'preview' }: Props = {}) {
   const [validationActionLoading, setValidationActionLoading] = useState(false);
   const [validationModalError, setValidationModalError] = useState<string | null>(null);
   const [rejectReason, setRejectReason] = useState('');
+  const [processLabel, setProcessLabel] = useState<string | null>(null);
 
   useEffect(() => {
     if (!documentId) {
@@ -201,6 +204,40 @@ export function DocumentPreviewPage({ mode = 'preview' }: Props = {}) {
       cancelled = true;
     };
   }, [isValidateMode, detail?.id, detail?.status, detail?.template_id]);
+
+  useEffect(() => {
+    if (!detail?.template_id) {
+      setProcessLabel(null);
+      return;
+    }
+    let cancelled = false;
+    void (async () => {
+      try {
+        const [templateResp, processesResp] = await Promise.all([
+          fetchTemplate(detail.template_id),
+          fetchProcesses(),
+        ]);
+        if (cancelled) return;
+        const processId = templateResp.data.process_id;
+        if (!processId) {
+          setProcessLabel(null);
+          return;
+        }
+        const process = processesResp.data.find((p: Process) => p.id === processId) ?? null;
+        if (!process) {
+          setProcessLabel(null);
+          return;
+        }
+        setProcessLabel(`Proceso: ${process.code} — ${process.name}`);
+      } catch {
+        if (!cancelled) setProcessLabel(null);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [detail?.template_id]);
 
   const handleDelete = async () => {
     if (!documentId) return;
@@ -352,6 +389,12 @@ export function DocumentPreviewPage({ mode = 'preview' }: Props = {}) {
 
   const headerMetaInfo = detail ? (
     <p className="text-xs text-text-muted dark:text-text-dark-muted text-center">
+      {processLabel ? (
+        <>
+          {processLabel}
+          {' · '}
+        </>
+      ) : null}
       {detail.owner_name ?? 'Autor desconocido'}
       {' · '}
       {detail.visibility_level ? visibilityLabel(detail.visibility_level) : (detail.is_shared_with_me ? 'Compartida' : 'Personal')}
@@ -389,6 +432,11 @@ export function DocumentPreviewPage({ mode = 'preview' }: Props = {}) {
                 <p className="text-xs text-text-muted uppercase tracking-widest font-black truncate max-w-[320px]">
                   {detail?.title ?? 'Documento'}
                 </p>
+                {processLabel && (
+                  <p className="text-[11px] text-text-muted mt-0.5 truncate max-w-[420px]">
+                    {processLabel}
+                  </p>
+                )}
               </div>
             </div>
             <div className="flex items-center gap-2">

--- a/frontend/src/pages/DocumentValidationPage.tsx
+++ b/frontend/src/pages/DocumentValidationPage.tsx
@@ -1,5 +1,5 @@
 import { Link, useParams } from 'react-router-dom';
-import { DocumentWizard } from '../features/documents/components/DocumentWizard';
+import { DocumentPreviewPage } from './DocumentPreviewPage';
 import { Button } from '@maya/shared-ui-react';
 
 /**
@@ -19,5 +19,5 @@ export function DocumentValidationPage() {
     );
   }
 
-  return <DocumentWizard documentId={documentId} mode="validate" />;
+  return <DocumentPreviewPage mode="validate" />;
 }


### PR DESCRIPTION
- Se corrigió la bandeja de revisión de plantillas en backend para respetar el modo secuencial: en review_mode = sequential solo se muestran revisiones de la etapa mínima pendiente.
- Se añadió test de regresión para cubrir el desbloqueo por etapas en dashboard de plantillas.
- En frontend se ajustó el acceso inicial para que la entrada a la aplicación sea siempre el panel (/dashboard), incluyendo el retorno tras autenticación.
- En dashboard frontend se unificó el flujo de pendientes de validar:
        - contador total = plantillas + documentos,
        - desglose por tipo (Plantillas / Documentos) con filtro sobre el listado,
        - clic en el total para mostrar todos los pendientes.
- Se transformó el widget/listado lateral para mostrar pendientes reales de validación (TPL + DOC) con navegación al flujo correcto:
        - plantillas → /templates/:id/review
        - documentos → /documents/:id/validate
- Se llevó la validación de documentos a una experiencia de previsualización con acciones en cabecera (paridad visual con revisión de plantillas), manteniendo el comportamiento actual de comentarios.
- Se añadió el contexto de proceso (Proceso: código — nombre) en cabeceras de revisión de plantillas y documentos.