### PR TITLE
Feature/revisar bloqueo enviar validar

### DIFF
--- a/backend/app/Services/DocumentBlockService.php
+++ b/backend/app/Services/DocumentBlockService.php
@@ -114,7 +114,11 @@ class DocumentBlockService
     public function assertMandatoryBlocksAreFilled(Document $document): void
     {
         $definitions = collect($this->blockDefinitionsForDocument($document))
-            ->filter(fn (array $def) => ($def['block_state'] ?? 'editable') !== 'optional');
+            ->filter(function (array $def): bool {
+                $state = (string) ($def['block_state'] ?? 'editable');
+
+                return $state !== 'optional' && $state !== 'locked';
+            });
 
         if ($definitions->isEmpty()) {
             return;

--- a/backend/tests/Feature/DocumentsTemplateVersionApiTest.php
+++ b/backend/tests/Feature/DocumentsTemplateVersionApiTest.php
@@ -809,6 +809,66 @@ class DocumentsTemplateVersionApiTest extends TestCase
             ->assertJsonPath('data.status', 'in_review');
     }
 
+    public function test_submit_document_allows_empty_locked_blocks(): void
+    {
+        $creatorId = (string) Str::uuid();
+        $this->grantPermissionsForUser($creatorId);
+        $reviewerId = 'ed568442-ece5-4c90-97ca-12c8969bb3a2';
+        [$hCreator, $hReviewer] = $this->authHeadersCreatorAndReviewer($creatorId, $reviewerId);
+
+        $tid = (string) Str::uuid();
+        $b1 = (string) Str::uuid();
+
+        Template::query()->forceCreate([
+            'id' => $tid,
+            'name' => 'Plantilla locked',
+            'description' => null,
+            'visibility_level' => TemplateVisibilityLevel::Personal->value,
+            'delivery_deadline' => null,
+            'study_type_id' => null,
+            'study_id' => null,
+            'module_id' => null,
+            'team_id' => null,
+            'created_by' => $creatorId,
+            'status' => 'draft',
+            'version' => 1,
+            'review_stages' => 1,
+            'review_mode' => 'sequential',
+        ]);
+
+        TemplateBlock::query()->forceCreate([
+            'id' => $b1,
+            'template_id' => $tid,
+            'title' => 'Bloque locked',
+            'default_content' => null,
+            'block_state' => 'locked',
+            'sort_order' => 0,
+        ]);
+
+        TemplateReviewer::query()->forceCreate([
+            'id' => (string) Str::uuid(),
+            'template_id' => $tid,
+            'user_id' => $reviewerId,
+            'stage' => 1,
+        ]);
+
+        $this->postJson("/api/v1/templates/{$tid}/submit-review", [], $hCreator)->assertOk();
+        $this->postJson("/api/v1/templates/{$tid}/publish", ['changelog' => 'v1'], $hReviewer)->assertOk();
+
+        $createDoc = $this->postJson('/api/v1/documents', [
+            'template_id' => $tid,
+            'title' => 'Doc locked vacío',
+            'delivery_deadline' => now()->addDay()->toDateString(),
+            'process_id' => '00000000-0000-0000-0000-000000000001',
+        ], $hCreator)->assertCreated();
+
+        $docId = (string) $createDoc->json('data.id');
+
+        $this->postJson("/api/v1/documents/{$docId}/submit", [], $hCreator)
+            ->assertOk()
+            ->assertJsonPath('data.status', 'in_review');
+    }
+
     public function test_approve_last_review_persists_published_document_version_snapshot(): void
     {
         $creatorId = (string) Str::uuid();

--- a/frontend/src/features/documents/components/DocumentWizard.tsx
+++ b/frontend/src/features/documents/components/DocumentWizard.tsx
@@ -1411,7 +1411,12 @@ export function DocumentWizard({ documentId, templateId, mode = 'edit' }: Props)
                 size="sm"
                 onClick={() =>
                   navigate(`/documents/${documentId}`, {
-                    state: { returnToStep: 'summary', returnToValidate: isValidateMode },
+                    state: {
+                      returnToStep: isValidateMode || !!documentId ? 'summary' : undefined,
+                      returnToValidate: isValidateMode,
+                      backTo: processBackTo,
+                      forceBackTo: !documentId && !isValidateMode,
+                    },
                   })
                 }
               >

--- a/frontend/src/pages/DocumentPreviewPage.tsx
+++ b/frontend/src/pages/DocumentPreviewPage.tsx
@@ -132,6 +132,7 @@ export function DocumentPreviewPage({ mode = 'preview' }: Props = {}) {
     returnToStep?: string;
     returnToValidate?: boolean;
     backTo?: string;
+    forceBackTo?: boolean;
   } | null;
   const cameFromSummary = previewState?.returnToStep === 'summary';
   const cameFromValidate = previewState?.returnToValidate === true;
@@ -156,6 +157,10 @@ export function DocumentPreviewPage({ mode = 'preview' }: Props = {}) {
       } else {
         navigate(`/documents/${documentId}/editor`, { state: { step: 'summary' } });
       }
+      return;
+    }
+    if (previewState?.forceBackTo) {
+      navigate(backTo);
       return;
     }
     if (window.history.length > 1) {


### PR DESCRIPTION
- Se corrigió la validación de envío a revisión para que solo exija bloques completables (editable/modifiable); los bloques locked no bloquean el envío.
- Se añadió test de regresión para cubrir el caso de documento con bloque locked vacío.
- Se ajustó la navegación de vuelta en previsualización de documentos para el flujo de creación:
desde resumen -> previsualización -> atrás ahora vuelve al listado del proceso (no al wizard),
manteniendo el retorno al resumen en edición/validación.