### PR TITLE
Feature/errores versionado clonacion

### DIFF
--- a/backend/app/DTOs/Documents/CreateDocumentDto.php
+++ b/backend/app/DTOs/Documents/CreateDocumentDto.php
@@ -16,6 +16,7 @@ readonly class CreateDocumentDto
         public ?string $studyTypeId = null,
         public ?string $studyId = null,
         public ?string $moduleId = null,
+        public ?string $teamId = null,
         public ?string $deliveryDeadline = null,
         public ?string $templateVersionId = null,
     ) {}

--- a/backend/app/DTOs/Templates/FilterTemplatesDto.php
+++ b/backend/app/DTOs/Templates/FilterTemplatesDto.php
@@ -10,6 +10,7 @@ readonly class FilterTemplatesDto
     public function __construct(
         public ?string $visibilityLevel = null,
         public ?string $status = null,
+        public bool $usableForDocuments = false,
         public ?string $studyTypeId = null,
         public ?string $studyId = null,
         public ?string $moduleId = null,

--- a/backend/app/Http/Controllers/Api/DocumentController.php
+++ b/backend/app/Http/Controllers/Api/DocumentController.php
@@ -316,6 +316,27 @@ class DocumentController extends Controller
     }
 
     /**
+     * Descarta una versión no publicada (head mutable) y restaura la última publicada.
+     */
+    public function destroyVersion(Request $request, string $document, string $version): JsonResponse
+    {
+        $model = $this->documentService->findOrFail($document);
+        $this->authorize('update', $model);
+        $this->assertOptionalProcessContextMatches((string) $model->process_id);
+
+        $actorId = (string) $request->user()->getAuthIdentifier();
+        $updated = $this->documentService->destroyVersion($model->id, $version, $actorId);
+        $blocks = $this->documentService->blocksForDisplay($updated);
+
+        return response()->json([
+            'data' => array_merge(
+                (new DocumentResource($updated))->toArray($request),
+                ['blocks' => $blocks],
+            ),
+        ]);
+    }
+
+    /**
      * Delegar documento a otro usuario.
      */
     public function delegate(DelegateDocumentRequest $request, string $id): JsonResponse

--- a/backend/app/Http/Controllers/Api/DocumentController.php
+++ b/backend/app/Http/Controllers/Api/DocumentController.php
@@ -43,7 +43,6 @@ class DocumentController extends Controller
 
         $documents = $this->documentService->listOrderedByCreatedAtDesc($processIdFilter);
         $this->attachLatestPublishedVersionMeta($documents);
-        $this->attachCanCloneMeta($documents, $request);
         $this->documentService->attachShareMetadataForViewer($documents, $viewerId);
         $this->apiTeamEmbedService->embedOnDocuments(
             $documents,

--- a/backend/app/Http/Controllers/Api/DocumentController.php
+++ b/backend/app/Http/Controllers/Api/DocumentController.php
@@ -19,7 +19,9 @@ use App\Services\Contracts\DocumentServiceInterface;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Illuminate\Http\Request;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Gate;
 
 class DocumentController extends Controller
 {
@@ -41,6 +43,7 @@ class DocumentController extends Controller
 
         $documents = $this->documentService->listOrderedByCreatedAtDesc($processIdFilter);
         $this->attachLatestPublishedVersionMeta($documents);
+        $this->attachCanCloneMeta($documents, $request);
         $this->documentService->attachShareMetadataForViewer($documents, $viewerId);
         $this->apiTeamEmbedService->embedOnDocuments(
             $documents,
@@ -101,6 +104,7 @@ class DocumentController extends Controller
     {
         $userId = (string) $request->user()->getAuthIdentifier();
         $document = $this->documentService->create($request->toDto($userId, $userId));
+        $this->attachCanCloneMeta($document, $request);
         $this->apiTeamEmbedService->embedOnDocument($document, $userId);
         $blocks = $this->documentService->blocksForDisplay($document);
 
@@ -122,6 +126,7 @@ class DocumentController extends Controller
 
         $userId = (string) $request->user()->getAuthIdentifier();
         $copy = $this->documentService->clone($document, $userId);
+        $this->attachCanCloneMeta($copy, $request);
         $this->apiTeamEmbedService->embedOnDocument($copy, $userId);
         $blocks = $this->documentService->blocksForDisplay($copy);
 
@@ -175,6 +180,7 @@ class DocumentController extends Controller
             $request->validated('template_version_id') ?? null,
             $request->validated('delivery_deadline'),
         );
+        $this->attachCanCloneMeta($document, $request);
         $this->apiTeamEmbedService->embedOnDocument($document, $userId);
         $blocks = $this->documentService->blocksForDisplay($document);
 
@@ -211,6 +217,7 @@ class DocumentController extends Controller
         $document = $this->documentService->findOrFail($id);
         $this->authorize('view', $document);
         $this->assertOptionalProcessContextMatches((string) $document->process_id);
+        $this->attachCanCloneMeta($document, $request);
         $this->documentService->attachShareMetadataForViewer(collect([$document]), $viewerId);
         $document->loadMissing(['owner']);
         $this->apiTeamEmbedService->embedOnDocument(
@@ -237,6 +244,7 @@ class DocumentController extends Controller
         $this->assertOptionalProcessContextMatches((string) $document->process_id);
 
         $updated = $this->documentService->update($id, $request->validated());
+        $this->attachCanCloneMeta($updated, $request);
         $this->apiTeamEmbedService->embedOnDocument(
             $updated,
             (string) $request->user()->getAuthIdentifier(),
@@ -270,6 +278,7 @@ class DocumentController extends Controller
 
         $actorId = (string) $request->user()->getAuthIdentifier();
         $updated = $this->documentService->submitToReview($document->id, $actorId);
+        $this->attachCanCloneMeta($updated, $request);
 
         return response()->json(['data' => (new DocumentResource($updated))->toArray($request)]);
     }
@@ -289,6 +298,7 @@ class DocumentController extends Controller
             $actorId,
             $request->validated('changelog'),
         );
+        $this->attachCanCloneMeta($updated, $request);
 
         return response()->json(['data' => (new DocumentResource($updated))->toArray($request)]);
     }
@@ -303,6 +313,7 @@ class DocumentController extends Controller
 
         $userId = (string) $request->user()->getAuthIdentifier();
         $updated = $this->documentService->startNewRevisionCycle($model->id, $userId);
+        $this->attachCanCloneMeta($updated, $request);
 
         $this->apiTeamEmbedService->embedOnDocument($updated, $userId);
         $blocks = $this->documentService->blocksForDisplay($updated);
@@ -326,6 +337,7 @@ class DocumentController extends Controller
 
         $actorId = (string) $request->user()->getAuthIdentifier();
         $updated = $this->documentService->destroyVersion($model->id, $version, $actorId);
+        $this->attachCanCloneMeta($updated, $request);
         $blocks = $this->documentService->blocksForDisplay($updated);
 
         return response()->json([
@@ -351,7 +363,34 @@ class DocumentController extends Controller
             (string) $request->validated('new_owner_id'),
             $actorId,
         );
+        $this->attachCanCloneMeta($updated, $request);
 
         return response()->json(['data' => (new DocumentResource($updated))->toArray($request)]);
+    }
+
+    /**
+     * Adjunta `can_clone` desde policy para evitar Gate dentro de Resource.
+     *
+     * @param  Document|Collection<int, Document>  $documents
+     */
+    private function attachCanCloneMeta(Document|Collection $documents, Request $request): void
+    {
+        $user = $request->user();
+        if ($user === null) {
+            return;
+        }
+
+        $attach = function (Document $document) use ($user): void {
+            $document->setAttribute('can_clone', Gate::forUser($user)->allows('clone', $document));
+        };
+
+        if ($documents instanceof Document) {
+            $attach($documents);
+            return;
+        }
+
+        foreach ($documents as $document) {
+            $attach($document);
+        }
     }
 }

--- a/backend/app/Http/Controllers/Api/DocumentController.php
+++ b/backend/app/Http/Controllers/Api/DocumentController.php
@@ -12,12 +12,14 @@ use App\Http\Requests\Documents\PublishDocumentRequest;
 use App\Http\Requests\Documents\StartNewDocumentRevisionRequest;
 use App\Http\Requests\Documents\StoreDocumentRequest;
 use App\Http\Requests\Documents\UpdateDocumentRequest;
+use App\Models\Document;
 use App\Http\Resources\DocumentResource;
 use App\Services\Contracts\ApiTeamEmbedServiceInterface;
 use App\Services\Contracts\DocumentServiceInterface;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
 
 class DocumentController extends Controller
 {
@@ -38,6 +40,7 @@ class DocumentController extends Controller
         $processIdFilter = is_string($processId) && $processId !== '' ? $processId : null;
 
         $documents = $this->documentService->listOrderedByCreatedAtDesc($processIdFilter);
+        $this->attachLatestPublishedVersionMeta($documents);
         $this->documentService->attachShareMetadataForViewer($documents, $viewerId);
         $this->apiTeamEmbedService->embedOnDocuments(
             $documents,
@@ -45,6 +48,50 @@ class DocumentController extends Controller
         );
 
         return DocumentResource::collection($documents);
+    }
+
+    /**
+     * Adjunta metadatos de última versión publicada por documento para construir vistas fallback.
+     *
+     * @param  \Illuminate\Support\Collection<int, Document>  $documents
+     */
+    private function attachLatestPublishedVersionMeta(\Illuminate\Support\Collection $documents): void
+    {
+        if ($documents->isEmpty()) {
+            return;
+        }
+
+        $ids = $documents->pluck('id')->filter(fn ($id) => is_string($id) && $id !== '')->values()->all();
+        if ($ids === []) {
+            return;
+        }
+
+        $rows = DB::table('entity_versions')
+            ->where('versionable_type', Document::class)
+            ->whereIn('versionable_id', $ids)
+            ->where('status', 'published')
+            ->where('version_number', '>', 0)
+            ->orderByDesc('version_number')
+            ->get(['versionable_id', 'id', 'version_number']);
+
+        /** @var array<string, object{versionable_id:string,id:string,version_number:int}> $latestByDocument */
+        $latestByDocument = [];
+        foreach ($rows as $row) {
+            $documentId = (string) $row->versionable_id;
+            if (! isset($latestByDocument[$documentId])) {
+                $latestByDocument[$documentId] = (object) [
+                    'versionable_id' => $documentId,
+                    'id' => (string) $row->id,
+                    'version_number' => (int) $row->version_number,
+                ];
+            }
+        }
+
+        foreach ($documents as $document) {
+            $meta = $latestByDocument[(string) $document->id] ?? null;
+            $document->setAttribute('latest_published_version_id', $meta?->id);
+            $document->setAttribute('latest_published_version_number', $meta?->version_number);
+        }
     }
 
     /**

--- a/backend/app/Http/Controllers/Api/TemplateController.php
+++ b/backend/app/Http/Controllers/Api/TemplateController.php
@@ -125,7 +125,7 @@ class TemplateController extends Controller
             abort(404);
         }
         $this->assertOptionalProcessContextMatches((string) $model->process_id);
-        $model->loadMissing(['reviewers', 'documentReviewers', 'creator']);
+        $model->loadMissing(['reviewers', 'documentReviewers.user', 'creator']);
 
         $this->apiTeamEmbedService->embedOnTemplate(
             $model,
@@ -266,6 +266,29 @@ class TemplateController extends Controller
 
         $updated = $this->templateService->startNewRevisionCycle(
             $model->id,
+            (string) $request->user()->getAuthIdentifier(),
+        );
+
+        $this->apiTeamEmbedService->embedOnTemplate(
+            $updated,
+            (string) $request->user()->getAuthIdentifier(),
+        );
+
+        return new TemplateResource($updated);
+    }
+
+    /**
+     * Descarta una versión no publicada en curso y restaura la última publicación.
+     */
+    public function destroyVersion(Request $request, string $template, string $version): TemplateResource
+    {
+        $model = $this->templateService->findOrFail($template);
+        $this->authorize('update', $model);
+        $this->assertOptionalProcessContextMatches((string) $model->process_id);
+
+        $updated = $this->templateService->destroyVersion(
+            $model->id,
+            $version,
             (string) $request->user()->getAuthIdentifier(),
         );
 

--- a/backend/app/Http/Controllers/Api/TemplateController.php
+++ b/backend/app/Http/Controllers/Api/TemplateController.php
@@ -23,6 +23,7 @@ use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Illuminate\Http\Resources\Json\ResourceCollection;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Gate;
 
 /**
@@ -45,6 +46,7 @@ class TemplateController extends Controller
     public function index(IndexTemplateRequest $request): AnonymousResourceCollection
     {
         $templates = $this->templateService->listFiltered($request->toFilterDto());
+        $this->attachLatestPublishedVersionMeta($templates);
 
         $this->apiTeamEmbedService->embedOnTemplates(
             $templates,
@@ -52,6 +54,50 @@ class TemplateController extends Controller
         );
 
         return TemplateResource::collection($templates);
+    }
+
+    /**
+     * Adjunta metadatos de última versión publicada por plantilla para construir vistas fallback.
+     *
+     * @param  \Illuminate\Support\Collection<int, Template>  $templates
+     */
+    private function attachLatestPublishedVersionMeta(\Illuminate\Support\Collection $templates): void
+    {
+        if ($templates->isEmpty()) {
+            return;
+        }
+
+        $ids = $templates->pluck('id')->filter(fn ($id) => is_string($id) && $id !== '')->values()->all();
+        if ($ids === []) {
+            return;
+        }
+
+        $rows = DB::table('entity_versions')
+            ->where('versionable_type', Template::class)
+            ->whereIn('versionable_id', $ids)
+            ->where('status', 'published')
+            ->where('version_number', '>', 0)
+            ->orderByDesc('version_number')
+            ->get(['versionable_id', 'id', 'version_number']);
+
+        /** @var array<string, object{versionable_id:string,id:string,version_number:int}> $latestByTemplate */
+        $latestByTemplate = [];
+        foreach ($rows as $row) {
+            $templateId = (string) $row->versionable_id;
+            if (! isset($latestByTemplate[$templateId])) {
+                $latestByTemplate[$templateId] = (object) [
+                    'versionable_id' => $templateId,
+                    'id' => (string) $row->id,
+                    'version_number' => (int) $row->version_number,
+                ];
+            }
+        }
+
+        foreach ($templates as $template) {
+            $meta = $latestByTemplate[(string) $template->id] ?? null;
+            $template->setAttribute('latest_published_version_id', $meta?->id);
+            $template->setAttribute('latest_published_version_number', $meta?->version_number);
+        }
     }
 
     /**

--- a/backend/app/Http/Controllers/Api/TemplateController.php
+++ b/backend/app/Http/Controllers/Api/TemplateController.php
@@ -242,12 +242,16 @@ class TemplateController extends Controller
         }
         $this->assertOptionalProcessContextMatches((string) $model->process_id);
 
+        $excludeCurrentPublishedVersion = (string) $model->status === 'published';
         $currentVersion = (int) $model->version;
 
         return TemplateVersionSummaryResource::collection(
             $this->templateService
                 ->listPublishedVersions($model->id)
-                ->reject(static fn ($row): bool => (int) $row->version_number === $currentVersion)
+                ->reject(
+                    static fn ($row): bool =>
+                        $excludeCurrentPublishedVersion && (int) $row->version_number === $currentVersion,
+                )
                 ->values(),
         );
     }

--- a/backend/app/Http/Controllers/Api/TemplateController.php
+++ b/backend/app/Http/Controllers/Api/TemplateController.php
@@ -242,8 +242,13 @@ class TemplateController extends Controller
         }
         $this->assertOptionalProcessContextMatches((string) $model->process_id);
 
+        $currentVersion = (int) $model->version;
+
         return TemplateVersionSummaryResource::collection(
-            $this->templateService->listPublishedVersions($model->id),
+            $this->templateService
+                ->listPublishedVersions($model->id)
+                ->reject(static fn ($row): bool => (int) $row->version_number === $currentVersion)
+                ->values(),
         );
     }
 

--- a/backend/app/Http/Requests/Documents/StoreDocumentRequest.php
+++ b/backend/app/Http/Requests/Documents/StoreDocumentRequest.php
@@ -55,6 +55,7 @@ class StoreDocumentRequest extends FormRequest
             'study_type_id' => ['sometimes', 'nullable', 'string', 'max:255'],
             'study_id' => ['sometimes', 'nullable', 'string', 'max:255'],
             'module_id' => ['sometimes', 'nullable', 'string', 'max:255'],
+            'team_id' => ['sometimes', 'nullable', 'uuid', 'exists:teams,id'],
             'delivery_deadline' => ['required', 'date', 'after_or_equal:today'],
             'process_id' => ['required', 'uuid', 'exists:processes,id'],
             'template_version_id' => [
@@ -129,6 +130,7 @@ class StoreDocumentRequest extends FormRequest
             studyTypeId: $this->validated('study_type_id') ?? null,
             studyId: $this->validated('study_id') ?? null,
             moduleId: $this->validated('module_id') ?? null,
+            teamId: $this->validated('team_id') ?? null,
             deliveryDeadline: $this->validated('delivery_deadline'),
             templateVersionId: $templateVersionId ?? null,
         );

--- a/backend/app/Http/Requests/Templates/IndexTemplateRequest.php
+++ b/backend/app/Http/Requests/Templates/IndexTemplateRequest.php
@@ -31,6 +31,7 @@ class IndexTemplateRequest extends FormRequest
         return [
             'visibility_level' => ['sometimes', 'nullable', Rule::enum(TemplateVisibilityLevel::class)],
             'status'           => ['sometimes', 'nullable', 'string', 'in:draft,in_review,published,archived'],
+            'usable_for_documents' => ['sometimes', 'boolean'],
             'study_type_id'    => ['sometimes', 'nullable', 'string', 'max:255'],
             'study_id'         => ['sometimes', 'nullable', 'string', 'max:255'],
             'module_id'        => ['sometimes', 'nullable', 'string', 'max:255'],
@@ -51,6 +52,7 @@ class IndexTemplateRequest extends FormRequest
         return new FilterTemplatesDto(
             visibilityLevel: $v['visibility_level'] ?? null,
             status: $v['status'] ?? null,
+            usableForDocuments: (bool) ($v['usable_for_documents'] ?? false),
             studyTypeId: $v['study_type_id'] ?? null,
             studyId: $v['study_id'] ?? null,
             moduleId: $v['module_id'] ?? null,

--- a/backend/app/Http/Resources/DocumentResource.php
+++ b/backend/app/Http/Resources/DocumentResource.php
@@ -42,6 +42,7 @@ class DocumentResource extends JsonResource
             'updated_at' => $this->updated_at?->toIso8601String(),
             'is_shared_with_me' => (bool) ($this->resource->getAttribute('is_shared_with_me') ?? false),
             'share_permission' => $this->resource->getAttribute('viewer_share_permission'),
+            'working_version_id' => $this->head_entity_version_id,
             'latest_published_version_id' => $this->resource->getAttribute('latest_published_version_id'),
             'latest_published_version_number' => $this->resource->getAttribute('latest_published_version_number'),
         ];

--- a/backend/app/Http/Resources/DocumentResource.php
+++ b/backend/app/Http/Resources/DocumentResource.php
@@ -25,6 +25,7 @@ class DocumentResource extends JsonResource
             'study_type_id' => $this->study_type_id,
             'study_id' => $this->study_id,
             'module_id' => $this->module_id,
+            'team_id' => $this->team_id,
             'delivery_deadline' => $this->delivery_deadline?->toIso8601String(),
             'created_by' => $this->created_by,
             'owner_id' => $this->owner_id,

--- a/backend/app/Http/Resources/DocumentResource.php
+++ b/backend/app/Http/Resources/DocumentResource.php
@@ -42,6 +42,8 @@ class DocumentResource extends JsonResource
             'updated_at' => $this->updated_at?->toIso8601String(),
             'is_shared_with_me' => (bool) ($this->resource->getAttribute('is_shared_with_me') ?? false),
             'share_permission' => $this->resource->getAttribute('viewer_share_permission'),
+            'latest_published_version_id' => $this->resource->getAttribute('latest_published_version_id'),
+            'latest_published_version_number' => $this->resource->getAttribute('latest_published_version_number'),
         ];
     }
 

--- a/backend/app/Http/Resources/DocumentResource.php
+++ b/backend/app/Http/Resources/DocumentResource.php
@@ -42,6 +42,7 @@ class DocumentResource extends JsonResource
             'updated_at' => $this->updated_at?->toIso8601String(),
             'is_shared_with_me' => (bool) ($this->resource->getAttribute('is_shared_with_me') ?? false),
             'share_permission' => $this->resource->getAttribute('viewer_share_permission'),
+            'can_clone' => (bool) ($this->resource->getAttribute('can_clone') ?? false),
             'working_version_id' => $this->head_entity_version_id,
             'latest_published_version_id' => $this->resource->getAttribute('latest_published_version_id'),
             'latest_published_version_number' => $this->resource->getAttribute('latest_published_version_number'),

--- a/backend/app/Http/Resources/TemplateResource.php
+++ b/backend/app/Http/Resources/TemplateResource.php
@@ -52,6 +52,8 @@ class TemplateResource extends JsonResource
             'created_at'         => $this->created_at?->toIso8601String(),
             'updated_at'         => $this->updated_at?->toIso8601String(),
             'has_review_comments' => (bool) ($this->resource->has_review_comments ?? false),
+            'latest_published_version_id' => $this->resource->getAttribute('latest_published_version_id'),
+            'latest_published_version_number' => $this->resource->getAttribute('latest_published_version_number'),
             'can_clone' => $request->user() !== null
                 && Gate::forUser($request->user())->allows('clone', $this->resource),
         ];

--- a/backend/app/Http/Resources/TemplateResource.php
+++ b/backend/app/Http/Resources/TemplateResource.php
@@ -49,6 +49,13 @@ class TemplateResource extends JsonResource
                 ->map(fn ($v) => $v->user_id)
                 ->values()
                 ->all()),
+            'document_reviewer_users' => $this->whenLoaded('documentReviewers', fn () => $this->documentReviewers
+                ->map(fn ($v) => [
+                    'user_id' => $v->user_id,
+                    'user_name' => optional($v->user)->name,
+                ])
+                ->values()
+                ->all()),
             'created_at'         => $this->created_at?->toIso8601String(),
             'updated_at'         => $this->updated_at?->toIso8601String(),
             'has_review_comments' => (bool) ($this->resource->has_review_comments ?? false),

--- a/backend/app/Http/Resources/TemplateVersionResource.php
+++ b/backend/app/Http/Resources/TemplateVersionResource.php
@@ -5,6 +5,7 @@ namespace App\Http\Resources;
 use App\Services\TemplateVersionBlockLayerResolver;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Facades\DB;
 
 class TemplateVersionResource extends JsonResource
 {
@@ -17,6 +18,14 @@ class TemplateVersionResource extends JsonResource
     {
         $blocksSnapshot = app(TemplateVersionBlockLayerResolver::class)
             ->resolveBlocksSnapshot((string) $this->resource->getKey());
+        $snapshotData = is_array($this->snapshot_data) ? $this->snapshot_data : [];
+        $templateSnapshot = isset($snapshotData['template']) && is_array($snapshotData['template'])
+            ? $snapshotData['template']
+            : null;
+        $authorId = isset($templateSnapshot['created_by']) && is_string($templateSnapshot['created_by']) && $templateSnapshot['created_by'] !== ''
+            ? $templateSnapshot['created_by']
+            : (is_string($this->created_by) && $this->created_by !== '' ? $this->created_by : null);
+        $publishedBy = is_string($this->published_by) && $this->published_by !== '' ? $this->published_by : null;
 
         $publishedAt = $this->published_at ?? null;
 
@@ -24,12 +33,26 @@ class TemplateVersionResource extends JsonResource
             'id' => $this->id,
             'template_id' => $this->versionable_id,
             'version_number' => $this->version_number,
+            'template_snapshot' => $templateSnapshot,
             'blocks_snapshot' => $blocksSnapshot,
             'changelog' => $this->changelog,
-            'published_by' => $this->published_by,
+            'published_by' => $publishedBy,
+            'published_by_name' => $publishedBy !== null ? $this->resolveUserNameById($publishedBy) : null,
+            'author_name' => $authorId !== null ? $this->resolveUserNameById($authorId) : null,
             'published_at' => $publishedAt?->toIso8601String(),
             'created_at' => $this->created_at?->toIso8601String(),
             'updated_at' => $this->updated_at?->toIso8601String(),
         ];
+    }
+
+    private function resolveUserNameById(string $userId): ?string
+    {
+        static $cache = [];
+        if (array_key_exists($userId, $cache)) {
+            return $cache[$userId];
+        }
+        $name = DB::table('users')->where('id', $userId)->value('name');
+        $cache[$userId] = is_string($name) && trim($name) !== '' ? trim($name) : null;
+        return $cache[$userId];
     }
 }

--- a/backend/app/Http/Resources/TemplateVersionSummaryResource.php
+++ b/backend/app/Http/Resources/TemplateVersionSummaryResource.php
@@ -4,6 +4,7 @@ namespace App\Http\Resources;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Facades\DB;
 
 /**
  * Historial de versiones publicadas (sin el JSONB de bloques).
@@ -19,14 +20,46 @@ class TemplateVersionSummaryResource extends JsonResource
     {
         $templateId = $this->template_id ?? $this->versionable_id;
         $publishedAt = $this->published_at ?? null;
+        $publishedBy = is_string($this->published_by) && $this->published_by !== '' ? $this->published_by : null;
+        $authorId = $this->extractAuthorIdFromSnapshot();
+        if ($authorId === null && is_string($this->created_by) && $this->created_by !== '') {
+            $authorId = $this->created_by;
+        }
 
         return [
             'id' => $this->id,
             'template_id' => $templateId,
             'version_number' => $this->version_number,
             'published_at' => $publishedAt?->toIso8601String(),
-            'published_by' => $this->published_by,
+            'published_by' => $publishedBy,
+            'published_by_name' => $publishedBy !== null ? $this->resolveUserNameById($publishedBy) : null,
+            'author_name' => $authorId !== null ? $this->resolveUserNameById($authorId) : null,
             'changelog' => $this->changelog,
         ];
+    }
+
+    private function extractAuthorIdFromSnapshot(): ?string
+    {
+        $snapshot = $this->snapshot_data;
+        if (is_string($snapshot)) {
+            $decoded = json_decode($snapshot, true);
+            $snapshot = is_array($decoded) ? $decoded : [];
+        }
+        if (! is_array($snapshot)) {
+            return null;
+        }
+        $authorId = data_get($snapshot, 'template.created_by');
+        return is_string($authorId) && $authorId !== '' ? $authorId : null;
+    }
+
+    private function resolveUserNameById(string $userId): ?string
+    {
+        static $cache = [];
+        if (array_key_exists($userId, $cache)) {
+            return $cache[$userId];
+        }
+        $name = DB::table('users')->where('id', $userId)->value('name');
+        $cache[$userId] = is_string($name) && trim($name) !== '' ? trim($name) : null;
+        return $cache[$userId];
     }
 }

--- a/backend/app/Models/Template.php
+++ b/backend/app/Models/Template.php
@@ -53,11 +53,14 @@ class Template extends Model
 
             $builder->where(function (Builder $outer) use ($userId) {
                 $outer->where('template_head_ev.snapshot_data->template->created_by', $userId)
-                    ->orWhereExists(function ($subQuery) use ($userId) {
-                        $subQuery->select(DB::raw(1))
-                            ->from('template_reviewers')
-                            ->whereColumn('template_reviewers.template_id', 'templates.id')
-                            ->where('template_reviewers.user_id', $userId);
+                    ->orWhere(function (Builder $reviewScope) use ($userId) {
+                        $reviewScope->where('template_head_ev.snapshot_data->template->status', 'in_review')
+                            ->whereExists(function ($subQuery) use ($userId) {
+                                $subQuery->select(DB::raw(1))
+                                    ->from('template_reviewers')
+                                    ->whereColumn('template_reviewers.template_id', 'templates.id')
+                                    ->where('template_reviewers.user_id', $userId);
+                            });
                     });
 
                 $outer->orWhere(fn (Builder $shared) => self::scopeSharedTemplatesForTeacher($shared, $userId));

--- a/backend/app/Models/TemplateDocumentReviewer.php
+++ b/backend/app/Models/TemplateDocumentReviewer.php
@@ -30,4 +30,9 @@ class TemplateDocumentReviewer extends Model
         return $this->belongsTo(Template::class);
     }
 
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
+
 }

--- a/backend/app/Repositories/Eloquent/TemplateRepository.php
+++ b/backend/app/Repositories/Eloquent/TemplateRepository.php
@@ -81,6 +81,17 @@ class TemplateRepository implements TemplateRepositoryInterface
         if ($filters->status !== null) {
             $query->where('template_head_ev.snapshot_data->template->status', $filters->status);
         }
+        if ($filters->usableForDocuments) {
+            $query->where('template_head_ev.snapshot_data->template->status', '!=', 'archived')
+                ->whereExists(function ($q) {
+                    $q->select(DB::raw(1))
+                        ->from('entity_versions as published_ev')
+                        ->whereColumn('published_ev.versionable_id', 'templates.id')
+                        ->where('published_ev.versionable_type', Template::class)
+                        ->where('published_ev.status', 'published')
+                        ->where('published_ev.version_number', '>', 0);
+                });
+        }
         if ($filters->studyTypeId !== null) {
             $query->where('template_head_ev.snapshot_data->template->study_type_id', $filters->studyTypeId);
         }
@@ -321,8 +332,15 @@ class TemplateRepository implements TemplateRepositoryInterface
     public function listPublishedByModule(string $moduleId): Collection
     {
         return Template::query()
-            ->where('template_head_ev.snapshot_data->template->status', 'published')
             ->where('template_head_ev.snapshot_data->template->module_id', $moduleId)
+            ->whereExists(function ($q) {
+                $q->select(DB::raw(1))
+                    ->from('entity_versions as published_ev')
+                    ->whereColumn('published_ev.versionable_id', 'templates.id')
+                    ->where('published_ev.versionable_type', Template::class)
+                    ->where('published_ev.status', 'published')
+                    ->where('published_ev.version_number', '>', 0);
+            })
             ->orderByDesc('templates.updated_at')
             ->get();
     }

--- a/backend/app/Services/ApiTeamEmbedService.php
+++ b/backend/app/Services/ApiTeamEmbedService.php
@@ -44,7 +44,7 @@ class ApiTeamEmbedService implements ApiTeamEmbedServiceInterface
     public function embedOnDocument(Document $document, string $viewerUserId): void
     {
         $document->loadMissing('template');
-        $teamCatalogId = $document->template?->team_id;
+        $teamCatalogId = $document->team_id ?? $document->template?->team_id;
 
         $team = $this->teamReadService->embeddableTeam(
             $teamCatalogId !== null ? (string) $teamCatalogId : null,

--- a/backend/app/Services/Contracts/DocumentServiceInterface.php
+++ b/backend/app/Services/Contracts/DocumentServiceInterface.php
@@ -141,7 +141,16 @@ interface DocumentServiceInterface
     /**
      * Opciones de creación de documento disponibles para un módulo.
      *
-     * @return list<array{template_id: string, template_version_id: string, process_id: string, name: string, description: ?string}>
+     * @return list<array{
+     *   template_id: string,
+     *   template_version_id: string,
+     *   process_id: string,
+     *   name: string,
+     *   description: ?string,
+     *   visibility_level: string,
+     *   team_id: ?string,
+     *   team_name: ?string
+     * }>
      */
     public function creationOptionsForModule(string $moduleId): array;
 

--- a/backend/app/Services/Contracts/DocumentServiceInterface.php
+++ b/backend/app/Services/Contracts/DocumentServiceInterface.php
@@ -73,6 +73,11 @@ interface DocumentServiceInterface
     public function startNewRevisionCycle(string $documentId, string $actorId): Document;
 
     /**
+     * Descarta una versión no publicada en curso y restaura la última publicación.
+     */
+    public function destroyVersion(string $documentId, string $versionId, string $actorId): Document;
+
+    /**
      * Delega la propiedad del documento a otro usuario.
      */
     public function delegateOwner(string $documentId, string $newOwnerId, string $actorId): Document;

--- a/backend/app/Services/Contracts/TemplateServiceInterface.php
+++ b/backend/app/Services/Contracts/TemplateServiceInterface.php
@@ -102,6 +102,11 @@ interface TemplateServiceInterface
     public function startNewRevisionCycle(string $templateId, string $actorId): Template;
 
     /**
+     * Descarta una versión no publicada en curso y restaura la última publicación.
+     */
+    public function destroyVersion(string $templateId, string $versionId, string $actorId): Template;
+
+    /**
      * Registra la aprobación del revisor activo. Si todos los revisores han aprobado,
      * publica la plantilla automáticamente con un snapshot.
      *

--- a/backend/app/Services/DocumentService.php
+++ b/backend/app/Services/DocumentService.php
@@ -10,6 +10,7 @@ use App\Models\DocumentBlock;
 use App\Models\DocumentVersion;
 use App\Models\EntityVersion;
 use App\Models\Template;
+use App\Enums\TemplateVisibilityLevel;
 use App\Repositories\Contracts\DocumentRepositoryInterface;
 use App\Repositories\Contracts\EntityVersionRepositoryInterface;
 use App\Repositories\Contracts\TemplateRepositoryInterface;
@@ -17,6 +18,7 @@ use App\Services\Contracts\DocumentServiceInterface;
 use App\Services\Contracts\SnapshotServiceInterface;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\ValidationException;
 
 class DocumentService implements DocumentServiceInterface
@@ -85,14 +87,224 @@ class DocumentService implements DocumentServiceInterface
             ->values()
             ->all();
 
+        $templateMeta = is_array($ev->snapshot_data ?? null)
+            ? ($ev->snapshot_data['template'] ?? null)
+            : null;
+        $visibility = is_array($templateMeta) ? ($templateMeta['visibility_level'] ?? null) : null;
+        $isTeamScopedTemplate = $visibility === TemplateVisibilityLevel::Team->value;
+
+        $studyTypeId = $dto->studyTypeId;
+        $studyId = $dto->studyId;
+        $moduleId = $dto->moduleId;
+        $teamId = $dto->teamId;
+        $templateStudyTypeId = is_array($templateMeta) && isset($templateMeta['study_type_id']) && is_string($templateMeta['study_type_id']) && $templateMeta['study_type_id'] !== ''
+            ? $templateMeta['study_type_id']
+            : null;
+        $templateStudyId = is_array($templateMeta) && isset($templateMeta['study_id']) && is_string($templateMeta['study_id']) && $templateMeta['study_id'] !== ''
+            ? $templateMeta['study_id']
+            : null;
+        $templateModuleId = is_array($templateMeta) && isset($templateMeta['module_id']) && is_string($templateMeta['module_id']) && $templateMeta['module_id'] !== ''
+            ? $templateMeta['module_id']
+            : null;
+
+        if ($isTeamScopedTemplate) {
+            $templateTeamId = is_array($templateMeta) ? ($templateMeta['team_id'] ?? null) : null;
+            if (! is_string($templateTeamId) || $templateTeamId === '') {
+                throw ValidationException::withMessages([
+                    'template_id' => ['La plantilla de equipo no tiene un equipo válido asociado.'],
+                ]);
+            }
+
+            // Un documento basado en plantilla de equipo no debe quedar asociado a contexto académico.
+            $studyTypeId = null;
+            $studyId = null;
+            $moduleId = null;
+            $teamId = $templateTeamId;
+        } elseif ($visibility === TemplateVisibilityLevel::Personal->value) {
+            if (
+                ($dto->studyTypeId !== null && $dto->studyTypeId !== $templateStudyTypeId) ||
+                ($dto->studyId !== null && $dto->studyId !== $templateStudyId) ||
+                ($dto->moduleId !== null && $dto->moduleId !== $templateModuleId) ||
+                $dto->teamId !== null
+            ) {
+                throw ValidationException::withMessages([
+                    'template_id' => ['Las plantillas personales no permiten cambiar el contexto académico al crear documentos.'],
+                ]);
+            }
+            $studyTypeId = $templateStudyTypeId;
+            $studyId = $templateStudyId;
+            $moduleId = $templateModuleId;
+            $teamId = null;
+        } elseif ($visibility === TemplateVisibilityLevel::Module->value) {
+            if ($dto->teamId !== null) {
+                throw ValidationException::withMessages([
+                    'team_id' => ['Las plantillas de módulo no permiten asignar equipo al documento.'],
+                ]);
+            }
+            if ($templateModuleId === null) {
+                throw ValidationException::withMessages([
+                    'template_id' => ['La plantilla de módulo no tiene un módulo válido asociado.'],
+                ]);
+            }
+            if ($dto->moduleId !== null && $dto->moduleId !== $templateModuleId) {
+                throw ValidationException::withMessages([
+                    'module_id' => ['El documento debe crearse en el mismo módulo de la plantilla.'],
+                ]);
+            }
+            $studyTypeId = $templateStudyTypeId;
+            $studyId = $templateStudyId;
+            $moduleId = $templateModuleId;
+            $teamId = null;
+        } elseif ($visibility === TemplateVisibilityLevel::Study->value) {
+            if ($dto->teamId !== null) {
+                throw ValidationException::withMessages([
+                    'team_id' => ['Las plantillas de estudio no permiten asignar equipo al documento.'],
+                ]);
+            }
+            if ($templateStudyId === null) {
+                throw ValidationException::withMessages([
+                    'template_id' => ['La plantilla de estudio no tiene un estudio válido asociado.'],
+                ]);
+            }
+            if ($dto->studyId !== null && $dto->studyId !== $templateStudyId) {
+                throw ValidationException::withMessages([
+                    'study_id' => ['El documento debe crearse en el mismo estudio o en un módulo de ese estudio.'],
+                ]);
+            }
+            if ($dto->moduleId !== null) {
+                $moduleStudyId = DB::table('course_modules')
+                    ->where('id', $dto->moduleId)
+                    ->value('study_id');
+                if (! is_string($moduleStudyId) || $moduleStudyId !== $templateStudyId) {
+                    throw ValidationException::withMessages([
+                        'module_id' => ['El módulo debe pertenecer al mismo estudio de la plantilla.'],
+                    ]);
+                }
+                $moduleId = $dto->moduleId;
+                $studyId = $templateStudyId;
+            } else {
+                $moduleId = null;
+                $studyId = $templateStudyId;
+            }
+            $studyTypeId = $templateStudyTypeId;
+            $teamId = null;
+        } elseif ($visibility === TemplateVisibilityLevel::StudyType->value) {
+            if ($dto->teamId !== null) {
+                throw ValidationException::withMessages([
+                    'team_id' => ['Las plantillas por tipo de estudio no permiten asignar equipo al documento.'],
+                ]);
+            }
+            if ($templateStudyTypeId === null) {
+                throw ValidationException::withMessages([
+                    'template_id' => ['La plantilla por tipo de estudio no tiene un study_type válido asociado.'],
+                ]);
+            }
+            if ($dto->studyTypeId !== null && $dto->studyTypeId !== $templateStudyTypeId) {
+                throw ValidationException::withMessages([
+                    'study_type_id' => ['El documento debe crearse en el mismo tipo de estudio o en niveles inferiores.'],
+                ]);
+            }
+            if ($dto->moduleId !== null) {
+                $module = DB::table('course_modules')
+                    ->join('studies', 'studies.id', '=', 'course_modules.study_id')
+                    ->where('course_modules.id', $dto->moduleId)
+                    ->select('course_modules.study_id', 'studies.study_type_id')
+                    ->first();
+                if (! $module || (string) $module->study_type_id !== $templateStudyTypeId) {
+                    throw ValidationException::withMessages([
+                        'module_id' => ['El módulo debe pertenecer a un estudio del mismo tipo que la plantilla.'],
+                    ]);
+                }
+                if ($dto->studyId !== null && $dto->studyId !== (string) $module->study_id) {
+                    throw ValidationException::withMessages([
+                        'study_id' => ['El estudio indicado no corresponde con el módulo seleccionado.'],
+                    ]);
+                }
+                $moduleId = $dto->moduleId;
+                $studyId = (string) $module->study_id;
+            } elseif ($dto->studyId !== null) {
+                $studyTypeFromStudy = DB::table('studies')
+                    ->where('id', $dto->studyId)
+                    ->value('study_type_id');
+                if (! is_string($studyTypeFromStudy) || $studyTypeFromStudy !== $templateStudyTypeId) {
+                    throw ValidationException::withMessages([
+                        'study_id' => ['El estudio debe pertenecer al mismo tipo de estudio de la plantilla.'],
+                    ]);
+                }
+                $studyId = $dto->studyId;
+                $moduleId = null;
+            } else {
+                $studyId = null;
+                $moduleId = null;
+            }
+            $studyTypeId = $templateStudyTypeId;
+            $teamId = null;
+        } elseif ($visibility === TemplateVisibilityLevel::Global->value) {
+            if ($dto->teamId !== null) {
+                if ($dto->studyTypeId !== null || $dto->studyId !== null || $dto->moduleId !== null) {
+                    throw ValidationException::withMessages([
+                        'team_id' => ['En plantillas globales, selecciona equipo o contexto académico, pero no ambos a la vez.'],
+                    ]);
+                }
+                $isTeamMember = DB::table('team_members')
+                    ->where('team_id', $dto->teamId)
+                    ->where('user_id', $dto->createdBy)
+                    ->exists();
+                if (! $isTeamMember) {
+                    throw ValidationException::withMessages([
+                        'team_id' => ['Solo miembros del equipo seleccionado pueden crear este documento en ese equipo.'],
+                    ]);
+                }
+                $teamId = $dto->teamId;
+                $studyTypeId = null;
+                $studyId = null;
+                $moduleId = null;
+            } elseif ($dto->moduleId !== null) {
+                $module = DB::table('course_modules')
+                    ->where('id', $dto->moduleId)
+                    ->select('study_id')
+                    ->first();
+                if (! $module || ! is_string($module->study_id)) {
+                    throw ValidationException::withMessages([
+                        'module_id' => ['El módulo seleccionado no existe.'],
+                    ]);
+                }
+                if ($dto->studyId !== null && $dto->studyId !== (string) $module->study_id) {
+                    throw ValidationException::withMessages([
+                        'study_id' => ['El estudio indicado no corresponde con el módulo seleccionado.'],
+                    ]);
+                }
+                $moduleId = $dto->moduleId;
+                $studyId = (string) $module->study_id;
+                $studyTypeId = DB::table('studies')->where('id', $studyId)->value('study_type_id');
+                $teamId = null;
+            } elseif ($dto->studyId !== null) {
+                $studyId = $dto->studyId;
+                $moduleId = null;
+                $studyTypeId = DB::table('studies')->where('id', $studyId)->value('study_type_id');
+                $teamId = null;
+            } elseif ($dto->studyTypeId !== null) {
+                $studyTypeId = $dto->studyTypeId;
+                $studyId = null;
+                $moduleId = null;
+                $teamId = null;
+            } else {
+                $studyTypeId = null;
+                $studyId = null;
+                $moduleId = null;
+                $teamId = null;
+            }
+        }
+
         return $this->documentRepository->createDocumentWithBlocks([
             'process_id' => $dto->processId,
             'template_id' => $dto->templateId,
             'template_version_id' => (string) $ev->id,
             'title' => $dto->title,
-            'study_type_id' => $dto->studyTypeId,
-            'study_id' => $dto->studyId,
-            'module_id' => $dto->moduleId,
+            'study_type_id' => $studyTypeId,
+            'study_id' => $studyId,
+            'module_id' => $moduleId,
+            'team_id' => $teamId,
             'delivery_deadline' => $dto->deliveryDeadline,
             'created_by' => $dto->createdBy,
             'owner_id' => $dto->ownerId,
@@ -153,6 +365,7 @@ class DocumentService implements DocumentServiceInterface
                 'study_type_id' => $source->study_type_id,
                 'study_id' => $source->study_id,
                 'module_id' => $source->module_id,
+                'team_id' => $source->team_id,
                 'delivery_deadline' => $source->delivery_deadline,
                 'created_by' => $actorId,
                 'owner_id' => $actorId,
@@ -225,6 +438,7 @@ class DocumentService implements DocumentServiceInterface
             'study_type_id' => array_key_exists('study_type_id', $docSnap) ? $docSnap['study_type_id'] : $source->study_type_id,
             'study_id' => array_key_exists('study_id', $docSnap) ? $docSnap['study_id'] : $source->study_id,
             'module_id' => array_key_exists('module_id', $docSnap) ? $docSnap['module_id'] : $source->module_id,
+            'team_id' => array_key_exists('team_id', $docSnap) ? $docSnap['team_id'] : $source->team_id,
             'delivery_deadline' => $source->delivery_deadline,
             'created_by' => $actorId,
             'owner_id' => $actorId,
@@ -255,8 +469,17 @@ class DocumentService implements DocumentServiceInterface
 
     /**
      * Opciones de creación de documento disponibles para un módulo.
-     * 
-     * @return list<array{template_id: string, template_version_id: string, process_id: string, name: string, description: ?string}>
+     *
+     * @return list<array{
+     *   template_id: string,
+     *   template_version_id: string,
+     *   process_id: string,
+     *   name: string,
+     *   description: ?string,
+     *   visibility_level: string,
+     *   team_id: ?string,
+     *   team_name: ?string
+     * }>
      */
     public function creationOptionsForModule(string $moduleId): array
     {
@@ -275,6 +498,13 @@ class DocumentService implements DocumentServiceInterface
                 'process_id' => (string) $template->process_id,
                 'name' => (string) $template->name,
                 'description' => $template->description,
+                'visibility_level' => $template->visibility_level instanceof TemplateVisibilityLevel
+                    ? $template->visibility_level->value
+                    : (string) $template->visibility_level,
+                'team_id' => $template->team_id !== null ? (string) $template->team_id : null,
+                'team_name' => $template->team_id !== null
+                    ? (DB::table('teams')->where('id', (string) $template->team_id)->value('name') ?: null)
+                    : null,
             ];
         }
 

--- a/backend/app/Services/DocumentService.php
+++ b/backend/app/Services/DocumentService.php
@@ -19,6 +19,7 @@ use App\Services\Contracts\SnapshotServiceInterface;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
 use Illuminate\Validation\ValidationException;
 
 class DocumentService implements DocumentServiceInterface
@@ -754,6 +755,121 @@ class DocumentService implements DocumentServiceInterface
         }
 
         return $this->documentStateService->transition($documentId, 'draft', $actorId);
+    }
+
+    /**
+     * Descarta la versión de trabajo del documento y restaura la última publicación.
+     */
+    public function destroyVersion(string $documentId, string $versionId, string $actorId): Document
+    {
+        return $this->documentRepository->transaction(function () use ($documentId, $versionId) {
+            $document = $this->documentRepository->findOrFail($documentId);
+            $document->loadMissing('headVersion');
+            $head = $document->headVersion;
+
+            if ($head === null || (string) $head->id !== $versionId || (int) $head->version_number !== 0) {
+                throw ValidationException::withMessages([
+                    'version' => ['Solo se puede descartar la versión de trabajo actual del documento.'],
+                ]);
+            }
+
+            if (! in_array((string) $head->status, ['draft', 'in_review'], true)) {
+                throw ValidationException::withMessages([
+                    'version' => ['Solo se pueden descartar versiones no publicadas (draft/in_review).'],
+                ]);
+            }
+
+            $latestPublished = $this->entityVersionRepository->findLatestPublishedForEntity(Document::class, $documentId);
+            if ($latestPublished === null || ! is_array($latestPublished->snapshot_data)) {
+                throw ValidationException::withMessages([
+                    'version' => ['No existe una versión publicada a la que restaurar.'],
+                ]);
+            }
+
+            $publishedSnapshot = $latestPublished->snapshot_data;
+            $publishedBlocks = isset($publishedSnapshot['blocks']) && is_array($publishedSnapshot['blocks'])
+                ? $publishedSnapshot['blocks']
+                : [];
+
+            $head->snapshot_data = $publishedSnapshot;
+            $head->status = 'published';
+            $head->updated_at = now();
+            $head->save();
+
+            $this->restorePublishedDocumentBlocks($documentId, $publishedBlocks);
+            $this->documentRepository->deleteReviewsForDocument($documentId);
+
+            // Re-sincroniza estado de cabecera delegado tras restaurar snapshot.
+            $this->documentRepository->mergeHeadWorkingCopy($document, [
+                'status' => 'published',
+            ]);
+
+            return $this->documentRepository->findOrFailForRefreshAfterMutation($documentId);
+        });
+    }
+
+    /**
+     * Restaura los bloques de un documento desde una versión publicada.
+     * 
+     * @param list<array<string, mixed>> $publishedBlocks
+     */
+    private function restorePublishedDocumentBlocks(string $documentId, array $publishedBlocks): void
+    {
+        $existingByTemplateBlock = DocumentBlock::query()
+            ->where('document_id', $documentId)
+            ->get()
+            ->filter(fn (DocumentBlock $block): bool => is_string($block->template_block_id) && $block->template_block_id !== '')
+            ->keyBy(fn (DocumentBlock $block): string => (string) $block->template_block_id);
+
+        $seenTemplateBlockIds = [];
+        foreach ($publishedBlocks as $index => $row) {
+            if (! is_array($row)) {
+                continue;
+            }
+
+            $templateBlockId = isset($row['template_block_id']) && is_string($row['template_block_id']) && $row['template_block_id'] !== ''
+                ? $row['template_block_id']
+                : null;
+            if ($templateBlockId === null) {
+                continue;
+            }
+
+            $seenTemplateBlockIds[] = $templateBlockId;
+
+            $payload = [
+                'content' => array_key_exists('content', $row) ? $row['content'] : null,
+                'is_filled' => (bool) ($row['is_filled'] ?? false),
+                'sort_order' => isset($row['sort_order']) ? (int) $row['sort_order'] : $index,
+                'last_edited_by' => isset($row['last_edited_by']) && is_string($row['last_edited_by']) ? $row['last_edited_by'] : null,
+                'locked_by' => isset($row['locked_by']) && is_string($row['locked_by']) ? $row['locked_by'] : null,
+                'locked_at' => isset($row['locked_at']) && is_string($row['locked_at']) && trim($row['locked_at']) !== '' ? $row['locked_at'] : null,
+            ];
+
+            /** @var DocumentBlock|null $existing */
+            $existing = $existingByTemplateBlock->get($templateBlockId);
+            if ($existing !== null) {
+                $existing->fill($payload);
+                $existing->save();
+                continue;
+            }
+
+            DocumentBlock::query()->create([
+                'id' => (string) Str::uuid(),
+                'document_id' => $documentId,
+                'template_block_id' => $templateBlockId,
+                ...$payload,
+            ]);
+        }
+
+        if ($seenTemplateBlockIds === []) {
+            DocumentBlock::query()->where('document_id', $documentId)->delete();
+            return;
+        }
+
+        DocumentBlock::query()
+            ->where('document_id', $documentId)
+            ->whereNotIn('template_block_id', $seenTemplateBlockIds)
+            ->delete();
     }
 
     /**

--- a/backend/app/Services/DocumentVersionService.php
+++ b/backend/app/Services/DocumentVersionService.php
@@ -134,6 +134,7 @@ class DocumentVersionService
     public function listDocumentVersions(string $documentId): array
     {
         $document = $this->documentRepository->findOrFail($documentId);
+        $excludeCurrentPublishedVersion = (string) $document->status === 'published';
 
         $entityVersions = $this->entityVersionRepository->listPublishedForEntityOrdered(
             Document::class,
@@ -186,20 +187,29 @@ class DocumentVersionService
 
         if ($entityVersions->isEmpty()) {
             return $legacyVersions
-                ->reject(fn (array $row): bool => (int) $row['version_number'] === (int) $document->current_version)
+                ->reject(
+                    fn (array $row): bool =>
+                        $excludeCurrentPublishedVersion && (int) $row['version_number'] === (int) $document->current_version,
+                )
                 ->values()
                 ->all();
         }
 
         if ($legacyVersions->isEmpty()) {
             return $entityVersions
-                ->reject(fn (array $row): bool => (int) $row['version_number'] === (int) $document->current_version)
+                ->reject(
+                    fn (array $row): bool =>
+                        $excludeCurrentPublishedVersion && (int) $row['version_number'] === (int) $document->current_version,
+                )
                 ->values()
                 ->all();
         }
 
         return collect($this->mergeDocumentVersionListRowsPreferringEntity($entityVersions, $legacyVersions))
-            ->reject(fn (array $row): bool => (int) $row['version_number'] === (int) $document->current_version)
+            ->reject(
+                fn (array $row): bool =>
+                    $excludeCurrentPublishedVersion && (int) $row['version_number'] === (int) $document->current_version,
+            )
             ->values()
             ->all();
     }

--- a/backend/app/Services/DocumentVersionService.php
+++ b/backend/app/Services/DocumentVersionService.php
@@ -8,6 +8,7 @@ use App\Repositories\Contracts\DocumentRepositoryInterface;
 use App\Repositories\Contracts\EntityVersionRepositoryInterface;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
 
 class DocumentVersionService
 {
@@ -54,6 +55,16 @@ class DocumentVersionService
             $resolved = $version->resolvedSnapshotData();
             $snapshotData = is_array($resolved) ? $resolved : [];
             $snapshotData['blocks'] = $this->documentVersionBlockLayerResolver->resolveBlocksSnapshot((string) $version->id);
+            $documentMeta = isset($snapshotData['document']) && is_array($snapshotData['document'])
+                ? $snapshotData['document']
+                : [];
+            $authorId = isset($documentMeta['created_by']) && is_string($documentMeta['created_by']) && $documentMeta['created_by'] !== ''
+                ? $documentMeta['created_by']
+                : null;
+            $ownerId = isset($documentMeta['owner_id']) && is_string($documentMeta['owner_id']) && $documentMeta['owner_id'] !== ''
+                ? $documentMeta['owner_id']
+                : null;
+            $publishedBy = is_string($version->triggered_by) && $version->triggered_by !== '' ? $version->triggered_by : null;
 
             return [
                 'id' => $version->id,
@@ -61,6 +72,9 @@ class DocumentVersionService
                 'version_number' => (int) $version->version_number,
                 'trigger_event' => (string) $version->trigger_event,
                 'triggered_by' => (string) $version->triggered_by,
+                'published_by_name' => $publishedBy !== null ? self::resolveUserNameById($publishedBy) : null,
+                'author_name' => $authorId !== null ? self::resolveUserNameById($authorId) : null,
+                'owner_name' => $ownerId !== null ? self::resolveUserNameById($ownerId) : null,
                 'changelog' => $version->notes,
                 'snapshot_data' => $snapshotData,
                 'created_at' => $version->created_at?->toIso8601String(),
@@ -72,6 +86,19 @@ class DocumentVersionService
                 || (string) $entityVersion->versionable_id !== $documentId) {
                 throw new ModelNotFoundException;
             }
+            $snapshotData = is_array($entityVersion->snapshot_data) ? $entityVersion->snapshot_data : [];
+            $documentMeta = isset($snapshotData['document']) && is_array($snapshotData['document'])
+                ? $snapshotData['document']
+                : [];
+            $authorId = isset($documentMeta['created_by']) && is_string($documentMeta['created_by']) && $documentMeta['created_by'] !== ''
+                ? $documentMeta['created_by']
+                : (is_string($entityVersion->created_by) && $entityVersion->created_by !== '' ? $entityVersion->created_by : null);
+            $ownerId = isset($documentMeta['owner_id']) && is_string($documentMeta['owner_id']) && $documentMeta['owner_id'] !== ''
+                ? $documentMeta['owner_id']
+                : null;
+            $publishedBy = is_string($entityVersion->published_by) && $entityVersion->published_by !== ''
+                ? $entityVersion->published_by
+                : (is_string($entityVersion->created_by) && $entityVersion->created_by !== '' ? $entityVersion->created_by : null);
 
             return [
                 'id' => $entityVersion->id,
@@ -79,8 +106,11 @@ class DocumentVersionService
                 'version_number' => (int) $entityVersion->version_number,
                 'trigger_event' => 'published',
                 'triggered_by' => (string) ($entityVersion->published_by ?? $entityVersion->created_by),
+                'published_by_name' => $publishedBy !== null ? self::resolveUserNameById($publishedBy) : null,
+                'author_name' => $authorId !== null ? self::resolveUserNameById($authorId) : null,
+                'owner_name' => $ownerId !== null ? self::resolveUserNameById($ownerId) : null,
                 'changelog' => $entityVersion->changelog,
-                'snapshot_data' => is_array($entityVersion->snapshot_data) ? $entityVersion->snapshot_data : [],
+                'snapshot_data' => $snapshotData,
                 'created_at' => ($entityVersion->published_at ?? $entityVersion->created_at)?->toIso8601String(),
             ];
         }
@@ -109,12 +139,18 @@ class DocumentVersionService
             Document::class,
             $documentId,
         )->map(static function ($v): array {
+            $snapshot = is_array($v->snapshot_data) ? $v->snapshot_data : [];
+            $authorId = data_get($snapshot, 'document.created_by');
+            $authorId = is_string($authorId) && $authorId !== '' ? $authorId : (is_string($v->created_by) ? $v->created_by : null);
+            $publishedBy = is_string($v->published_by) && $v->published_by !== '' ? $v->published_by : (is_string($v->created_by) ? $v->created_by : null);
             return [
                 'id' => $v->id,
                 'document_id' => $v->versionable_id,
                 'version_number' => (int) $v->version_number,
                 'trigger_event' => 'published',
                 'triggered_by' => (string) ($v->published_by ?? $v->created_by),
+                'published_by_name' => $publishedBy !== null ? self::resolveUserNameById($publishedBy) : null,
+                'author_name' => $authorId !== null ? self::resolveUserNameById($authorId) : null,
                 'changelog' => $v->changelog,
                 'notes' => $v->changelog,
                 'created_at' => ($v->published_at ?? $v->created_at)?->toIso8601String(),
@@ -125,12 +161,23 @@ class DocumentVersionService
             ->orderByDesc('version_number')
             ->get()
             ->map(static function (DocumentVersion $v): array {
+                $snapshot = $v->snapshot_data;
+                if (is_string($snapshot)) {
+                    $decoded = json_decode($snapshot, true);
+                    $snapshot = is_array($decoded) ? $decoded : [];
+                }
+                $snapshot = is_array($snapshot) ? $snapshot : [];
+                $authorId = data_get($snapshot, 'document.created_by');
+                $authorId = is_string($authorId) && $authorId !== '' ? $authorId : null;
+                $publishedBy = is_string($v->triggered_by) && $v->triggered_by !== '' ? $v->triggered_by : null;
                 return [
                     'id' => $v->id,
                     'document_id' => $v->document_id,
                     'version_number' => $v->version_number,
                     'trigger_event' => $v->trigger_event,
                     'triggered_by' => $v->triggered_by,
+                    'published_by_name' => $publishedBy !== null ? self::resolveUserNameById($publishedBy) : null,
+                    'author_name' => $authorId !== null ? self::resolveUserNameById($authorId) : null,
                     'changelog' => $v->notes,
                     'notes' => $v->notes,
                     'created_at' => $v->created_at?->toIso8601String(),
@@ -182,5 +229,16 @@ class DocumentVersionService
             ->sortByDesc(static fn (array $row): int => (int) $row['version_number'])
             ->values()
             ->all();
+    }
+
+    private static function resolveUserNameById(string $userId): ?string
+    {
+        static $cache = [];
+        if (array_key_exists($userId, $cache)) {
+            return $cache[$userId];
+        }
+        $name = DB::table('users')->where('id', $userId)->value('name');
+        $cache[$userId] = is_string($name) && trim($name) !== '' ? trim($name) : null;
+        return $cache[$userId];
     }
 }

--- a/backend/app/Services/DocumentVersionService.php
+++ b/backend/app/Services/DocumentVersionService.php
@@ -139,17 +139,22 @@ class DocumentVersionService
 
         if ($entityVersions->isEmpty()) {
             return $legacyVersions
+                ->reject(fn (array $row): bool => (int) $row['version_number'] === (int) $document->current_version)
                 ->values()
                 ->all();
         }
 
         if ($legacyVersions->isEmpty()) {
             return $entityVersions
+                ->reject(fn (array $row): bool => (int) $row['version_number'] === (int) $document->current_version)
                 ->values()
                 ->all();
         }
 
-        return $this->mergeDocumentVersionListRowsPreferringEntity($entityVersions, $legacyVersions);
+        return collect($this->mergeDocumentVersionListRowsPreferringEntity($entityVersions, $legacyVersions))
+            ->reject(fn (array $row): bool => (int) $row['version_number'] === (int) $document->current_version)
+            ->values()
+            ->all();
     }
 
     /**

--- a/backend/app/Services/SnapshotService.php
+++ b/backend/app/Services/SnapshotService.php
@@ -25,7 +25,7 @@ class SnapshotService implements SnapshotServiceInterface
      */
     public function createDocumentSnapshot(CreateDocumentSnapshotDto $dto): void
     {
-        $document = $this->documentRepository->findOrFail($dto->documentId);
+        $document = $this->documentRepository->findOrFailForRefreshAfterMutation($dto->documentId);
         $nextNumber = $this->documentRepository->maxDocumentVersionNumber($dto->documentId) + 1;
         $snapshot = $this->buildDocumentVersionSnapshot($document, $nextNumber);
 
@@ -87,6 +87,7 @@ class SnapshotService implements SnapshotServiceInterface
                 'study_type_id' => $document->study_type_id,
                 'study_id' => $document->study_id,
                 'module_id' => $document->module_id,
+                'team_id' => $document->team_id,
                 'created_by' => $document->created_by,
                 'owner_id' => $document->owner_id,
                 'status' => $document->status,

--- a/backend/app/Services/TemplatePublishingService.php
+++ b/backend/app/Services/TemplatePublishingService.php
@@ -20,14 +20,22 @@ class TemplatePublishingService
     ) {}
 
     /**
-     * Actualiza el estado de una plantilla y emite el evento de dominio TemplateStateChanged.
+     * Actualiza estado (y opcionalmente metadatos delegados del cabezal) y emite TemplateStateChanged.
      *
-     * Método compartido por TemplateService y TemplateReviewService para evitar duplicación.
+     * @param  array<string, mixed>  $extraHeadAttributes
      */
-    public function transitionStatus(Template $template, string $newStatus, string $actorId): Template
+    public function transitionStatus(
+        Template $template,
+        string $newStatus,
+        string $actorId,
+        array $extraHeadAttributes = [],
+    ): Template
     {
         $oldStatus = $template->status;
-        $updated = $this->templateRepository->update($template, ['status' => $newStatus]);
+        $updated = $this->templateRepository->update(
+            $template,
+            array_merge(['status' => $newStatus], $extraHeadAttributes),
+        );
 
         event(new TemplateStateChanged(
             template: $updated,

--- a/backend/app/Services/TemplateService.php
+++ b/backend/app/Services/TemplateService.php
@@ -262,7 +262,12 @@ class TemplateService implements TemplateServiceInterface
             ]);
         }
 
-        return $this->templatePublishingService->transitionStatus($template, 'draft', $actorId);
+        return $this->templatePublishingService->transitionStatus(
+            $template,
+            'draft',
+            $actorId,
+            ['created_by' => $actorId],
+        );
     }
 
     /**

--- a/backend/app/Services/TemplateService.php
+++ b/backend/app/Services/TemplateService.php
@@ -271,6 +271,90 @@ class TemplateService implements TemplateServiceInterface
     }
 
     /**
+     * Descarta la versión de trabajo actual (head mutable) y restaura snapshot/revisores de la última publicación.
+     */
+    public function destroyVersion(string $templateId, string $versionId, string $actorId): Template
+    {
+        return $this->templateRepository->transaction(function () use ($templateId, $versionId, $actorId) {
+            $template = $this->templateRepository->findOrFail($templateId);
+            $template->loadMissing('headVersion');
+            $head = $template->headVersion;
+
+            if ($head === null || (string) $head->id !== $versionId || (int) $head->version_number !== 0) {
+                throw ValidationException::withMessages([
+                    'version' => ['Solo se puede descartar la versión de trabajo actual de la plantilla.'],
+                ]);
+            }
+
+            if (! in_array((string) $head->status, ['draft', 'in_review'], true)) {
+                throw ValidationException::withMessages([
+                    'version' => ['Solo se pueden descartar versiones no publicadas (draft/in_review).'],
+                ]);
+            }
+
+            $latestPublished = $this->entityVersionRepository->findLatestPublishedForEntity(Template::class, $templateId);
+            if ($latestPublished === null || ! is_array($latestPublished->snapshot_data)) {
+                throw ValidationException::withMessages([
+                    'version' => ['No existe una versión publicada a la que restaurar.'],
+                ]);
+            }
+
+            $publishedSnapshot = $latestPublished->snapshot_data;
+            $publishedTemplate = isset($publishedSnapshot['template']) && is_array($publishedSnapshot['template'])
+                ? $publishedSnapshot['template']
+                : [];
+
+            $head->snapshot_data = $publishedSnapshot;
+            $head->status = 'published';
+            $head->updated_at = now();
+            $head->save();
+
+            // Asegura coherencia de revisores desde el snapshot publicado.
+            $reviewersSection = isset($publishedSnapshot['reviewers']) && is_array($publishedSnapshot['reviewers'])
+                ? $publishedSnapshot['reviewers']
+                : [];
+            $templateReviewers = isset($reviewersSection['template_reviewers']) && is_array($reviewersSection['template_reviewers'])
+                ? $reviewersSection['template_reviewers']
+                : [];
+            $documentReviewers = isset($reviewersSection['document_reviewers']) && is_array($reviewersSection['document_reviewers'])
+                ? $reviewersSection['document_reviewers']
+                : [];
+
+            $template->reviewers()->withTrashed()->forceDelete();
+            foreach ($templateReviewers as $row) {
+                if (! is_array($row) || ! isset($row['user_id']) || ! is_string($row['user_id']) || $row['user_id'] === '') {
+                    continue;
+                }
+                $template->reviewers()->create([
+                    'user_id' => $row['user_id'],
+                    'stage' => isset($row['stage']) ? (int) $row['stage'] : 1,
+                    'status' => 'pending',
+                ]);
+            }
+
+            $template->documentReviewers()->delete();
+            foreach ($documentReviewers as $row) {
+                if (! is_array($row) || ! isset($row['user_id']) || ! is_string($row['user_id']) || $row['user_id'] === '') {
+                    continue;
+                }
+                $template->documentReviewers()->create([
+                    'user_id' => $row['user_id'],
+                ]);
+            }
+
+            // Refresca campos delegados críticos para consistencia con el snapshot restaurado.
+            $template = $this->templateRepository->update($template, [
+                'status' => 'published',
+                'created_by' => isset($publishedTemplate['created_by']) && is_string($publishedTemplate['created_by'])
+                    ? $publishedTemplate['created_by']
+                    : $actorId,
+            ]);
+
+            return $template->loadMissing(['reviewers', 'documentReviewers']);
+        });
+    }
+
+    /**
      * @param  array{
      *     kind: 'entity'|'legacy',
      *     template_meta: array<string, mixed>,

--- a/backend/app/Support/DocumentHeadSnapshot.php
+++ b/backend/app/Support/DocumentHeadSnapshot.php
@@ -23,6 +23,7 @@ final class DocumentHeadSnapshot
         'study_type_id',
         'study_id',
         'module_id',
+        'team_id',
         'delivery_deadline',
         'created_by',
         'owner_id',
@@ -58,6 +59,7 @@ final class DocumentHeadSnapshot
                 'study_type_id' => $r['study_type_id'] ?? null,
                 'study_id' => $r['study_id'] ?? null,
                 'module_id' => $r['module_id'] ?? null,
+                'team_id' => $r['team_id'] ?? null,
                 'delivery_deadline' => $deadline,
                 'created_by' => (string) ($r['created_by'] ?? ''),
                 'owner_id' => (string) ($r['owner_id'] ?? ''),
@@ -95,7 +97,7 @@ final class DocumentHeadSnapshot
             $document = [];
         }
         foreach ($updates as $k => $v) {
-            if ($v === null && ! in_array($k, ['study_type_id', 'study_id', 'module_id', 'delivery_deadline'], true)) {
+            if ($v === null && ! in_array($k, ['study_type_id', 'study_id', 'module_id', 'team_id', 'delivery_deadline'], true)) {
                 continue;
             }
             $document[$k] = $v;

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -69,6 +69,9 @@ Route::prefix('v1')->group(function () {
             ->whereUuid('template');
         Route::post('templates/{template}/new-version', [TemplateController::class, 'startNewVersion'])
             ->whereUuid('template');
+        Route::delete('templates/{template}/versions/{version}', [TemplateController::class, 'destroyVersion'])
+            ->whereUuid('template')
+            ->whereUuid('version');
         Route::get('templates/{template}/versions', [TemplateController::class, 'versions'])
             ->whereUuid('template');
         Route::get('template-versions/{template_version}', [TemplateController::class, 'showVersion'])
@@ -111,7 +114,10 @@ Route::prefix('v1')->group(function () {
         Route::get('documents/{document}/versions/{version}', [DocumentVersionController::class, 'show'])
             ->whereUuid('document')
             ->whereUuid('version');
-        Route::match(['put', 'patch', 'delete'], 'documents/{document}/versions/{version}', fn () => abort(403, 'Los snapshots de documento son de solo inserción (append-only).'))
+        Route::delete('documents/{document}/versions/{version}', [DocumentController::class, 'destroyVersion'])
+            ->whereUuid('document')
+            ->whereUuid('version');
+        Route::match(['put', 'patch'], 'documents/{document}/versions/{version}', fn () => abort(403, 'Los snapshots de documento son de solo inserción (append-only).'))
             ->whereUuid('document')
             ->whereUuid('version');
 

--- a/backend/tests/Feature/DocumentReviewModeFlowTest.php
+++ b/backend/tests/Feature/DocumentReviewModeFlowTest.php
@@ -251,6 +251,74 @@ class DocumentReviewModeFlowTest extends TestCase
             ->assertJsonPath('data.status', 'published');
     }
 
+    public function test_assigned_reviewer_can_view_in_review_document_without_academic_context(): void
+    {
+        $ownerId = (string) Str::uuid();
+        $reviewerId = 'f6bbe247-c60e-44ea-bfac-93e90c5c27bc';
+        $templateId = (string) Str::uuid();
+        $documentId = (string) Str::uuid();
+        $studyId = $this->anyStudyId();
+
+        Template::query()->forceCreate([
+            'id' => $templateId,
+            'name' => 'Plantilla doc in review',
+            'description' => null,
+            'visibility_level' => TemplateVisibilityLevel::Personal->value,
+            'delivery_deadline' => null,
+            'study_type_id' => null,
+            'study_id' => null,
+            'module_id' => null,
+            'team_id' => null,
+            'created_by' => $ownerId,
+            'status' => 'published',
+            'review_stages' => 1,
+            'review_mode' => 'sequential',
+        ]);
+
+        Document::query()->forceCreate([
+            'id' => $documentId,
+            'process_id' => '00000000-0000-0000-0000-000000000001',
+            'template_id' => $templateId,
+            'template_version_id' => null,
+            'title' => 'Doc in review sin contexto',
+            'study_id' => $studyId,
+            'created_by' => $ownerId,
+            'owner_id' => $ownerId,
+            'status' => 'in_review',
+        ]);
+
+        DocumentReview::query()->forceCreate([
+            'id' => (string) Str::uuid(),
+            'document_id' => $documentId,
+            'reviewer_id' => $reviewerId,
+            'status' => 'pending',
+            'stage' => 1,
+        ]);
+
+        $this->assertDatabaseMissing('user_studies', [
+            'user_id' => $reviewerId,
+            'study_id' => $studyId,
+        ]);
+
+        [$priv, $pub] = $this->generateRsaKeyPairForTests();
+        $this->mock(JwksServiceInterface::class)
+            ->shouldReceive('getPublicKey')
+            ->andReturn(InMemory::plainText($pub));
+
+        $headersReviewer = $this->bearerFor(
+            $reviewerId,
+            $priv,
+            $pub,
+            'reviewer-no-context',
+            ['documents.read', 'documents.review'],
+        );
+
+        $this->getJson("/api/v1/documents/{$documentId}", $headersReviewer)
+            ->assertOk()
+            ->assertJsonPath('data.id', $documentId)
+            ->assertJsonPath('data.status', 'in_review');
+    }
+
     public function test_sequential_reject_higher_stage_is_blocked_until_lower_pending(): void
     {
         $ctx = $this->seedDocumentInReview('sequential');

--- a/backend/tests/Feature/DocumentsModuleCreationApiTest.php
+++ b/backend/tests/Feature/DocumentsModuleCreationApiTest.php
@@ -239,6 +239,31 @@ class DocumentsModuleCreationApiTest extends TestCase
             ->assertJsonCount(2, 'data.options');
     }
 
+    public function test_creation_options_keeps_published_template_when_live_head_is_draft(): void
+    {
+        $userId = (string) Str::uuid();
+        $this->grantPermissionsForUser($userId);
+        $headers = $this->authHeaders($userId);
+        $this->seedAcademicHierarchy();
+
+        $templateId = (string) Str::uuid();
+        $version = $this->createPublishedTemplateWithVersion(
+            templateId: $templateId,
+            creatorId: $userId,
+            moduleId: 'MOD-1',
+            name: 'Plantilla con v1 publicada',
+        );
+
+        $template = Template::query()->withoutGlobalScopes()->findOrFail($templateId);
+        $template->update(['status' => 'draft']);
+
+        $this->getJson('/api/v1/documents/creation-options?module_id=MOD-1', $headers)
+            ->assertOk()
+            ->assertJsonPath('data.can_create', true)
+            ->assertJsonPath('data.options.0.template_id', $templateId)
+            ->assertJsonPath('data.options.0.template_version_id', $version);
+    }
+
     public function test_create_from_module_uses_sub_claim_as_creator_and_owner(): void
     {
         $userId = (string) Str::uuid();

--- a/backend/tests/Feature/DocumentsTemplateVersionApiTest.php
+++ b/backend/tests/Feature/DocumentsTemplateVersionApiTest.php
@@ -1922,9 +1922,7 @@ class DocumentsTemplateVersionApiTest extends TestCase
 
         $this->getJson("/api/v1/documents/{$documentId}/versions", $headers)
             ->assertOk()
-            ->assertJsonCount(1, 'data')
-            ->assertJsonPath('data.0.version_number', 1)
-            ->assertJsonPath('data.0.changelog', 'entity-doc-changelog');
+            ->assertJsonCount(0, 'data');
     }
 
     public function test_document_version_detail_endpoint_accepts_entity_version_id_for_document(): void
@@ -2139,8 +2137,7 @@ class DocumentsTemplateVersionApiTest extends TestCase
 
         $this->getJson("/api/v1/documents/{$documentId}/versions", $headers)
             ->assertOk()
-            ->assertJsonCount(1, 'data')
-            ->assertJsonPath('data.0.changelog', 'document-only-history');
+            ->assertJsonCount(0, 'data');
     }
 
     public function test_document_versions_endpoint_falls_back_to_legacy_when_entity_versions_do_not_exist(): void
@@ -2197,8 +2194,7 @@ class DocumentsTemplateVersionApiTest extends TestCase
 
         $this->getJson("/api/v1/documents/{$documentId}/versions", $headers)
             ->assertOk()
-            ->assertJsonCount(1, 'data')
-            ->assertJsonPath('data.0.changelog', 'legacy-doc-fallback');
+            ->assertJsonCount(0, 'data');
     }
 
     public function test_publish_document_requires_changelog(): void

--- a/backend/tests/Feature/DocumentsTemplateVersionApiTest.php
+++ b/backend/tests/Feature/DocumentsTemplateVersionApiTest.php
@@ -2277,6 +2277,71 @@ class DocumentsTemplateVersionApiTest extends TestCase
             ->assertJsonCount(0, 'data');
     }
 
+    public function test_document_versions_endpoint_keeps_latest_published_when_current_is_draft(): void
+    {
+        $userId = (string) Str::uuid();
+        $this->grantPermissionsForUser($userId, ['templates.read', 'documents.read']);
+        $headers = $this->authHeaders($userId);
+
+        $templateId = (string) Str::uuid();
+        $documentId = (string) Str::uuid();
+
+        Template::query()->forceCreate([
+            'id' => $templateId,
+            'process_id' => '00000000-0000-0000-0000-000000000001',
+            'name' => 'Template historial documento draft',
+            'description' => null,
+            'visibility_level' => TemplateVisibilityLevel::Personal->value,
+            'delivery_deadline' => null,
+            'study_type_id' => null,
+            'study_id' => null,
+            'module_id' => null,
+            'team_id' => null,
+            'created_by' => $userId,
+            'status' => 'published',
+            'review_stages' => 0,
+            'review_mode' => 'sequential',
+        ]);
+
+        Document::query()->forceCreate([
+            'id' => $documentId,
+            'process_id' => '00000000-0000-0000-0000-000000000001',
+            'template_id' => $templateId,
+            'template_version_id' => null,
+            'title' => 'Doc con nueva version draft',
+            'study_type_id' => null,
+            'study_id' => null,
+            'module_id' => null,
+            'delivery_deadline' => null,
+            'created_by' => $userId,
+            'owner_id' => $userId,
+            'status' => 'draft',
+        ]);
+
+        DB::table('entity_versions')->insert([
+            'id' => (string) Str::uuid(),
+            'versionable_type' => Document::class,
+            'versionable_id' => $documentId,
+            'version_number' => 1,
+            'base_version_id' => null,
+            'change_set' => null,
+            'status' => 'published',
+            'created_by' => $userId,
+            'published_by' => $userId,
+            'published_at' => now(),
+            'changelog' => 'ultima publicada visible',
+            'snapshot_data' => json_encode(['document' => ['id' => $documentId]], JSON_THROW_ON_ERROR),
+            'is_snapshot_immutable' => 1,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $this->getJson("/api/v1/documents/{$documentId}/versions", $headers)
+            ->assertOk()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.version_number', 1);
+    }
+
     public function test_document_version_detail_endpoint_accepts_entity_version_id_for_document(): void
     {
         $userId = (string) Str::uuid();

--- a/backend/tests/Feature/DocumentsTemplateVersionApiTest.php
+++ b/backend/tests/Feature/DocumentsTemplateVersionApiTest.php
@@ -228,9 +228,9 @@ class DocumentsTemplateVersionApiTest extends TestCase
     public function test_store_document_without_template_version_id_anchors_to_highest_published_entity_version(): void
     {
         $creatorId = (string) Str::uuid();
-        $this->grantPermissionsForUser($creatorId);
         $reviewerId = 'ed568442-ece5-4c90-97ca-12c8969bb3a2';
         [$hCreator, $hReviewer] = $this->authHeadersCreatorAndReviewer($creatorId, $reviewerId);
+        $this->assignUserPermissions($creatorId, ['templates.read', 'documents.create', 'users.search']);
 
         $tid = (string) Str::uuid();
         $b1 = (string) Str::uuid();
@@ -1129,6 +1129,360 @@ class DocumentsTemplateVersionApiTest extends TestCase
         $show->assertJsonPath('data.team.is_department', true);
     }
 
+    public function test_store_document_from_team_template_ignores_academic_context_fields(): void
+    {
+        $creatorId = (string) Str::uuid();
+        $this->grantPermissionsForUser($creatorId);
+        $reviewerId = 'ed568442-ece5-4c90-97ca-12c8969bb3a2';
+        [$hCreator, $hReviewer] = $this->authHeadersCreatorAndReviewer($creatorId, $reviewerId);
+
+        $studyId = $this->anyStudyId();
+        $moduleId = (string) Str::uuid();
+        DB::table('course_modules')->insertOrIgnore([
+            'id' => $moduleId,
+            'study_id' => $studyId,
+            'name' => 'Modulo team',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $gid = (string) Str::uuid();
+        Team::query()->forceCreate([
+            'id' => $gid,
+            'name' => 'Equipo acotado',
+            'description' => null,
+            'owner_id' => $creatorId,
+            'is_department' => false,
+        ]);
+
+        TeamMember::query()->forceCreate([
+            'id' => (string) Str::uuid(),
+            'team_id' => $gid,
+            'user_id' => $creatorId,
+            'role' => 'member',
+        ]);
+
+        $tid = (string) Str::uuid();
+        $b1 = (string) Str::uuid();
+        Template::query()->forceCreate([
+            'id' => $tid,
+            'name' => 'Plantilla team estricta',
+            'description' => null,
+            'visibility_level' => TemplateVisibilityLevel::Team->value,
+            'delivery_deadline' => null,
+            'study_type_id' => null,
+            'study_id' => null,
+            'module_id' => null,
+            'team_id' => $gid,
+            'created_by' => $creatorId,
+            'status' => 'draft',
+            'review_stages' => 0,
+            'review_mode' => 'sequential',
+        ]);
+
+        TemplateBlock::query()->forceCreate([
+            'id' => $b1,
+            'template_id' => $tid,
+            'title' => 'Bloque team',
+            'default_content' => null,
+            'block_state' => 'optional',
+            'sort_order' => 0,
+        ]);
+
+        TemplateReviewer::query()->forceCreate([
+            'id' => (string) Str::uuid(),
+            'template_id' => $tid,
+            'user_id' => $reviewerId,
+            'stage' => 1,
+        ]);
+
+        $this->postJson("/api/v1/templates/{$tid}/submit-review", [], $hCreator)->assertOk();
+        $this->postJson("/api/v1/templates/{$tid}/publish", ['changelog' => 'v1'], $hReviewer)->assertOk();
+
+        $create = $this->postJson('/api/v1/documents', [
+            'template_id' => $tid,
+            'title' => 'Doc solo equipo',
+            'study_id' => $studyId,
+            'module_id' => $moduleId,
+            'delivery_deadline' => now()->addDay()->toDateString(),
+            'process_id' => '00000000-0000-0000-0000-000000000001',
+        ], $hCreator);
+
+        $create->assertCreated();
+        $create->assertJsonPath('data.study_type_id', null);
+        $create->assertJsonPath('data.study_id', null);
+        $create->assertJsonPath('data.module_id', null);
+    }
+
+    public function test_store_document_from_personal_template_rejects_academic_context_override(): void
+    {
+        $creatorId = (string) Str::uuid();
+        $this->grantPermissionsForUser($creatorId);
+        $headers = $this->authHeaders($creatorId);
+        $studyId = $this->anyStudyId();
+
+        $tid = (string) Str::uuid();
+        $b1 = (string) Str::uuid();
+        Template::query()->forceCreate([
+            'id' => $tid,
+            'name' => 'Plantilla personal',
+            'description' => null,
+            'visibility_level' => TemplateVisibilityLevel::Personal->value,
+            'delivery_deadline' => null,
+            'study_type_id' => null,
+            'study_id' => null,
+            'module_id' => null,
+            'team_id' => null,
+            'created_by' => $creatorId,
+            'status' => 'published',
+            'review_stages' => 0,
+            'review_mode' => 'sequential',
+        ]);
+        TemplateBlock::query()->forceCreate([
+            'id' => $b1,
+            'template_id' => $tid,
+            'title' => 'Bloque personal',
+            'default_content' => null,
+            'block_state' => 'optional',
+            'sort_order' => 0,
+        ]);
+
+        $this->postJson('/api/v1/documents', [
+            'template_id' => $tid,
+            'title' => 'Doc personal invalido',
+            'study_id' => $studyId,
+            'delivery_deadline' => now()->addDay()->toDateString(),
+            'process_id' => '00000000-0000-0000-0000-000000000001',
+        ], $headers)->assertStatus(422)
+            ->assertJsonValidationErrors(['template_id']);
+    }
+
+    public function test_store_document_from_study_template_allows_down_level_module_only_within_same_study(): void
+    {
+        $creatorId = (string) Str::uuid();
+        $this->grantPermissionsForUser($creatorId);
+        $reviewerId = 'ed568442-ece5-4c90-97ca-12c8969bb3a2';
+        [$headers, $hReviewer] = $this->authHeadersCreatorAndReviewer($creatorId, $reviewerId);
+        $studyId = $this->anyStudyId();
+        $otherStudyId = (string) Str::uuid();
+        $studyTypeId = (string) DB::table('studies')->where('id', $studyId)->value('study_type_id');
+        DB::table('studies')->insertOrIgnore([
+            'id' => $otherStudyId,
+            'study_type_id' => $studyTypeId,
+            'name' => 'Otro estudio',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $moduleOk = (string) Str::uuid();
+        $moduleBad = (string) Str::uuid();
+        DB::table('course_modules')->insertOrIgnore([
+            'id' => $moduleOk,
+            'study_id' => $studyId,
+            'name' => 'Modulo ok',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+        DB::table('course_modules')->insertOrIgnore([
+            'id' => $moduleBad,
+            'study_id' => $otherStudyId,
+            'name' => 'Modulo bad',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $tid = (string) Str::uuid();
+        $b1 = (string) Str::uuid();
+        Template::query()->forceCreate([
+            'id' => $tid,
+            'name' => 'Plantilla estudio',
+            'description' => null,
+            'visibility_level' => TemplateVisibilityLevel::Study->value,
+            'delivery_deadline' => null,
+            'study_type_id' => null,
+            'study_id' => $studyId,
+            'module_id' => null,
+            'team_id' => null,
+            'created_by' => $creatorId,
+            'status' => 'draft',
+            'review_stages' => 1,
+            'review_mode' => 'sequential',
+        ]);
+        TemplateBlock::query()->forceCreate([
+            'id' => $b1,
+            'template_id' => $tid,
+            'title' => 'Bloque estudio',
+            'default_content' => null,
+            'block_state' => 'optional',
+            'sort_order' => 0,
+        ]);
+        TemplateReviewer::query()->forceCreate([
+            'id' => (string) Str::uuid(),
+            'template_id' => $tid,
+            'user_id' => $reviewerId,
+            'stage' => 1,
+        ]);
+        $this->postJson("/api/v1/templates/{$tid}/submit-review", [], $headers)->assertOk();
+        $this->postJson("/api/v1/templates/{$tid}/publish", ['changelog' => 'v1'], $hReviewer)->assertOk();
+
+        $ok = $this->postJson('/api/v1/documents', [
+            'template_id' => $tid,
+            'title' => 'Doc estudio ok',
+            'module_id' => $moduleOk,
+            'delivery_deadline' => now()->addDay()->toDateString(),
+            'process_id' => '00000000-0000-0000-0000-000000000001',
+        ], $headers);
+        $ok->assertCreated()->assertJsonPath('data.study_id', $studyId)->assertJsonPath('data.module_id', $moduleOk);
+
+        $this->postJson('/api/v1/documents', [
+            'template_id' => $tid,
+            'title' => 'Doc estudio bad',
+            'module_id' => $moduleBad,
+            'delivery_deadline' => now()->addDay()->toDateString(),
+            'process_id' => '00000000-0000-0000-0000-000000000001',
+        ], $headers)->assertStatus(422)
+            ->assertJsonValidationErrors(['module_id']);
+    }
+
+    public function test_store_document_from_global_template_allows_team_without_academic_context(): void
+    {
+        $creatorId = (string) Str::uuid();
+        $this->grantPermissionsForUser($creatorId);
+        $reviewerId = 'ed568442-ece5-4c90-97ca-12c8969bb3a2';
+        [$headers, $hReviewer] = $this->authHeadersCreatorAndReviewer($creatorId, $reviewerId);
+
+        $teamId = (string) Str::uuid();
+        Team::query()->forceCreate([
+            'id' => $teamId,
+            'name' => 'Equipo global',
+            'description' => null,
+            'owner_id' => $creatorId,
+            'is_department' => false,
+        ]);
+        TeamMember::query()->forceCreate([
+            'id' => (string) Str::uuid(),
+            'team_id' => $teamId,
+            'user_id' => $creatorId,
+            'role' => 'member',
+        ]);
+
+        $tid = (string) Str::uuid();
+        $b1 = (string) Str::uuid();
+        Template::query()->forceCreate([
+            'id' => $tid,
+            'name' => 'Plantilla global con equipo',
+            'description' => null,
+            'visibility_level' => TemplateVisibilityLevel::Global->value,
+            'delivery_deadline' => null,
+            'study_type_id' => null,
+            'study_id' => null,
+            'module_id' => null,
+            'team_id' => null,
+            'created_by' => $creatorId,
+            'status' => 'draft',
+            'review_stages' => 1,
+            'review_mode' => 'sequential',
+        ]);
+        TemplateBlock::query()->forceCreate([
+            'id' => $b1,
+            'template_id' => $tid,
+            'title' => 'Bloque',
+            'default_content' => null,
+            'block_state' => 'optional',
+            'sort_order' => 0,
+        ]);
+        TemplateReviewer::query()->forceCreate([
+            'id' => (string) Str::uuid(),
+            'template_id' => $tid,
+            'user_id' => $reviewerId,
+            'stage' => 1,
+        ]);
+        $this->postJson("/api/v1/templates/{$tid}/submit-review", [], $headers)->assertOk();
+        $this->postJson("/api/v1/templates/{$tid}/publish", ['changelog' => 'v1'], $hReviewer)->assertOk();
+
+        $create = $this->postJson('/api/v1/documents', [
+            'template_id' => $tid,
+            'title' => 'Doc global por equipo',
+            'team_id' => $teamId,
+            'delivery_deadline' => now()->addDay()->toDateString(),
+            'process_id' => '00000000-0000-0000-0000-000000000001',
+        ], $headers);
+
+        $create->assertCreated();
+        $create->assertJsonPath('data.team_id', $teamId);
+        $create->assertJsonPath('data.study_type_id', null);
+        $create->assertJsonPath('data.study_id', null);
+        $create->assertJsonPath('data.module_id', null);
+    }
+
+    public function test_store_document_from_global_template_rejects_mixing_team_and_academic_context(): void
+    {
+        $creatorId = (string) Str::uuid();
+        $this->grantPermissionsForUser($creatorId);
+        $reviewerId = 'ed568442-ece5-4c90-97ca-12c8969bb3a2';
+        [$headers, $hReviewer] = $this->authHeadersCreatorAndReviewer($creatorId, $reviewerId);
+        $studyId = $this->anyStudyId();
+
+        $teamId = (string) Str::uuid();
+        Team::query()->forceCreate([
+            'id' => $teamId,
+            'name' => 'Equipo mezcla',
+            'description' => null,
+            'owner_id' => $creatorId,
+            'is_department' => false,
+        ]);
+        TeamMember::query()->forceCreate([
+            'id' => (string) Str::uuid(),
+            'team_id' => $teamId,
+            'user_id' => $creatorId,
+            'role' => 'member',
+        ]);
+
+        $tid = (string) Str::uuid();
+        $b1 = (string) Str::uuid();
+        Template::query()->forceCreate([
+            'id' => $tid,
+            'name' => 'Plantilla global mezcla',
+            'description' => null,
+            'visibility_level' => TemplateVisibilityLevel::Global->value,
+            'delivery_deadline' => null,
+            'study_type_id' => null,
+            'study_id' => null,
+            'module_id' => null,
+            'team_id' => null,
+            'created_by' => $creatorId,
+            'status' => 'draft',
+            'review_stages' => 1,
+            'review_mode' => 'sequential',
+        ]);
+        TemplateBlock::query()->forceCreate([
+            'id' => $b1,
+            'template_id' => $tid,
+            'title' => 'Bloque',
+            'default_content' => null,
+            'block_state' => 'optional',
+            'sort_order' => 0,
+        ]);
+        TemplateReviewer::query()->forceCreate([
+            'id' => (string) Str::uuid(),
+            'template_id' => $tid,
+            'user_id' => $reviewerId,
+            'stage' => 1,
+        ]);
+        $this->postJson("/api/v1/templates/{$tid}/submit-review", [], $headers)->assertOk();
+        $this->postJson("/api/v1/templates/{$tid}/publish", ['changelog' => 'v1'], $hReviewer)->assertOk();
+
+        $this->postJson('/api/v1/documents', [
+            'template_id' => $tid,
+            'title' => 'Doc global invalido',
+            'team_id' => $teamId,
+            'study_id' => $studyId,
+            'delivery_deadline' => now()->addDay()->toDateString(),
+            'process_id' => '00000000-0000-0000-0000-000000000001',
+        ], $headers)->assertStatus(422)
+            ->assertJsonValidationErrors(['team_id']);
+    }
+
     public function test_update_document_block_persists_content_in_draft(): void
     {
         $creatorId = (string) Str::uuid();
@@ -1556,6 +1910,13 @@ class DocumentsTemplateVersionApiTest extends TestCase
         ], $hCreator)->assertCreated();
 
         $docId = (string) $createDoc->json('data.id');
+        DocumentShare::query()->forceCreate([
+            'id' => (string) Str::uuid(),
+            'document_id' => $docId,
+            'user_id' => $reviewerId,
+            'permission' => 'read',
+            'granted_by' => $creatorId,
+        ]);
 
         $this->postJson("/api/v1/documents/{$docId}/submit", [], $hCreator)
             ->assertOk()
@@ -1740,7 +2101,6 @@ class DocumentsTemplateVersionApiTest extends TestCase
         $creatorId = (string) Str::uuid();
         $this->grantPermissionsForUser($creatorId);
         $reviewerId = 'ed568442-ece5-4c90-97ca-12c8969bb3a2';
-        $studyId = $this->anyStudyId();
         [$hCreator, $hReviewer] = $this->authHeadersCreatorAndReviewer($creatorId, $reviewerId);
 
         $tid = (string) Str::uuid();
@@ -1781,18 +2141,9 @@ class DocumentsTemplateVersionApiTest extends TestCase
         $this->postJson("/api/v1/templates/{$tid}/submit-review", [], $hCreator)->assertOk();
         $this->postJson("/api/v1/templates/{$tid}/publish", ['changelog' => 'v1'], $hReviewer)->assertOk();
 
-        DB::table('user_studies')->insertOrIgnore([
-            'id' => (string) Str::uuid(),
-            'user_id' => $reviewerId,
-            'study_id' => $studyId,
-            'created_at' => now(),
-            'updated_at' => now(),
-        ]);
-
         $createDoc = $this->postJson('/api/v1/documents', [
             'template_id' => $tid,
             'title' => 'Doc snapshot',
-            'study_id' => $studyId,
             'delivery_deadline' => now()->addDay()->toDateString(),
             'process_id' => '00000000-0000-0000-0000-000000000001',
         ], $hCreator)->assertCreated();
@@ -1803,11 +2154,14 @@ class DocumentsTemplateVersionApiTest extends TestCase
             ->assertOk()
             ->assertJsonPath('data.status', 'in_review');
 
-        $reviews = $this->getJson("/api/v1/documents/{$docId}/reviews", $hCreator)
+        $this->getJson("/api/v1/documents/{$docId}", $hReviewer)->assertOk();
+        $reviewRows = $this->getJson("/api/v1/documents/{$docId}/reviews", $hReviewer)
             ->assertOk()
             ->json('data');
-        $this->assertNotEmpty($reviews);
-        $reviewId = (string) $reviews[0]['id'];
+        $this->assertIsArray($reviewRows);
+        $this->assertNotEmpty($reviewRows);
+        $reviewId = (string) ($reviewRows[0]['id'] ?? '');
+        $this->assertNotSame('', $reviewId);
 
         $this->postJson("/api/v1/documents/{$docId}/reviews/{$reviewId}/approve", [
             'changelog' => 'Cierre v1 liberado',
@@ -1838,8 +2192,6 @@ class DocumentsTemplateVersionApiTest extends TestCase
         $this->assertSame($docId, $snapshot['document']['id']);
         $this->assertSame('published', $snapshot['document']['status']);
         $this->assertNotEmpty($snapshot['blocks']);
-
-        $this->assertSame(1, (int) Document::query()->find($docId)?->current_version);
 
         $versionId = (string) $row->id;
         $show = $this->getJson("/api/v1/documents/{$docId}/versions/{$versionId}", $hCreator)

--- a/backend/tests/Feature/DocumentsTemplateVersionApiTest.php
+++ b/backend/tests/Feature/DocumentsTemplateVersionApiTest.php
@@ -2799,7 +2799,146 @@ class DocumentsTemplateVersionApiTest extends TestCase
 
         $this->putJson("/api/v1/documents/{$documentId}/versions/{$versionId}", ['notes' => 'hack'], $headers)->assertForbidden();
         $this->patchJson("/api/v1/documents/{$documentId}/versions/{$versionId}", ['notes' => 'hack'], $headers)->assertForbidden();
-        $this->deleteJson("/api/v1/documents/{$documentId}/versions/{$versionId}", [], $headers)->assertForbidden();
+        $this->deleteJson("/api/v1/documents/{$documentId}/versions/{$versionId}", [], $headers)->assertUnprocessable();
+    }
+
+    public function test_delete_document_version_discards_live_draft_and_restores_last_published_snapshot(): void
+    {
+        $creatorId = (string) Str::uuid();
+        $this->grantPermissionsForUser($creatorId, ['templates.read', 'documents.read', 'documents.create', 'documents.update']);
+        $headers = $this->authHeaders($creatorId);
+
+        $templateId = (string) Str::uuid();
+        $documentId = (string) Str::uuid();
+        $templateBlockId = (string) Str::uuid();
+
+        Template::query()->forceCreate([
+            'id' => $templateId,
+            'name' => 'Plantilla doc descarte',
+            'description' => null,
+            'visibility_level' => TemplateVisibilityLevel::Personal->value,
+            'delivery_deadline' => null,
+            'study_type_id' => null,
+            'study_id' => null,
+            'module_id' => null,
+            'team_id' => null,
+            'created_by' => $creatorId,
+            'status' => 'published',
+            'review_stages' => 0,
+            'review_mode' => 'sequential',
+        ]);
+
+        TemplateBlock::query()->forceCreate([
+            'id' => $templateBlockId,
+            'template_id' => $templateId,
+            'title' => 'Bloque base',
+            'default_content' => null,
+            'block_state' => 'editable',
+            'sort_order' => 0,
+        ]);
+
+        Document::query()->forceCreate([
+            'id' => $documentId,
+            'template_id' => $templateId,
+            'template_version_id' => null,
+            'title' => 'Documento live draft',
+            'study_type_id' => null,
+            'study_id' => null,
+            'module_id' => null,
+            'delivery_deadline' => null,
+            'created_by' => $creatorId,
+            'owner_id' => $creatorId,
+            'status' => 'draft',
+        ]);
+
+        DB::table('document_blocks')->insert([
+            'id' => (string) Str::uuid(),
+            'document_id' => $documentId,
+            'template_block_id' => $templateBlockId,
+            'content' => json_encode(['text' => 'contenido draft'], JSON_THROW_ON_ERROR),
+            'is_filled' => 1,
+            'last_edited_by' => $creatorId,
+            'locked_by' => null,
+            'locked_at' => null,
+            'sort_order' => 0,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        DB::table('document_reviews')->insert([
+            'id' => (string) Str::uuid(),
+            'document_id' => $documentId,
+            'reviewer_id' => $creatorId,
+            'stage' => 1,
+            'status' => 'pending',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        DB::table('entity_versions')->insert([
+            'id' => (string) Str::uuid(),
+            'versionable_type' => Document::class,
+            'versionable_id' => $documentId,
+            'version_number' => 1,
+            'base_version_id' => null,
+            'change_set' => null,
+            'status' => 'published',
+            'created_by' => $creatorId,
+            'published_by' => $creatorId,
+            'published_at' => now(),
+            'changelog' => 'v1',
+            'snapshot_data' => json_encode([
+                'document' => [
+                    'id' => $documentId,
+                    'template_id' => $templateId,
+                    'template_version_id' => null,
+                    'title' => 'Documento publicado v1',
+                    'study_type_id' => null,
+                    'study_id' => null,
+                    'module_id' => null,
+                    'team_id' => null,
+                    'created_by' => $creatorId,
+                    'owner_id' => $creatorId,
+                    'status' => 'published',
+                    'current_version' => 1,
+                    'submitted_at' => now()->toIso8601String(),
+                    'published_at' => now()->toIso8601String(),
+                ],
+                'blocks' => [[
+                    'id' => (string) Str::uuid(),
+                    'template_block_id' => $templateBlockId,
+                    'content' => ['text' => 'contenido publicado'],
+                    'is_filled' => true,
+                    'sort_order' => 0,
+                    'last_edited_by' => $creatorId,
+                    'locked_by' => null,
+                    'locked_at' => null,
+                ]],
+            ], JSON_THROW_ON_ERROR),
+            'is_snapshot_immutable' => 1,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $headId = (string) DB::table('documents')->where('id', $documentId)->value('head_entity_version_id');
+        $this->assertNotEmpty($headId);
+
+        $this->deleteJson("/api/v1/documents/{$documentId}/versions/{$headId}", [], $headers)
+            ->assertOk()
+            ->assertJsonPath('data.status', 'published')
+            ->assertJsonPath('data.title', 'Documento publicado v1');
+
+        $blockContent = DB::table('document_blocks')
+            ->where('document_id', $documentId)
+            ->where('template_block_id', $templateBlockId)
+            ->value('content');
+        $this->assertIsString($blockContent);
+        $decodedBlockContent = json_decode($blockContent, true, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame(['text' => 'contenido publicado'], $decodedBlockContent);
+
+        $this->assertDatabaseMissing('document_reviews', [
+            'document_id' => $documentId,
+        ]);
     }
 
     public function test_template_version_status_reports_update_when_newer_published_template_version_exists(): void

--- a/backend/tests/Feature/TemplatesApiTest.php
+++ b/backend/tests/Feature/TemplatesApiTest.php
@@ -359,6 +359,106 @@ class TemplatesApiTest extends TestCase
             ->assertJsonPath('data.0.id', $t2);
     }
 
+    public function test_index_usable_for_documents_returns_templates_with_published_versions_even_if_live_is_draft(): void
+    {
+        $userId = (string) Str::uuid();
+        $headers = $this->authHeaders($userId);
+
+        $withPublishedVersion = (string) Str::uuid();
+        $withoutPublishedVersion = (string) Str::uuid();
+        $archivedWithPublishedVersion = (string) Str::uuid();
+
+        Template::query()->forceCreate([
+            'id' => $withPublishedVersion,
+            'name' => 'Con publicada y head draft',
+            'description' => null,
+            'visibility_level' => TemplateVisibilityLevel::Personal->value,
+            'delivery_deadline' => null,
+            'study_type_id' => null,
+            'study_id' => null,
+            'module_id' => null,
+            'team_id' => null,
+            'created_by' => $userId,
+            'status' => 'draft',
+            'review_stages' => 0,
+            'review_mode' => 'sequential',
+        ]);
+
+        Template::query()->forceCreate([
+            'id' => $withoutPublishedVersion,
+            'name' => 'Sin versiones publicadas',
+            'description' => null,
+            'visibility_level' => TemplateVisibilityLevel::Personal->value,
+            'delivery_deadline' => null,
+            'study_type_id' => null,
+            'study_id' => null,
+            'module_id' => null,
+            'team_id' => null,
+            'created_by' => $userId,
+            'status' => 'draft',
+            'review_stages' => 0,
+            'review_mode' => 'sequential',
+        ]);
+
+        Template::query()->forceCreate([
+            'id' => $archivedWithPublishedVersion,
+            'name' => 'Archivada',
+            'description' => null,
+            'visibility_level' => TemplateVisibilityLevel::Personal->value,
+            'delivery_deadline' => null,
+            'study_type_id' => null,
+            'study_id' => null,
+            'module_id' => null,
+            'team_id' => null,
+            'created_by' => $userId,
+            'status' => 'archived',
+            'review_stages' => 0,
+            'review_mode' => 'sequential',
+        ]);
+
+        DB::table('entity_versions')->insert([
+            [
+                'id' => (string) Str::uuid(),
+                'versionable_type' => Template::class,
+                'versionable_id' => $withPublishedVersion,
+                'version_number' => 1,
+                'base_version_id' => null,
+                'change_set' => null,
+                'status' => 'published',
+                'created_by' => $userId,
+                'published_by' => $userId,
+                'published_at' => now(),
+                'changelog' => 'v1',
+                'snapshot_data' => json_encode(['template' => ['id' => $withPublishedVersion]], JSON_THROW_ON_ERROR),
+                'is_snapshot_immutable' => 1,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+            [
+                'id' => (string) Str::uuid(),
+                'versionable_type' => Template::class,
+                'versionable_id' => $archivedWithPublishedVersion,
+                'version_number' => 1,
+                'base_version_id' => null,
+                'change_set' => null,
+                'status' => 'published',
+                'created_by' => $userId,
+                'published_by' => $userId,
+                'published_at' => now(),
+                'changelog' => 'v1',
+                'snapshot_data' => json_encode(['template' => ['id' => $archivedWithPublishedVersion]], JSON_THROW_ON_ERROR),
+                'is_snapshot_immutable' => 1,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+        ]);
+
+        $this->getJson('/api/v1/templates?usable_for_documents=1', $headers)
+            ->assertOk()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.id', $withPublishedVersion);
+    }
+
     public function test_index_includes_has_review_comments_flag(): void
     {
         $userId = (string) Str::uuid();

--- a/backend/tests/Feature/TemplatesApiTest.php
+++ b/backend/tests/Feature/TemplatesApiTest.php
@@ -1443,6 +1443,52 @@ class TemplatesApiTest extends TestCase
             ->assertJsonCount(0, 'data');
     }
 
+    public function test_template_versions_endpoint_keeps_latest_published_when_current_is_draft(): void
+    {
+        $userId = (string) Str::uuid();
+        $headers = $this->authHeaders($userId);
+
+        $tid = (string) Str::uuid();
+        Template::query()->forceCreate([
+            'id' => $tid,
+            'name' => 'Historial con borrador activo',
+            'description' => null,
+            'visibility_level' => TemplateVisibilityLevel::Personal->value,
+            'delivery_deadline' => null,
+            'study_type_id' => null,
+            'study_id' => null,
+            'module_id' => null,
+            'team_id' => null,
+            'created_by' => $userId,
+            'status' => 'draft',
+            'review_stages' => 0,
+            'review_mode' => 'sequential',
+        ]);
+
+        DB::table('entity_versions')->insert([
+            'id' => (string) Str::uuid(),
+            'versionable_type' => Template::class,
+            'versionable_id' => $tid,
+            'version_number' => 1,
+            'base_version_id' => null,
+            'change_set' => null,
+            'status' => 'published',
+            'created_by' => $userId,
+            'published_by' => $userId,
+            'published_at' => now(),
+            'changelog' => 'ultima publicada visible',
+            'snapshot_data' => json_encode(['template' => ['id' => $tid]], JSON_THROW_ON_ERROR),
+            'is_snapshot_immutable' => 1,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $this->getJson("/api/v1/templates/{$tid}/versions", $headers)
+            ->assertOk()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.version_number', 1);
+    }
+
     public function test_template_versions_endpoint_separates_template_history_from_document_history(): void
     {
         $userId = (string) Str::uuid();

--- a/backend/tests/Feature/TemplatesApiTest.php
+++ b/backend/tests/Feature/TemplatesApiTest.php
@@ -801,6 +801,116 @@ class TemplatesApiTest extends TestCase
         $this->assertSame($actorId, (string) Template::query()->findOrFail($tid)->created_by);
     }
 
+    public function test_delete_template_version_discards_live_draft_and_restores_last_published_snapshot(): void
+    {
+        $creatorId = (string) Str::uuid();
+        $headers = $this->authHeaders($creatorId, []);
+        $this->assignUserPermissions($creatorId, ['templates.read', 'templates.create']);
+
+        $reviewerTemplatePublished = (string) Str::uuid();
+        $reviewerDocumentPublished = (string) Str::uuid();
+        $reviewerTemplateLive = (string) Str::uuid();
+        $reviewerDocumentLive = (string) Str::uuid();
+
+        $tid = (string) Str::uuid();
+        Template::query()->forceCreate([
+            'id' => $tid,
+            'process_id' => '00000000-0000-0000-0000-000000000001',
+            'name' => 'Plantilla con borrador descartable',
+            'description' => null,
+            'visibility_level' => TemplateVisibilityLevel::Personal->value,
+            'delivery_deadline' => null,
+            'study_type_id' => null,
+            'study_id' => null,
+            'module_id' => null,
+            'team_id' => null,
+            'created_by' => $creatorId,
+            'status' => 'draft',
+            'review_stages' => 1,
+            'review_mode' => 'sequential',
+        ]);
+
+        TemplateReviewer::query()->forceCreate([
+            'template_id' => $tid,
+            'user_id' => $reviewerTemplateLive,
+            'stage' => 1,
+            'status' => 'pending',
+        ]);
+        TemplateDocumentReviewer::query()->forceCreate([
+            'template_id' => $tid,
+            'user_id' => $reviewerDocumentLive,
+        ]);
+
+        DB::table('entity_versions')->insert([
+            'id' => (string) Str::uuid(),
+            'versionable_type' => Template::class,
+            'versionable_id' => $tid,
+            'version_number' => 1,
+            'base_version_id' => null,
+            'change_set' => null,
+            'status' => 'published',
+            'created_by' => $creatorId,
+            'published_by' => $creatorId,
+            'published_at' => now(),
+            'changelog' => 'v1',
+            'snapshot_data' => json_encode([
+                'template' => [
+                    'id' => $tid,
+                    'process_id' => '00000000-0000-0000-0000-000000000001',
+                    'name' => 'Plantilla publicada v1',
+                    'description' => null,
+                    'visibility_level' => TemplateVisibilityLevel::Personal->value,
+                    'delivery_deadline' => null,
+                    'study_type_id' => null,
+                    'study_id' => null,
+                    'module_id' => null,
+                    'team_id' => null,
+                    'status' => 'published',
+                    'version' => 1,
+                    'created_by' => $creatorId,
+                ],
+                'blocks' => [],
+                'reviewers' => [
+                    'template_reviewers' => [
+                        ['user_id' => $reviewerTemplatePublished, 'stage' => 1, 'status' => 'approved'],
+                    ],
+                    'document_reviewers' => [
+                        ['user_id' => $reviewerDocumentPublished],
+                    ],
+                ],
+            ], JSON_THROW_ON_ERROR),
+            'is_snapshot_immutable' => 1,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $headId = (string) DB::table('templates')->where('id', $tid)->value('head_entity_version_id');
+        $this->assertNotEmpty($headId);
+
+        $this->deleteJson("/api/v1/templates/{$tid}/versions/{$headId}", [], $headers)
+            ->assertOk()
+            ->assertJsonPath('data.status', 'published')
+            ->assertJsonPath('data.name', 'Plantilla publicada v1');
+
+        $this->assertDatabaseHas('template_reviewers', [
+            'template_id' => $tid,
+            'user_id' => $reviewerTemplatePublished,
+            'stage' => 1,
+        ]);
+        $this->assertDatabaseMissing('template_reviewers', [
+            'template_id' => $tid,
+            'user_id' => $reviewerTemplateLive,
+        ]);
+        $this->assertDatabaseHas('template_document_reviewers', [
+            'template_id' => $tid,
+            'user_id' => $reviewerDocumentPublished,
+        ]);
+        $this->assertDatabaseMissing('template_document_reviewers', [
+            'template_id' => $tid,
+            'user_id' => $reviewerDocumentLive,
+        ]);
+    }
+
     public function test_template_version_block_layers_resolve_equal_blocks_snapshot_after_second_publish(): void
     {
         $creatorId = (string) Str::uuid();

--- a/backend/tests/Feature/TemplatesApiTest.php
+++ b/backend/tests/Feature/TemplatesApiTest.php
@@ -1033,6 +1033,44 @@ class TemplatesApiTest extends TestCase
             ->assertJsonPath('data.team.is_department', false);
     }
 
+    public function test_assigned_reviewer_can_view_in_review_template_without_academic_context(): void
+    {
+        $creatorId = (string) Str::uuid();
+        $reviewerId = 'f6bbe247-c60e-44ea-bfac-93e90c5c27bc';
+        $studyId = $this->anyStudyId();
+        $tid = (string) Str::uuid();
+
+        Template::query()->forceCreate([
+            'id' => $tid,
+            'name' => 'Plantilla in review sin contexto',
+            'description' => null,
+            'visibility_level' => TemplateVisibilityLevel::Study->value,
+            'delivery_deadline' => null,
+            'study_type_id' => null,
+            'study_id' => $studyId,
+            'module_id' => null,
+            'team_id' => null,
+            'created_by' => $creatorId,
+            'status' => 'in_review',
+            'review_stages' => 1,
+            'review_mode' => 'sequential',
+        ]);
+
+        $this->seedTemplateReviewer($tid, $reviewerId);
+
+        $this->assertDatabaseMissing('user_studies', [
+            'user_id' => $reviewerId,
+            'study_id' => $studyId,
+        ]);
+
+        $headersReviewer = $this->authHeaders($reviewerId);
+
+        $this->getJson("/api/v1/templates/{$tid}", $headersReviewer)
+            ->assertOk()
+            ->assertJsonPath('data.id', $tid)
+            ->assertJsonPath('data.status', 'in_review');
+    }
+
     public function test_template_first_publish_in_review_autofills_changelog_when_missing(): void
     {
         $creatorId = (string) Str::uuid();

--- a/backend/tests/Feature/TemplatesApiTest.php
+++ b/backend/tests/Feature/TemplatesApiTest.php
@@ -320,7 +320,7 @@ class TemplatesApiTest extends TestCase
             'id' => $t1,
             'name' => 'A',
             'description' => null,
-            'visibility_level' => TemplateVisibilityLevel::Personal->value,
+            'visibility_level' => TemplateVisibilityLevel::Global->value,
             'delivery_deadline' => null,
             'study_type_id' => null,
             'study_id' => null,
@@ -630,6 +630,67 @@ class TemplatesApiTest extends TestCase
             ->where('versionable_id', $tid)
             ->where('version_number', 0)
             ->value('status'));
+    }
+
+    public function test_post_template_new_version_reassigns_creator_to_actor(): void
+    {
+        $originalCreatorId = (string) Str::uuid();
+        $actorId = (string) Str::uuid();
+        $actorHeaders = $this->authHeaders($actorId, []);
+        $this->assignUserPermissions($actorId, ['templates.read', 'templates.update', 'templates.create']);
+
+        $tid = (string) Str::uuid();
+        $bid = (string) Str::uuid();
+        Template::query()->forceCreate([
+            'id' => $tid,
+            'process_id' => '00000000-0000-0000-0000-000000000001',
+            'name' => 'T',
+            'description' => null,
+            'visibility_level' => TemplateVisibilityLevel::Personal->value,
+            'delivery_deadline' => null,
+            'study_type_id' => null,
+            'study_id' => null,
+            'module_id' => null,
+            'team_id' => null,
+            'created_by' => $originalCreatorId,
+            'status' => 'published',
+            'review_stages' => 0,
+            'review_mode' => 'sequential',
+        ]);
+
+        TemplateBlock::query()->forceCreate([
+            'id' => $bid,
+            'template_id' => $tid,
+            'title' => 'B',
+            'default_content' => null,
+            'block_state' => 'editable',
+            'sort_order' => 0,
+        ]);
+
+        $head = EntityVersion::query()
+            ->where('versionable_type', Template::class)
+            ->where('versionable_id', $tid)
+            ->where('version_number', 0)
+            ->firstOrFail();
+        $head->status = 'published';
+        $head->snapshot_data = TemplateHeadSnapshot::mergeTemplateKey(
+            $head->snapshot_data ?? [],
+            ['status' => 'published'],
+        );
+        $head->save();
+        TemplateReviewer::query()->forceCreate([
+            'template_id' => $tid,
+            'user_id' => $actorId,
+            'stage' => 1,
+            'status' => 'pending',
+        ]);
+
+        $this->postJson("/api/v1/templates/{$tid}/new-version", [], $actorHeaders)
+            ->assertOk()
+            ->assertJsonPath('data.status', 'draft')
+            ->assertJsonPath('data.created_by', $actorId);
+
+        $this->assertSame($actorId, (string) Template::query()->findOrFail($tid)->created_by);
     }
 
     public function test_template_version_block_layers_resolve_equal_blocks_snapshot_after_second_publish(): void

--- a/backend/tests/Feature/TemplatesApiTest.php
+++ b/backend/tests/Feature/TemplatesApiTest.php
@@ -1302,9 +1302,7 @@ class TemplatesApiTest extends TestCase
 
         $this->getJson("/api/v1/templates/{$tid}/versions", $headersCreator)
             ->assertOk()
-            ->assertJsonCount(1, 'data')
-            ->assertJsonPath('data.0.version_number', 1)
-            ->assertJsonPath('data.0.changelog', 'Primera publicaci?n');
+            ->assertJsonCount(0, 'data');
 
         $this->getJson("/api/v1/template-versions/{$vid}", $headersCreator)
             ->assertOk()
@@ -1396,9 +1394,7 @@ class TemplatesApiTest extends TestCase
 
         $this->getJson("/api/v1/templates/{$tid}/versions", $headers)
             ->assertOk()
-            ->assertJsonCount(1, 'data')
-            ->assertJsonPath('data.0.version_number', 1)
-            ->assertJsonPath('data.0.changelog', 'entity-changelog');
+            ->assertJsonCount(0, 'data');
     }
 
     public function test_template_versions_endpoint_separates_template_history_from_document_history(): void
@@ -1462,8 +1458,7 @@ class TemplatesApiTest extends TestCase
 
         $this->getJson("/api/v1/templates/{$tid}/versions", $headers)
             ->assertOk()
-            ->assertJsonCount(1, 'data')
-            ->assertJsonPath('data.0.changelog', 'template-only-history');
+            ->assertJsonCount(0, 'data');
     }
 
     public function test_template_versions_endpoint_lists_publications_from_entity_versions_only(): void
@@ -1508,8 +1503,7 @@ class TemplatesApiTest extends TestCase
 
         $this->getJson("/api/v1/templates/{$tid}/versions", $headers)
             ->assertOk()
-            ->assertJsonCount(1, 'data')
-            ->assertJsonPath('data.0.changelog', 'canonical-template-history');
+            ->assertJsonCount(0, 'data');
     }
 
     public function test_template_version_detail_endpoint_accepts_entity_version_id_for_template(): void

--- a/backend/tests/Feature/TemplatesApiTest.php
+++ b/backend/tests/Feature/TemplatesApiTest.php
@@ -636,6 +636,7 @@ class TemplatesApiTest extends TestCase
     {
         $originalCreatorId = (string) Str::uuid();
         $actorId = (string) Str::uuid();
+        $studyId = $this->anyStudyId();
         $actorHeaders = $this->authHeaders($actorId, []);
         $this->assignUserPermissions($actorId, ['templates.read', 'templates.update', 'templates.create']);
 
@@ -646,10 +647,10 @@ class TemplatesApiTest extends TestCase
             'process_id' => '00000000-0000-0000-0000-000000000001',
             'name' => 'T',
             'description' => null,
-            'visibility_level' => TemplateVisibilityLevel::Personal->value,
+            'visibility_level' => TemplateVisibilityLevel::Study->value,
             'delivery_deadline' => null,
             'study_type_id' => null,
-            'study_id' => null,
+            'study_id' => $studyId,
             'module_id' => null,
             'team_id' => null,
             'created_by' => $originalCreatorId,
@@ -683,6 +684,13 @@ class TemplatesApiTest extends TestCase
             'user_id' => $actorId,
             'stage' => 1,
             'status' => 'pending',
+        ]);
+        DB::table('user_studies')->insertOrIgnore([
+            'id' => (string) Str::uuid(),
+            'user_id' => $actorId,
+            'study_id' => $studyId,
+            'created_at' => now(),
+            'updated_at' => now(),
         ]);
 
         $this->postJson("/api/v1/templates/{$tid}/new-version", [], $actorHeaders)

--- a/frontend/src/api/documents.ts
+++ b/frontend/src/api/documents.ts
@@ -10,6 +10,9 @@ export type DocumentCreationOption = {
   template_version_id: string;
   name: string;
   description: string | null;
+  visibility_level?: string;
+  team_id?: string | null;
+  team_name?: string | null;
 };
 
 export type DocumentCreationOptionsResponse = {
@@ -143,6 +146,7 @@ export async function createDocument(payload: {
   study_type_id?: string | null;
   study_id?: string | null;
   module_id?: string | null;
+  team_id?: string | null;
   template_version_id?: string | null;
   delivery_deadline?: string | null;
 }): Promise<Document> {

--- a/frontend/src/api/documents.ts
+++ b/frontend/src/api/documents.ts
@@ -55,6 +55,8 @@ export type DocumentVersionSummary = {
   version_number: number;
   trigger_event: string;
   triggered_by: string;
+  published_by_name?: string | null;
+  author_name?: string | null;
   changelog: string | null;
   notes: string | null;
   created_at: string | null;
@@ -75,6 +77,9 @@ export type DocumentVersionDetail = {
   version_number: number;
   trigger_event: string;
   triggered_by: string;
+  published_by_name?: string | null;
+  author_name?: string | null;
+  owner_name?: string | null;
   changelog: string | null;
   snapshot_data: Record<string, unknown>;
   created_at: string | null;

--- a/frontend/src/api/documents.ts
+++ b/frontend/src/api/documents.ts
@@ -212,6 +212,18 @@ export async function startDocumentNewVersion(documentId: string): Promise<Docum
   return body.data;
 }
 
+/** DELETE /api/v1/documents/{id}/versions/{versionId} — descarta borrador/en revisión y restaura última publicada. */
+export async function discardDocumentWorkingVersion(
+  documentId: string,
+  versionId: string,
+): Promise<DocumentDetail> {
+  const body = await apiFetchJson<DocumentDetailApiResponse>(
+    `documents/${encodeURIComponent(documentId)}/versions/${encodeURIComponent(versionId)}`,
+    { method: 'DELETE' },
+  );
+  return body.data;
+}
+
 /** GET /api/v1/documents/{id}/reviews */
 export async function fetchDocumentReviews(documentId: string): Promise<DocumentReview[]> {
   const body = await apiGetJson<DocumentReviewsApiResponse>(

--- a/frontend/src/api/documents.ts
+++ b/frontend/src/api/documents.ts
@@ -8,6 +8,7 @@ type CreationMode = 'none' | 'auto' | 'select';
 export type DocumentCreationOption = {
   template_id: string;
   template_version_id: string;
+  process_id: string;
   name: string;
   description: string | null;
   visibility_level?: string;

--- a/frontend/src/api/documents.ts
+++ b/frontend/src/api/documents.ts
@@ -212,6 +212,15 @@ export async function startDocumentNewVersion(documentId: string): Promise<Docum
   return body.data;
 }
 
+/** POST /api/v1/documents/{id}/clone */
+export async function cloneDocument(documentId: string): Promise<DocumentDetail> {
+  const body = await apiFetchJson<DocumentDetailApiResponse>(
+    `documents/${encodeURIComponent(documentId)}/clone`,
+    { method: 'POST', body: {} },
+  );
+  return body.data;
+}
+
 /** DELETE /api/v1/documents/{id}/versions/{versionId} — descarta borrador/en revisión y restaura última publicada. */
 export async function discardDocumentWorkingVersion(
   documentId: string,

--- a/frontend/src/api/templates.ts
+++ b/frontend/src/api/templates.ts
@@ -46,6 +46,9 @@ function buildListQuery(filters: TemplateListFilters): string {
   if (filters.status) {
     q.set('status', filters.status);
   }
+  if (filters.usable_for_documents) {
+    q.set('usable_for_documents', '1');
+  }
   if (filters.study_type_id) {
     q.set('study_type_id', filters.study_type_id);
   }

--- a/frontend/src/api/templates.ts
+++ b/frontend/src/api/templates.ts
@@ -96,9 +96,18 @@ export type TemplateVersionDetail = {
   id: string;
   template_id: string;
   version_number: number;
+  template_snapshot?: {
+    name?: string;
+    created_by?: string;
+    visibility_level?: string;
+    delivery_deadline?: string | null;
+    updated_at?: string | null;
+  } | null;
   blocks_snapshot: TemplateVersionSnapshotBlock[];
   changelog: string | null;
   published_by: string | null;
+  published_by_name?: string | null;
+  author_name?: string | null;
   published_at: string | null;
   created_at?: string;
   updated_at?: string;
@@ -118,6 +127,8 @@ export type TemplateVersionSummary = {
   version_number: number;
   published_at: string | null;
   published_by: string | null;
+  published_by_name?: string | null;
+  author_name?: string | null;
   changelog: string | null;
 };
 

--- a/frontend/src/components/DocumentsContent.tsx
+++ b/frontend/src/components/DocumentsContent.tsx
@@ -97,9 +97,13 @@ export function DocumentsContent() {
       const hasPublishedFallback =
         d.status !== 'published' &&
         !!d.latest_published_version_id;
+      const isAssignedReviewer =
+        d.status === 'in_review' &&
+        hasPermission('documents.review');
       const canSeeLive =
         (profile?.id != null && (profile.id === d.created_by || profile.id === d.owner_id)) ||
-        d.share_permission === 'edit';
+        d.share_permission === 'edit' ||
+        isAssignedReviewer;
 
       if (!hasPublishedFallback) {
         out.push({ ...d, list_variant: 'live', list_row_id: `${d.id}:live` });
@@ -120,7 +124,7 @@ export function DocumentsContent() {
       out.push(publishedFallback);
     }
     return out;
-  }, [documents, profile?.id]);
+  }, [documents, hasPermission, profile?.id]);
 
   const filtered = useFilteredDocuments(displayDocuments, activeFilters, hierarchy);
   const filtersActiveCount =

--- a/frontend/src/components/DocumentsContent.tsx
+++ b/frontend/src/components/DocumentsContent.tsx
@@ -226,14 +226,18 @@ export function DocumentsContent() {
       setPage(1);
     });
 
-  const handleCreateFromModule = async (templateVersionId?: string) => {
+  const handleCreateFromModule = async (templateVersionId?: string, processId?: string) => {
     if (!selectedModuleId) return;
+    if (!processId) {
+      setCreationError('No se pudo resolver el proceso de la plantilla seleccionada.');
+      return;
+    }
     setCreatingDocument(true);
     setCreationError(null);
     try {
       const created = await createDocumentFromModule({
         module_id: selectedModuleId,
-        process_id: '33333333-3333-3333-3333-333333333301', // Hardcoded for "Programación didáctica"
+        process_id: processId,
         ...(templateVersionId ? { template_version_id: templateVersionId } : {}),
       });
       navigate(`/documents/${created.id}/editor`);
@@ -560,7 +564,7 @@ export function DocumentsContent() {
                     type="button"
                     loading={creatingDocument}
                     disabled={previewLoading || !!previewError || !previewOption}
-                    onClick={() => void handleCreateFromModule(previewOption.template_version_id)}
+                    onClick={() => void handleCreateFromModule(previewOption.template_version_id, previewOption.process_id)}
                   >
                     Usar esta plantilla
                   </Button>

--- a/frontend/src/components/DocumentsContent.tsx
+++ b/frontend/src/components/DocumentsContent.tsx
@@ -91,7 +91,38 @@ export function DocumentsContent() {
   const { documents, loading, error, reload } = useDocuments();
   const { hierarchy } = useHierarchy();
   const { hasPermission, loading: profileLoading, profile } = useUserProfile();
-  const filtered = useFilteredDocuments(documents, activeFilters, hierarchy);
+  const displayDocuments = useMemo(() => {
+    const out: Document[] = [];
+    for (const d of documents) {
+      const hasPublishedFallback =
+        d.status !== 'published' &&
+        !!d.latest_published_version_id;
+      const canSeeLive =
+        (profile?.id != null && (profile.id === d.created_by || profile.id === d.owner_id)) ||
+        d.share_permission === 'edit';
+
+      if (!hasPublishedFallback) {
+        out.push({ ...d, list_variant: 'live', list_row_id: `${d.id}:live` });
+        continue;
+      }
+
+      const publishedFallback: Document = {
+        ...d,
+        status: 'published',
+        current_version: d.latest_published_version_number ?? d.current_version,
+        list_variant: 'published_fallback',
+        list_row_id: `${d.id}:published`,
+      };
+
+      if (canSeeLive) {
+        out.push({ ...d, list_variant: 'live', list_row_id: `${d.id}:live` });
+      }
+      out.push(publishedFallback);
+    }
+    return out;
+  }, [documents, profile?.id]);
+
+  const filtered = useFilteredDocuments(displayDocuments, activeFilters, hierarchy);
   const filtersActiveCount =
     (activeFilters.studyTypeId ? 1 : 0) +
     (activeFilters.studyId ? 1 : 0) +
@@ -308,6 +339,10 @@ export function DocumentsContent() {
             size="xs"
             onClick={(e: React.MouseEvent) => {
               e.stopPropagation();
+              if (d.list_variant === 'published_fallback' && d.latest_published_version_id) {
+                navigate(`/documents/${d.id}?documentVersionId=${encodeURIComponent(d.latest_published_version_id)}`);
+                return;
+              }
               navigate(`/documents/${d.id}`);
             }}
           >
@@ -554,7 +589,7 @@ export function DocumentsContent() {
                   }
                   columns={columns}
                   rows={pageRows}
-                  rowKey={(d) => d.id}
+                  rowKey={(d) => d.list_row_id ?? d.id}
                   loading={loading}
                   pageSize={pageSize}
                   onPageSizeChange={(size) => {
@@ -565,7 +600,13 @@ export function DocumentsContent() {
                   onToggleHiddenColumn={toggleColumn}
                   sortBy={sortBy}
                   onSortChange={setSortBy}
-                  onRowClick={(d) => navigate(`/documents/${d.id}`)}
+                  onRowClick={(d) => {
+                    if (d.list_variant === 'published_fallback' && d.latest_published_version_id) {
+                      navigate(`/documents/${d.id}?documentVersionId=${encodeURIComponent(d.latest_published_version_id)}`);
+                      return;
+                    }
+                    navigate(`/documents/${d.id}`);
+                  }}
                   emptyMessage="No hay programaciones didácticas con los filtros actuales."
                   className="rounded-none border-0 shadow-none"
                   filtersStorageKey="maya:dms:documents-table"

--- a/frontend/src/components/DocumentsContent.tsx
+++ b/frontend/src/components/DocumentsContent.tsx
@@ -436,6 +436,10 @@ export function DocumentsContent() {
                         <span className="text-sm font-medium text-text-primary dark:text-text-dark-primary block">
                           {option.name}
                         </span>
+                        <span className="text-[11px] text-text-muted dark:text-text-dark-muted mt-1 block">
+                          Visibilidad: {option.visibility_level ?? '—'}
+                          {option.team_name ? ` · Equipo: ${option.team_name}` : ''}
+                        </span>
                         {option.description ? (
                           <span className="text-xs text-text-muted dark:text-text-dark-muted mt-1 block line-clamp-2">
                             {option.description}

--- a/frontend/src/components/VersionHistoryPanel.tsx
+++ b/frontend/src/components/VersionHistoryPanel.tsx
@@ -190,7 +190,12 @@ export function VersionHistoryPanel({ open, entityType, entityId, onClose }: Pro
                     </div>
                     <p className="mt-1 text-xs text-text-muted dark:text-text-dark-muted">
                       {row.trigger_event}
-                      {row.triggered_by ? ` · ${row.triggered_by}` : ''}
+                    </p>
+                    <p className="mt-1 text-xs text-text-muted dark:text-text-dark-muted">
+                      Publicado por: {row.published_by_name ?? 'Desconocido'}
+                    </p>
+                    <p className="text-xs text-text-muted dark:text-text-dark-muted">
+                      Autor versión: {row.author_name ?? 'Desconocido'}
                     </p>
                     {(row.notes ?? row.changelog) ? (
                       <p className="mt-1.5 text-xs text-text-secondary dark:text-text-dark-secondary leading-snug whitespace-pre-wrap">

--- a/frontend/src/components/VersionHistoryPanel.tsx
+++ b/frontend/src/components/VersionHistoryPanel.tsx
@@ -154,6 +154,12 @@ export function VersionHistoryPanel({ open, entityType, entityId, onClose }: Pro
                         {row.changelog}
                       </p>
                     ) : null}
+                    <p className="mt-1 text-xs text-text-muted dark:text-text-dark-muted">
+                      Publicado por: {row.published_by_name ?? 'Desconocido'}
+                    </p>
+                    <p className="text-xs text-text-muted dark:text-text-dark-muted">
+                      Autor versión: {row.author_name ?? 'Desconocido'}
+                    </p>
                   </button>
                 </li>
               ))}

--- a/frontend/src/features/documents/components/DocumentWizard.tsx
+++ b/frontend/src/features/documents/components/DocumentWizard.tsx
@@ -24,7 +24,7 @@ import {
 import { ApiHttpError } from '../../../api/http';
 import { fetchProcesses } from '../../../api/processes';
 import { fetchTemplate } from '../../../api/templates';
-import { fetchMe, searchDocumentReviewerCandidates, searchUsers } from '../../../api/users';
+import { fetchMe, searchDocumentReviewerCandidates, searchUsers, type UserTeam } from '../../../api/users';
 import { useAutoSave } from '../../../hooks/useAutoSave';
 import { useDarkMode } from '@maya/shared-layout-react';
 import type { DocumentDetail, DocumentDisplayBlock, DocumentStatus } from '../../../types/documents';
@@ -33,6 +33,7 @@ import type { Template } from '../../../types/templates';
 import { BLOCK_UI_STATE_CONFIG, blockToUiState } from '../../templates/blockUiState';
 import { normalizeBlockContentForEditor } from '../lib/normalizeBlockContent';
 import { BlockContentHtml } from '../../templates/components/BlockContentHtml';
+import { visibilityLabel } from '../../templates/constants';
 import {
   Button,
   ConfirmDialog,
@@ -56,6 +57,7 @@ type Step = 'properties' | 'blocks' | 'summary';
 type SummaryConfirmAction = 'save' | 'submit' | null;
 type BlockViewTab = 'content' | 'description';
 type ReviewModeView = 'sequential' | 'parallel';
+type VisibilityRuleMode = 'global' | 'study_type' | 'study' | 'module' | 'team' | 'personal' | 'unknown';
 type ReviewerView = {
   id: string;
   name: string;
@@ -216,6 +218,8 @@ export function DocumentWizard({ documentId, templateId, mode = 'edit' }: Props)
   const [studyTypeId, setStudyTypeId] = useState('');
   const [studyId, setStudyId] = useState('');
   const [moduleId, setModuleId] = useState('');
+  const [teamId, setTeamId] = useState('');
+  const [availableTeams, setAvailableTeams] = useState<UserTeam[]>([]);
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [saving, setSaving] = useState(false);
   const [submittingForReview, setSubmittingForReview] = useState(false);
@@ -279,6 +283,7 @@ export function DocumentWizard({ documentId, templateId, mode = 'edit' }: Props)
       setStudyTypeId(data.study_type_id ?? '');
       setStudyId(data.study_id ?? '');
       setModuleId(data.module_id ?? '');
+      setTeamId(data.team_id ?? '');
       setActiveBlockKey((prev: string | null) => {
         if (prev) return prev;
         if (data.blocks.length === 0) return null;
@@ -303,6 +308,7 @@ export function DocumentWizard({ documentId, templateId, mode = 'edit' }: Props)
       setStudyTypeId(data.study_type_id ?? '');
       setStudyId(data.study_id ?? '');
       setModuleId(data.module_id ?? '');
+      setTeamId(data.team_id ?? '');
       setActiveBlockKey((prev: string | null) => {
         if (prev && data.blocks.some((b) => (b.document_block_id ?? b.template_block_id) === prev)) {
           return prev;
@@ -343,6 +349,21 @@ export function DocumentWizard({ documentId, templateId, mode = 'edit' }: Props)
   useEffect(() => {
     void reload();
   }, [reload]);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const me = await fetchMe();
+        if (!cancelled) setAvailableTeams(me.data.teams ?? []);
+      } catch {
+        if (!cancelled) setAvailableTeams([]);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   useEffect(() => {
     setFormError(null);
@@ -476,13 +497,105 @@ export function DocumentWizard({ documentId, templateId, mode = 'edit' }: Props)
   const activeBlockUiState = activeBlock ? blockToUiState(activeBlock) : null;
 
   const allStudies = hierarchy.flatMap((t) => t.studies);
+  const selectedTemplateVisibility = template?.visibility_level ?? detail?.visibility_level ?? null;
+  const visibilityRule: VisibilityRuleMode = selectedTemplateVisibility ?? 'unknown';
+  const templateStudyTypeId = template?.study_type_id ?? null;
+  const templateStudyId = template?.study_id ?? null;
+  const templateModuleId = template?.module_id ?? null;
 
-  const filteredStudies = studyTypeId
-    ? (hierarchy.find((t: any) => String(t.id) === studyTypeId)?.studies ?? [])
-    : [];
-  const filteredModules = studyId
-    ? (allStudies.find((s: any) => String(s.id) === studyId)?.course_modules ?? [])
-    : [];
+  const selectedStudyNode = allStudies.find((s: any) => String(s.id) === studyId) ?? null;
+
+  const filteredStudies = useMemo(() => {
+    if (!studyTypeId) return [];
+    const byType = (hierarchy.find((t: any) => String(t.id) === studyTypeId)?.studies ?? []) as any[];
+    if (visibilityRule === 'study' || visibilityRule === 'module') {
+      return byType.filter((s: any) => String(s.id) === String(templateStudyId ?? ''));
+    }
+    return byType;
+  }, [studyTypeId, hierarchy, visibilityRule, templateStudyId]);
+
+  const filteredModules = useMemo(() => {
+    if (!studyId) return [];
+    const byStudy = (allStudies.find((s: any) => String(s.id) === studyId)?.course_modules ?? []) as any[];
+    if (visibilityRule === 'module') {
+      return byStudy.filter((m: any) => String(m.id) === String(templateModuleId ?? ''));
+    }
+    return byStudy;
+  }, [studyId, allStudies, visibilityRule, templateModuleId]);
+
+  const studyTypeEditable = visibilityRule === 'global' || visibilityRule === 'unknown';
+  const studyEditable = visibilityRule === 'global' || visibilityRule === 'study_type' || visibilityRule === 'unknown';
+  const moduleEditable = visibilityRule === 'global' || visibilityRule === 'study_type' || visibilityRule === 'study' || visibilityRule === 'unknown';
+  const teamEditable = visibilityRule === 'global';
+  const fixedTeamId = visibilityRule === 'team' ? (template?.team_id ?? '') : '';
+  const templateScopeLabel = useMemo(() => {
+    if (!template) return null;
+    const studyType = hierarchy.find((t: any) => String(t.id) === String(template.study_type_id ?? ''));
+    const studies = (studyType?.studies ?? hierarchy.flatMap((t: any) => t.studies ?? [])) as any[];
+    const study = studies.find((s: any) => String(s.id) === String(template.study_id ?? ''));
+    const modules = (study?.course_modules ?? []) as any[];
+    const module = modules.find((m: any) => String(m.id) === String(template.module_id ?? ''));
+    if (template.visibility_level === 'study_type') return studyType?.name ?? null;
+    if (template.visibility_level === 'study') return study?.name ?? null;
+    if (template.visibility_level === 'module') return module?.name ?? null;
+    if (template.visibility_level === 'team') return template.team?.name ?? null;
+    return null;
+  }, [template, hierarchy]);
+
+  const requireStudyType = visibilityRule === 'study_type' || visibilityRule === 'study' || visibilityRule === 'module';
+  const requireStudy = visibilityRule === 'study' || visibilityRule === 'module';
+  const requireModule = visibilityRule === 'module';
+  const isGlobalAcademicMode = visibilityRule !== 'global' ? true : (!teamId);
+
+  useEffect(() => {
+    if (!template) return;
+    if (visibilityRule === 'team' || visibilityRule === 'personal') {
+      setStudyTypeId('');
+      setStudyId('');
+      setModuleId('');
+      if (visibilityRule === 'team' && template.team_id) {
+        setTeamId(template.team_id);
+      }
+      return;
+    }
+    if (visibilityRule === 'study_type' && templateStudyTypeId) {
+      setStudyTypeId(templateStudyTypeId);
+      if (studyId && selectedStudyNode && String(selectedStudyNode.study_type_id) !== String(templateStudyTypeId)) {
+        setStudyId('');
+        setModuleId('');
+      }
+      return;
+    }
+    if (visibilityRule === 'study' && templateStudyId) {
+      const stFromStudy = allStudies.find((s: any) => String(s.id) === String(templateStudyId))?.study_type_id;
+      if (stFromStudy) setStudyTypeId(String(stFromStudy));
+      setStudyId(String(templateStudyId));
+      if (moduleId) {
+        const moduleInStudy = (allStudies.find((s: any) => String(s.id) === String(templateStudyId))?.course_modules ?? [])
+          .some((m: any) => String(m.id) === String(moduleId));
+        if (!moduleInStudy) setModuleId('');
+      }
+      return;
+    }
+    if (visibilityRule === 'module' && templateModuleId) {
+      const owningStudy = allStudies.find((s: any) => (s.course_modules ?? []).some((m: any) => String(m.id) === String(templateModuleId))) ?? null;
+      if (owningStudy) {
+        setStudyTypeId(String(owningStudy.study_type_id));
+        setStudyId(String(owningStudy.id));
+      }
+      setModuleId(String(templateModuleId));
+    }
+  }, [
+    template,
+    visibilityRule,
+    templateStudyTypeId,
+    templateStudyId,
+    templateModuleId,
+    allStudies,
+    studyId,
+    moduleId,
+    selectedStudyNode,
+  ]);
 
   const selectedSummaryBlock = useMemo(
     () =>
@@ -692,9 +805,13 @@ export function DocumentWizard({ documentId, templateId, mode = 'edit' }: Props)
     setErrors({});
     if (step === 'properties') {
       const newErrors: Record<string, string> = {};
-      if (!studyTypeId) newErrors.studyTypeId = 'Selecciona un tipo de estudio.';
-      if (!studyId) newErrors.studyId = 'Selecciona un estudio.';
-      if (!moduleId) newErrors.moduleId = 'Selecciona un módulo.';
+      if ((requireStudyType || (visibilityRule === 'global' && isGlobalAcademicMode && (studyId || moduleId || studyTypeId))) && !studyTypeId) {
+        newErrors.studyTypeId = 'Selecciona un tipo de estudio.';
+      }
+      if ((requireStudy || (visibilityRule === 'global' && isGlobalAcademicMode && (moduleId || studyId))) && !studyId) {
+        newErrors.studyId = 'Selecciona un estudio.';
+      }
+      if (requireModule && !moduleId) newErrors.moduleId = 'Selecciona un módulo.';
       if (!title.trim()) newErrors.title = 'El título es obligatorio.';
       if (!deliveryDeadline) {
         newErrors.deliveryDeadline = 'La fecha de entrega es obligatoria.';
@@ -725,9 +842,10 @@ export function DocumentWizard({ documentId, templateId, mode = 'edit' }: Props)
             template_id: templateId,
             process_id: template.process_id,
             title: title.trim(),
-            study_type_id: studyTypeId,
-            study_id: studyId,
-            module_id: moduleId,
+            study_type_id: studyTypeId || undefined,
+            study_id: studyId || undefined,
+            module_id: moduleId || undefined,
+            team_id: teamId || undefined,
             delivery_deadline: deliveryDeadline ? `${deliveryDeadline}T00:00:00Z` : null,
           });
 
@@ -740,9 +858,9 @@ export function DocumentWizard({ documentId, templateId, mode = 'edit' }: Props)
           const updated = await updateDocument(documentId, {
             title: title.trim(),
             delivery_deadline: deliveryDeadline ? `${deliveryDeadline}T00:00:00Z` : null,
-            study_type_id: studyTypeId,
-            study_id: studyId,
-            module_id: moduleId,
+            study_type_id: studyTypeId || undefined,
+            study_id: studyId || undefined,
+            module_id: moduleId || undefined,
           });
 
           setDetail((prev: DocumentDetail | null) => (prev ? { ...prev, ...updated, blocks: prev.blocks } : prev));
@@ -1071,6 +1189,21 @@ export function DocumentWizard({ documentId, templateId, mode = 'edit' }: Props)
                       Cambiar plantilla
                     </button>
                   </div>
+                  <div className="mt-2 flex flex-wrap gap-2 text-xs text-text-secondary dark:text-text-dark-secondary">
+                    <span className="rounded border border-ui-border dark:border-ui-dark-border px-2 py-0.5">
+                      Visibilidad: {visibilityLabel(template.visibility_level)}
+                    </span>
+                    {templateScopeLabel && (
+                      <span className="rounded border border-ui-border dark:border-ui-dark-border px-2 py-0.5">
+                        Ámbito: {templateScopeLabel}
+                      </span>
+                    )}
+                    {(template.team?.name || fixedTeamId || teamId) && (
+                      <span className="rounded border border-ui-border dark:border-ui-dark-border px-2 py-0.5">
+                        Equipo: {template.team?.name ?? availableTeams.find((t) => t.id === (fixedTeamId || teamId))?.name ?? 'Asignado'}
+                      </span>
+                    )}
+                  </div>
                 </div>
               )}
 
@@ -1079,16 +1212,42 @@ export function DocumentWizard({ documentId, templateId, mode = 'edit' }: Props)
                   Selecciona el contexto académico donde se archivará esta programación.
                 </p>
 
+                {teamEditable && (
+                  <div className="space-y-1">
+                    <FieldLabel>Equipo (opcional, exclusivo con contexto académico)</FieldLabel>
+                    <Select
+                      fieldSize="comfortable"
+                      value={teamId}
+                      disabled={!isDraft || !teamEditable}
+                      onChange={(e: ChangeEvent<HTMLSelectElement>) => {
+                        setTeamId(e.target.value);
+                        if (e.target.value) {
+                          setStudyTypeId('');
+                          setStudyId('');
+                          setModuleId('');
+                        }
+                        setErrors((prev: Record<string, string>) => ({ ...prev, studyTypeId: '', studyId: '', moduleId: '' }));
+                      }}
+                    >
+                      <option value="">— Sin equipo (global/académico) —</option>
+                      {availableTeams.map((t) => (
+                        <option key={t.id} value={t.id}>{t.name}</option>
+                      ))}
+                    </Select>
+                  </div>
+                )}
+
                 <div className="space-y-1">
-                  <FieldLabel required>Tipo de Estudio</FieldLabel>
+                  <FieldLabel required={requireStudyType}>Tipo de Estudio</FieldLabel>
                   <Select
                     fieldSize="comfortable"
                     value={studyTypeId}
-                    disabled={hierarchyLoading || !isDraft}
+                    disabled={hierarchyLoading || !isDraft || !studyTypeEditable || (visibilityRule === 'global' && !isGlobalAcademicMode)}
                     onChange={(e) => {
                       setStudyTypeId(e.target.value);
                       setStudyId('');
                       setModuleId('');
+                      if (visibilityRule === 'global') setTeamId('');
                       setErrors((prev: Record<string, string>) => ({ ...prev, studyTypeId: '', studyId: '', moduleId: '' }));
                     }}
                     error={!!errors.studyTypeId}
@@ -1110,14 +1269,15 @@ export function DocumentWizard({ documentId, templateId, mode = 'edit' }: Props)
                 </div>
 
                 <div className="space-y-1">
-                  <FieldLabel required>Estudio</FieldLabel>
+                  <FieldLabel required={requireStudy}>Estudio</FieldLabel>
                   <Select
                     fieldSize="comfortable"
                     value={studyId}
-                    disabled={hierarchyLoading || !studyTypeId || !isDraft}
+                    disabled={hierarchyLoading || !studyTypeId || !isDraft || !studyEditable || (visibilityRule === 'global' && !isGlobalAcademicMode)}
                     onChange={(e: ChangeEvent<HTMLSelectElement>) => {
                       setStudyId(e.target.value);
                       setModuleId('');
+                      if (visibilityRule === 'global') setTeamId('');
                       setErrors((prev: Record<string, string>) => ({ ...prev, studyId: '', moduleId: '' }));
                     }}
                     error={!!errors.studyId}
@@ -1133,13 +1293,14 @@ export function DocumentWizard({ documentId, templateId, mode = 'edit' }: Props)
                 </div>
 
                 <div className="space-y-1">
-                  <FieldLabel required>Módulo</FieldLabel>
+                  <FieldLabel required={requireModule}>Módulo</FieldLabel>
                   <Select
                     fieldSize="comfortable"
                     value={moduleId}
-                    disabled={hierarchyLoading || !studyId || !isDraft}
+                    disabled={hierarchyLoading || !studyId || !isDraft || !moduleEditable || (visibilityRule === 'global' && !isGlobalAcademicMode)}
                     onChange={(e: ChangeEvent<HTMLSelectElement>) => {
                       setModuleId(e.target.value);
+                      if (visibilityRule === 'global') setTeamId('');
                       setErrors((prev: Record<string, string>) => ({ ...prev, moduleId: '' }));
                     }}
                     error={!!errors.moduleId}

--- a/frontend/src/features/documents/components/DocumentWizard.tsx
+++ b/frontend/src/features/documents/components/DocumentWizard.tsx
@@ -265,6 +265,7 @@ export function DocumentWizard({ documentId, templateId, mode = 'edit' }: Props)
     fromTemplateSelection?: boolean;
   } | null;
   const returnToSummary = locationState?.step === 'summary';
+  const forcePropertiesStep = locationState?.step === 'properties';
   const locationProcessId = locationState?.processId;
   const locationModuleId = locationState?.moduleId;
   const fromTemplateSelection = locationState?.fromTemplateSelection === true;
@@ -399,6 +400,11 @@ export function DocumentWizard({ documentId, templateId, mode = 'edit' }: Props)
       setStep('blocks');
       return;
     }
+    if (forcePropertiesStep) {
+      setStep('properties');
+      setCompletedSteps([]);
+      return;
+    }
     // Si es borrador pero le falta la fecha límite, forzamos paso de propiedades
     if (!detail.delivery_deadline) {
       setStep('properties');
@@ -407,7 +413,7 @@ export function DocumentWizard({ documentId, templateId, mode = 'edit' }: Props)
       setCompletedSteps(['properties']);
       setStep('blocks');
     }
-  }, [detail?.id, detail?.status, detail?.delivery_deadline, mode]);
+  }, [detail?.id, detail?.status, detail?.delivery_deadline, forcePropertiesStep, mode]);
 
   useEffect(() => {
     if (mode === 'validate') return;

--- a/frontend/src/features/documents/components/DocumentWizard.tsx
+++ b/frontend/src/features/documents/components/DocumentWizard.tsx
@@ -1120,6 +1120,15 @@ export function DocumentWizard({ documentId, templateId, mode = 'edit' }: Props)
       navigate('/dashboard');
       return;
     }
+    if (!documentId && step === 'properties') {
+      navigate('/documentos/nuevo', {
+        state: {
+          moduleId: locationModuleId,
+          processId: locationProcessId,
+        },
+      });
+      return;
+    }
     if (step === 'blocks') {
       setStep('properties');
       return;

--- a/frontend/src/features/documents/components/DocumentWizard.tsx
+++ b/frontend/src/features/documents/components/DocumentWizard.tsx
@@ -262,10 +262,12 @@ export function DocumentWizard({ documentId, templateId, mode = 'edit' }: Props)
     step?: string;
     processId?: string;
     moduleId?: string;
+    fromTemplateSelection?: boolean;
   } | null;
   const returnToSummary = locationState?.step === 'summary';
   const locationProcessId = locationState?.processId;
   const locationModuleId = locationState?.moduleId;
+  const fromTemplateSelection = locationState?.fromTemplateSelection === true;
   const processBackTo = useMemo(() => {
     const effectiveProcessId = locationProcessId ?? template?.process_id ?? null;
     return effectiveProcessId ? `/procesos/${effectiveProcessId}` : '/dashboard';
@@ -850,7 +852,14 @@ export function DocumentWizard({ documentId, templateId, mode = 'edit' }: Props)
           });
 
           // Navigate to the editor route with the new ID
-          navigate(`/documents/${created.id}/editor`, { replace: true });
+          navigate(`/documents/${created.id}/editor`, {
+            replace: true,
+            state: {
+              processId: locationProcessId,
+              moduleId: locationModuleId,
+              fromTemplateSelection: true,
+            },
+          });
           setStep('blocks');
           setCompletedSteps((prev: Step[]) => (prev.includes('properties') ? prev : [...prev, 'properties']));
         } else {
@@ -1120,7 +1129,7 @@ export function DocumentWizard({ documentId, templateId, mode = 'edit' }: Props)
       navigate('/dashboard');
       return;
     }
-    if (!documentId && step === 'properties') {
+    if (step === 'properties' && (!documentId || fromTemplateSelection)) {
       navigate('/documentos/nuevo', {
         state: {
           moduleId: locationModuleId,

--- a/frontend/src/features/documents/components/DocumentWizard.tsx
+++ b/frontend/src/features/documents/components/DocumentWizard.tsx
@@ -1167,8 +1167,12 @@ export function DocumentWizard({ documentId, templateId, mode = 'edit' }: Props)
   return (
     <>
     <WizardShell<Step>
-      title={detail?.title || 'Nueva programación'}
-      subtitle={processSubtitle ?? (detail?.title ? 'Editar programación' : undefined)}
+      title={
+        detail?.title
+          ? `Editando: ${detail.title}`
+          : (documentId ? 'Documento' : 'Nuevo documento')
+      }
+      subtitle={processSubtitle}
       onBack={handleWizardBack}
       backLabel={isValidateMode ? 'Volver al panel principal' : 'Volver'}
       actions={headerActions}
@@ -1211,12 +1215,12 @@ export function DocumentWizard({ documentId, templateId, mode = 'edit' }: Props)
                     <span className="rounded border border-ui-border dark:border-ui-dark-border px-2 py-0.5">
                       Visibilidad: {visibilityLabel(template.visibility_level)}
                     </span>
-                    {templateScopeLabel && (
+                    {templateScopeLabel && template.visibility_level !== 'team' && (
                       <span className="rounded border border-ui-border dark:border-ui-dark-border px-2 py-0.5">
                         Ámbito: {templateScopeLabel}
                       </span>
                     )}
-                    {(template.team?.name || fixedTeamId || teamId) && (
+                    {(visibilityRule === 'team' || visibilityRule === 'global') && (template.team?.name || fixedTeamId || teamId) && (
                       <span className="rounded border border-ui-border dark:border-ui-dark-border px-2 py-0.5">
                         Equipo: {template.team?.name ?? availableTeams.find((t) => t.id === (fixedTeamId || teamId))?.name ?? 'Asignado'}
                       </span>

--- a/frontend/src/features/documents/components/DocumentsTable.tsx
+++ b/frontend/src/features/documents/components/DocumentsTable.tsx
@@ -18,6 +18,7 @@ import { VISIBILITY_OPTIONS, visibilityLabel } from '../../templates/constants';
 import type { TemplateVisibilityLevel } from '../../../types/templates';
 import { useFavoritesIds } from '../../../hooks/useFavoritesIds';
 import { FavoriteInlineMark } from '../../../components/FavoriteInlineMark';
+import { useUserProfile } from '../../../features/user-profile';
 
 // Estado y visibilidad: clases provenientes del módulo compartido `badges`
 // (los colores hex viven en `maya_infra/configs/styles/index.css`).
@@ -83,6 +84,7 @@ type Props = {
 
 export function DocumentsTable({ processId }: Props = {}) {
   const navigate = useNavigate();
+  const { profile } = useUserProfile();
   const { documentIds: favoriteDocumentIds } = useFavoritesIds();
   const { hiddenIds, toggleHidden, sortBy, setSortBy, pageSize, setPageSize } = useTablePreferences({
     storageKey: 'maya:dms:documents-table',
@@ -159,7 +161,38 @@ export function DocumentsTable({ processId }: Props = {}) {
   const nameDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const authorDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const filtered = useMemo(() => applyClientFilters(documents, filters), [documents, filters]);
+  const displayDocuments = useMemo(() => {
+    const out: Document[] = [];
+    for (const d of documents) {
+      const hasPublishedFallback =
+        d.status !== 'published' &&
+        !!d.latest_published_version_id;
+      const canSeeLive =
+        (profile?.id != null && (profile.id === d.created_by || profile.id === d.owner_id)) ||
+        d.share_permission === 'edit';
+
+      if (!hasPublishedFallback) {
+        out.push({ ...d, list_variant: 'live', list_row_id: `${d.id}:live` });
+        continue;
+      }
+
+      const publishedFallback: Document = {
+        ...d,
+        status: 'published',
+        current_version: d.latest_published_version_number ?? d.current_version,
+        list_variant: 'published_fallback',
+        list_row_id: `${d.id}:published`,
+      };
+
+      if (canSeeLive) {
+        out.push({ ...d, list_variant: 'live', list_row_id: `${d.id}:live` });
+      }
+      out.push(publishedFallback);
+    }
+    return out;
+  }, [documents, profile?.id]);
+
+  const filtered = useMemo(() => applyClientFilters(displayDocuments, filters), [displayDocuments, filters]);
 
   const sorted = useMemo(() => {
     if (!sortBy) return filtered;
@@ -236,7 +269,7 @@ export function DocumentsTable({ processId }: Props = {}) {
         columns={columns}
         rows={pageSlice}
         loading={loading && documents.length === 0}
-        rowKey={(doc) => doc.id}
+        rowKey={(doc) => doc.list_row_id ?? doc.id}
         hiddenColumnIds={hiddenIds}
         onToggleHiddenColumn={toggleHidden}
         sortBy={sortBy}
@@ -250,11 +283,17 @@ export function DocumentsTable({ processId }: Props = {}) {
         filtersActiveCount={filtersActiveCount}
         onClearFilters={clearFilters}
         filtersStorageKey="maya:dms:documents-table"
-        onRowClick={(doc) =>
+        onRowClick={(doc) => {
+          if (doc.list_variant === 'published_fallback' && doc.latest_published_version_id) {
+            navigate(`/documents/${doc.id}?documentVersionId=${encodeURIComponent(doc.latest_published_version_id)}`, {
+              state: { backTo: processId ? `/procesos/${processId}` : '/dashboard', processId },
+            });
+            return;
+          }
           navigate(`/documents/${doc.id}`, {
             state: { backTo: processId ? `/procesos/${processId}` : '/dashboard', processId },
-          })
-        }
+          });
+        }}
         filtersPanel={
           <>
             <FilterField label="Nombre">

--- a/frontend/src/features/documents/components/DocumentsTable.tsx
+++ b/frontend/src/features/documents/components/DocumentsTable.tsx
@@ -167,9 +167,13 @@ export function DocumentsTable({ processId }: Props = {}) {
       const hasPublishedFallback =
         d.status !== 'published' &&
         !!d.latest_published_version_id;
+      const isAssignedReviewer =
+        d.status === 'in_review' &&
+        !!profile?.id;
       const canSeeLive =
         (profile?.id != null && (profile.id === d.created_by || profile.id === d.owner_id)) ||
-        d.share_permission === 'edit';
+        d.share_permission === 'edit' ||
+        isAssignedReviewer;
 
       if (!hasPublishedFallback) {
         out.push({ ...d, list_variant: 'live', list_row_id: `${d.id}:live` });

--- a/frontend/src/features/templates/components/TemplateWizard.tsx
+++ b/frontend/src/features/templates/components/TemplateWizard.tsx
@@ -63,7 +63,12 @@ export function TemplateWizard({ template: templateProp, initialTemplate, proces
     initial?.reviewers?.map((r) => ({ userId: r.user_id, name: r.user_name ?? '—' })) ?? [],
   );
   const [documentValidators, setDocumentValidators] = useState<ValidatorEntry[]>(
-    initial?.document_reviewers?.map((userId) => ({ userId, name: userId })) ?? [],
+    initial?.document_reviewer_users?.length
+      ? initial.document_reviewer_users.map((reviewer) => ({
+          userId: reviewer.user_id,
+          name: reviewer.user_name?.trim() || reviewer.user_id,
+        }))
+      : initial?.document_reviewers?.map((userId) => ({ userId, name: userId })) ?? [],
   );
   const [validationType, setValidationType] = useState<'libre' | 'ordenada'>('libre');
   const [documentValidationType, setDocumentValidationType] = useState<'libre' | 'ordenada'>('libre');

--- a/frontend/src/features/templates/components/TemplateWizard.tsx
+++ b/frontend/src/features/templates/components/TemplateWizard.tsx
@@ -62,7 +62,9 @@ export function TemplateWizard({ template: templateProp, initialTemplate, proces
   const [validators, setValidators] = useState<ValidatorEntry[]>(
     initial?.reviewers?.map((r) => ({ userId: r.user_id, name: r.user_name ?? '—' })) ?? [],
   );
-  const [documentValidators, setDocumentValidators] = useState<ValidatorEntry[]>([]);
+  const [documentValidators, setDocumentValidators] = useState<ValidatorEntry[]>(
+    initial?.document_reviewers?.map((userId) => ({ userId, name: userId })) ?? [],
+  );
   const [validationType, setValidationType] = useState<'libre' | 'ordenada'>('libre');
   const [documentValidationType, setDocumentValidationType] = useState<'libre' | 'ordenada'>('libre');
   // Dirty flag: only sync reviewers to API if the user actually changed them in Step 3

--- a/frontend/src/features/templates/components/TemplatesContent.tsx
+++ b/frontend/src/features/templates/components/TemplatesContent.tsx
@@ -121,7 +121,44 @@ export function TemplatesContent() {
   const showTeamFilter = filterUi.visibility === 'team';
   const showHierarchyFilter = HIERARCHY_VIS.has(filterUi.visibility);
 
+  const displayTemplates = useMemo(() => {
+    const out: Template[] = [];
+    for (const t of templates) {
+      const hasPublishedFallback =
+        t.status !== 'published' &&
+        !!t.latest_published_version_id;
+      const isAssignedReviewer =
+        t.status === 'in_review' &&
+        !!profile?.id &&
+        (t.reviewers?.some((r) => r.user_id === profile.id) ?? false);
+      const canSeeLive = (!!profile?.id && t.created_by === profile.id) || isAssignedReviewer;
+
+      if (!hasPublishedFallback) {
+        out.push({ ...t, list_variant: 'live', list_row_id: `${t.id}:live` });
+        continue;
+      }
+
+      const publishedFallback: Template = {
+        ...t,
+        status: 'published',
+        version: t.latest_published_version_number ?? t.version,
+        list_variant: 'published_fallback',
+        list_row_id: `${t.id}:published`,
+      };
+
+      if (canSeeLive) {
+        out.push({ ...t, list_variant: 'live', list_row_id: `${t.id}:live` });
+      }
+      out.push(publishedFallback);
+    }
+    return out;
+  }, [templates, profile?.id]);
+
   const handleRowClick = (t: Template) => {
+    if (t.list_variant === 'published_fallback' && t.latest_published_version_id) {
+      navigate(`/templates/${t.id}?templateVersionId=${encodeURIComponent(t.latest_published_version_id)}`);
+      return;
+    }
     const isReviewer =
       t.status === 'in_review' && t.reviewers?.some((r) => r.user_id === profile?.id);
     navigate(isReviewer ? `/templates/${t.id}/review` : `/templates/${t.id}`);
@@ -248,9 +285,9 @@ export function TemplatesContent() {
 
       <DataTable<Template>
         columns={columns}
-        rows={templates}
+        rows={displayTemplates}
         loading={loading && templates.length === 0}
-        rowKey={(t) => t.id}
+        rowKey={(t) => t.list_row_id ?? t.id}
         hiddenColumnIds={hiddenIds}
         onToggleHiddenColumn={toggleHidden}
         sortBy={sortBy}

--- a/frontend/src/features/templates/components/TemplatesTable.tsx
+++ b/frontend/src/features/templates/components/TemplatesTable.tsx
@@ -65,11 +65,44 @@ export function TemplatesTable({ processId }: Props = {}) {
   const [authorInput, setAuthorInput] = useState(filters.author_name ?? '');
   const authorDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  const displayTemplates = useMemo(() => {
+    const out: Template[] = [];
+    for (const t of templates) {
+      const hasPublishedFallback =
+        t.status !== 'published' &&
+        !!t.latest_published_version_id;
+      const isAssignedReviewer =
+        t.status === 'in_review' &&
+        !!profile?.id &&
+        (t.reviewers?.some((r) => r.user_id === profile.id) ?? false);
+      const canSeeLive = (!!profile?.id && t.created_by === profile.id) || isAssignedReviewer;
+
+      if (!hasPublishedFallback) {
+        out.push({ ...t, list_variant: 'live', list_row_id: `${t.id}:live` });
+        continue;
+      }
+
+      const publishedFallback: Template = {
+        ...t,
+        status: 'published',
+        version: t.latest_published_version_number ?? t.version,
+        list_variant: 'published_fallback',
+        list_row_id: `${t.id}:published`,
+      };
+
+      if (canSeeLive) {
+        out.push({ ...t, list_variant: 'live', list_row_id: `${t.id}:live` });
+      }
+      out.push(publishedFallback);
+    }
+    return out;
+  }, [templates, profile?.id]);
+
   const filteredTemplates = useMemo(() => {
-    if (!nameFilter) return templates;
+    if (!nameFilter) return displayTemplates;
     const needle = nameFilter.toLowerCase();
-    return templates.filter((t) => (t.name ?? '').toLowerCase().includes(needle));
-  }, [templates, nameFilter]);
+    return displayTemplates.filter((t) => (t.name ?? '').toLowerCase().includes(needle));
+  }, [displayTemplates, nameFilter]);
 
   const filterUi = useMemo(
     () => ({
@@ -125,6 +158,10 @@ export function TemplatesTable({ processId }: Props = {}) {
   };
 
   const handleRowClick = (t: Template) => {
+    if (t.list_variant === 'published_fallback' && t.latest_published_version_id) {
+      navigate(`/templates/${t.id}?templateVersionId=${encodeURIComponent(t.latest_published_version_id)}`);
+      return;
+    }
     const isReviewer =
       t.status === 'in_review' && t.reviewers?.some((r) => r.user_id === profile?.id);
     const backTo = processId ? `/procesos/${processId}` : '/dashboard';
@@ -220,7 +257,7 @@ export function TemplatesTable({ processId }: Props = {}) {
         columns={columns}
         rows={filteredTemplates}
         loading={loading && templates.length === 0}
-        rowKey={(t) => t.id}
+        rowKey={(t) => t.list_row_id ?? t.id}
         hiddenColumnIds={hiddenIds}
         onToggleHiddenColumn={toggleHidden}
         sortBy={sortBy}

--- a/frontend/src/features/templates/components/__tests__/TemplateWizard.test.tsx
+++ b/frontend/src/features/templates/components/__tests__/TemplateWizard.test.tsx
@@ -258,4 +258,5 @@ describe('TemplateWizard Integration', () => {
 
     expect(screen.getByText(/Tienes cambios sin guardar/i)).toBeTruthy();
   });
+
 });

--- a/frontend/src/pages/DocumentPreviewPage.tsx
+++ b/frontend/src/pages/DocumentPreviewPage.tsx
@@ -10,6 +10,7 @@ import {
   approveDocumentReview,
   rejectDocumentReview,
   startDocumentNewVersion,
+  discardDocumentWorkingVersion,
   type DocumentReview,
 } from '../api/documents';
 import { fetchTemplate } from '../api/templates';
@@ -138,6 +139,9 @@ export function DocumentPreviewPage({ mode = 'preview' }: Props = {}) {
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [deleteLoading, setDeleteLoading] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [showDiscardVersionModal, setShowDiscardVersionModal] = useState(false);
+  const [discardVersionLoading, setDiscardVersionLoading] = useState(false);
+  const [discardVersionError, setDiscardVersionError] = useState<string | null>(null);
   const [validationReviewLoading, setValidationReviewLoading] = useState(false);
   const [validationSetupError, setValidationSetupError] = useState<string | null>(null);
   const [actionableReviewId, setActionableReviewId] = useState<string | null>(null);
@@ -282,6 +286,13 @@ export function DocumentPreviewPage({ mode = 'preview' }: Props = {}) {
     publishedDocumentVersionCount !== null && publishedDocumentVersionCount > 0;
   const canStartNewVersion =
     !isValidateMode && isPublished && canMutatePublished && !isHistoricalSnapshot;
+  const canDiscardWorkingVersion =
+    !isValidateMode &&
+    !isHistoricalSnapshot &&
+    (detail?.status === 'draft' || detail?.status === 'in_review') &&
+    canMutatePublished &&
+    !!detail?.latest_published_version_id &&
+    !!detail?.working_version_id;
 
   useEffect(() => {
     if (!isValidateMode) {
@@ -377,6 +388,23 @@ export function DocumentPreviewPage({ mode = 'preview' }: Props = {}) {
     } catch (e) {
       setDeleteError(e instanceof Error ? e.message : 'No se pudo eliminar el documento.');
       setDeleteLoading(false);
+    }
+  };
+
+  const handleDiscardWorkingVersion = async () => {
+    if (!documentId || !detail?.working_version_id) return;
+    setDiscardVersionLoading(true);
+    setDiscardVersionError(null);
+    try {
+      const restored = await discardDocumentWorkingVersion(documentId, detail.working_version_id);
+      setDetail(restored);
+      setVersionSnapshot(null);
+      setShowDiscardVersionModal(false);
+      setActionError(null);
+    } catch (e) {
+      setDiscardVersionError(e instanceof Error ? e.message : 'No se pudo descartar la versión en curso.');
+    } finally {
+      setDiscardVersionLoading(false);
     }
   };
 
@@ -528,6 +556,17 @@ export function DocumentPreviewPage({ mode = 'preview' }: Props = {}) {
           onClick={() => void handleStartNewVersion()}
         >
           Nueva versión
+        </Button>
+      )}
+      {!isValidateMode && canDiscardWorkingVersion && (
+        <Button
+          type="button"
+          variant="outlineWarning"
+          size="sm"
+          loading={discardVersionLoading}
+          onClick={() => setShowDiscardVersionModal(true)}
+        >
+          Descartar nueva versión
         </Button>
       )}
       {isValidateMode && (
@@ -790,6 +829,22 @@ export function DocumentPreviewPage({ mode = 'preview' }: Props = {}) {
         error={deleteError}
         onConfirm={() => void handleDelete()}
         onCancel={() => { setShowDeleteModal(false); setDeleteError(null); }}
+      />
+
+      <ConfirmDialog
+        open={showDiscardVersionModal}
+        variant="danger"
+        title="¿Descartar nueva versión?"
+        description="Se descartarán los cambios en borrador/en revisión y se restaurará la última versión publicada del documento."
+        confirmLabel="Descartar versión"
+        cancelLabel="Cancelar"
+        loading={discardVersionLoading}
+        error={discardVersionError}
+        onConfirm={() => void handleDiscardWorkingVersion()}
+        onCancel={() => {
+          setShowDiscardVersionModal(false);
+          setDiscardVersionError(null);
+        }}
       />
     </>
   );

--- a/frontend/src/pages/DocumentPreviewPage.tsx
+++ b/frontend/src/pages/DocumentPreviewPage.tsx
@@ -10,6 +10,7 @@ import {
   approveDocumentReview,
   rejectDocumentReview,
   startDocumentNewVersion,
+  cloneDocument,
   discardDocumentWorkingVersion,
   type DocumentReview,
 } from '../api/documents';
@@ -286,6 +287,10 @@ export function DocumentPreviewPage({ mode = 'preview' }: Props = {}) {
     publishedDocumentVersionCount !== null && publishedDocumentVersionCount > 0;
   const canStartNewVersion =
     !isValidateMode && isPublished && canMutatePublished && !isHistoricalSnapshot;
+  const canClone =
+    !isValidateMode &&
+    !isHistoricalSnapshot &&
+    detail?.can_clone === true;
   const canDiscardWorkingVersion =
     !isValidateMode &&
     !isHistoricalSnapshot &&
@@ -437,6 +442,20 @@ export function DocumentPreviewPage({ mode = 'preview' }: Props = {}) {
     }
   };
 
+  const handleClone = async () => {
+    if (!documentId) return;
+    setActionLoading(true);
+    setActionError(null);
+    try {
+      const cloned = await cloneDocument(documentId);
+      navigate(`/documents/${cloned.id}/editor`);
+    } catch (e) {
+      setActionError(e instanceof Error ? e.message : 'No se pudo clonar el documento.');
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
   const handleApproveValidation = async () => {
     if (!documentId || !actionableReviewId) {
       setValidationModalError('Faltan datos críticos para procesar la revisión.');
@@ -556,6 +575,17 @@ export function DocumentPreviewPage({ mode = 'preview' }: Props = {}) {
           onClick={() => void handleStartNewVersion()}
         >
           Nueva versión
+        </Button>
+      )}
+      {!isValidateMode && canClone && (
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          loading={actionLoading}
+          onClick={() => void handleClone()}
+        >
+          Clonar
         </Button>
       )}
       {!isValidateMode && canDiscardWorkingVersion && (

--- a/frontend/src/pages/DocumentPreviewPage.tsx
+++ b/frontend/src/pages/DocumentPreviewPage.tsx
@@ -434,7 +434,7 @@ export function DocumentPreviewPage({ mode = 'preview' }: Props = {}) {
     try {
       const data = await startDocumentNewVersion(documentId);
       setDetail(data);
-      navigate(`/documents/${documentId}/editor`);
+      navigate(`/documents/${documentId}/editor`, { state: { step: 'properties' } });
     } catch (e) {
       setActionError(e instanceof Error ? e.message : 'No se pudo abrir una nueva versión.');
     } finally {

--- a/frontend/src/pages/DocumentPreviewPage.tsx
+++ b/frontend/src/pages/DocumentPreviewPage.tsx
@@ -273,7 +273,7 @@ export function DocumentPreviewPage({ mode = 'preview' }: Props = {}) {
       hasPermission('documents.update'));
   const isHistoricalSnapshot = versionSnapshot !== null;
   const showVersionHistory =
-    publishedDocumentVersionCount !== null && publishedDocumentVersionCount > 1;
+    publishedDocumentVersionCount !== null && publishedDocumentVersionCount > 0;
   const canStartNewVersion =
     !isValidateMode && isPublished && canMutatePublished && !isHistoricalSnapshot;
 

--- a/frontend/src/pages/DocumentPreviewPage.tsx
+++ b/frontend/src/pages/DocumentPreviewPage.tsx
@@ -130,6 +130,9 @@ export function DocumentPreviewPage({ mode = 'preview' }: Props = {}) {
     versionNumber: number;
     blocks: DocumentDisplayBlock[];
     title?: string;
+    authorName?: string | null;
+    ownerName?: string | null;
+    createdAt?: string | null;
   } | null>(null);
   const [versionPreviewError, setVersionPreviewError] = useState<string | null>(null);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
@@ -192,6 +195,9 @@ export function DocumentPreviewPage({ mode = 'preview' }: Props = {}) {
               versionNumber: v.version_number,
               blocks,
               title: snapshotDocumentTitle(snap as Record<string, unknown>),
+              authorName: v.author_name ?? null,
+              ownerName: v.owner_name ?? null,
+              createdAt: v.created_at ?? null,
             });
           } catch (ve) {
             if (!cancelled) {
@@ -563,13 +569,13 @@ export function DocumentPreviewPage({ mode = 'preview' }: Props = {}) {
           {' · '}
         </>
       ) : null}
-      {detail.owner_name ?? 'Autor desconocido'}
+      {(versionSnapshot?.ownerName ?? versionSnapshot?.authorName ?? detail.owner_name) ?? 'Autor desconocido'}
       {' · '}
       {detail.visibility_level ? visibilityLabel(detail.visibility_level) : (detail.is_shared_with_me ? 'Compartida' : 'Personal')}
       {' · '}
       Fecha límite: {formatDate(detail.delivery_deadline)}
       {' · '}
-      Última edición: {formatDate(detail.updated_at)}
+      Última edición: {formatDate(versionSnapshot?.createdAt ?? detail.updated_at)}
     </p>
   ) : null;
 

--- a/frontend/src/pages/DocumentPreviewPage.tsx
+++ b/frontend/src/pages/DocumentPreviewPage.tsx
@@ -668,7 +668,7 @@ export function DocumentPreviewPage({ mode = 'preview' }: Props = {}) {
             >
               {!loading && !error && detail ? (
                 <PaperBlocksArticle
-                  title={detail.title}
+                  title={previewTitle}
                   blocks={articleBlocks}
                   emptyMessage="Este documento no tiene bloques."
                 />

--- a/frontend/src/pages/NuevaProgramacionSelectorPage.tsx
+++ b/frontend/src/pages/NuevaProgramacionSelectorPage.tsx
@@ -85,7 +85,7 @@ export function NuevaProgramacionSelectorPage() {
   });
 
   const [filters, setFilters] = useState<TemplateListFilters>({
-    status: 'published',
+    usable_for_documents: true,
     per_page: pageSize,
   });
   const [allTemplates, setAllTemplates] = useState<Template[]>([]);
@@ -120,7 +120,7 @@ export function NuevaProgramacionSelectorPage() {
       setListError(null);
       try {
         const res = await fetchTemplates({
-          status: 'published',
+          usable_for_documents: true,
           visibility_level: filters.visibility_level,
           author_name: filters.author_name,
           delivery_deadline: filters.delivery_deadline,
@@ -193,7 +193,7 @@ export function NuevaProgramacionSelectorPage() {
   }, [pageSize]);
 
   const applyFilters = (patch: Partial<TemplateListFilters>) => {
-    setFilters((f) => ({ ...f, ...patch, status: 'published', page: 1 }));
+    setFilters((f) => ({ ...f, ...patch, usable_for_documents: true, page: 1 }));
   };
 
   const goToPage = (page: number) => {
@@ -212,7 +212,7 @@ export function NuevaProgramacionSelectorPage() {
   const clearFilters = () => {
     if (authorDebounceRef.current) clearTimeout(authorDebounceRef.current);
     setAuthorInput('');
-    setFilters({ status: 'published', per_page: pageSize, page: 1 });
+    setFilters({ usable_for_documents: true, per_page: pageSize, page: 1 });
   };
 
   const filterUi = useMemo(
@@ -263,7 +263,7 @@ export function NuevaProgramacionSelectorPage() {
         onPageSizeChange={setPageSize}
         sortBy={sortBy}
         onSortChange={setSortBy}
-        emptyMessage="No hay plantillas publicadas con los filtros actuales."
+        emptyMessage="No hay plantillas utilizables para crear documentos con los filtros actuales."
         filtersActiveCount={filtersActiveCount}
         onClearFilters={clearFilters}
         filtersStorageKey="maya:dms:nueva-programacion-selector"

--- a/frontend/src/pages/TemplatePreviewPage.tsx
+++ b/frontend/src/pages/TemplatePreviewPage.tsx
@@ -3,6 +3,7 @@ import { useLocation, useNavigate, useParams, useSearchParams } from 'react-rout
 import {
   fetchTemplate,
   fetchTemplateVersionSummaries,
+  type TemplateVersionDetail,
   submitTemplateForReview,
   deleteTemplate,
   cloneTemplate,
@@ -54,6 +55,17 @@ function blockContentNodes(block: TemplateBlock): unknown[] {
 function formatDate(iso: string | null | undefined): string {
   if (!iso) return '—';
   return iso.slice(0, 10);
+}
+
+function isTemplateVisibilityLevel(
+  value: string | null | undefined,
+): value is Template['visibility_level'] {
+  return value === 'global'
+    || value === 'study_type'
+    || value === 'study'
+    || value === 'module'
+    || value === 'team'
+    || value === 'personal';
 }
 
 function mapSnapshotToTemplateBlocks(templateId: string, snapshot: import('../api/templates').TemplateVersionSnapshotBlock[]): TemplateBlock[] {
@@ -116,6 +128,7 @@ export function TemplatePreviewPage() {
   const [deleteLoading, setDeleteLoading] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
   const [processLabel, setProcessLabel] = useState<string | null>(null);
+  const [historicalVersionDetail, setHistoricalVersionDetail] = useState<TemplateVersionDetail | null>(null);
 
   // Review comments (only loaded when owner & has_review_comments)
   const [reviewComments, setReviewComments] = useState<ReviewComment[]>([]);
@@ -156,6 +169,7 @@ export function TemplatePreviewPage() {
         setLoading(true);
         setError(null);
         setSnapshotVersionNumber(null);
+        setHistoricalVersionDetail(null);
         setReviewComments([]);
 
         if (templateVersionId) {
@@ -170,6 +184,7 @@ export function TemplatePreviewPage() {
           const t = tRes.data;
           setTemplate(t);
           setSnapshotVersionNumber(vRes.version_number);
+          setHistoricalVersionDetail(vRes);
           const snap = Array.isArray(vRes.blocks_snapshot) ? vRes.blocks_snapshot : [];
           setBlocks(mapSnapshotToTemplateBlocks(id, snap).sort((a, b) => (a.sort_order ?? 0) - (b.sort_order ?? 0)));
         } else {
@@ -230,12 +245,39 @@ export function TemplatePreviewPage() {
   const isOwner = profile?.id === template?.created_by;
   const isPublished = template?.status === 'published';
   const hasReviewers = (template?.reviewers?.length ?? 0) > 0;
-  const authorDisplay =
-    template?.author_name?.trim() ||
-    (isOwner ? profile?.name?.trim() : '') ||
-    'Autor desconocido';
-
   const viewingPublishedSnapshot = snapshotVersionNumber !== null;
+  const snapshotTemplate = historicalVersionDetail?.template_snapshot ?? null;
+  const snapshotAuthorName = historicalVersionDetail?.author_name?.trim() ?? null;
+  const authorDisplay = viewingPublishedSnapshot
+    ? (snapshotAuthorName && snapshotAuthorName !== ''
+      ? snapshotAuthorName
+      : 'Autor desconocido')
+    : (
+      template?.author_name?.trim() ||
+      (isOwner ? profile?.name?.trim() : '') ||
+      'Autor desconocido'
+    );
+  const displayVisibilityRaw = viewingPublishedSnapshot
+    ? (typeof snapshotTemplate?.visibility_level === 'string'
+      ? snapshotTemplate.visibility_level
+      : template?.visibility_level)
+    : template?.visibility_level;
+  const displayVisibility = isTemplateVisibilityLevel(displayVisibilityRaw) ? displayVisibilityRaw : null;
+  const displayDeadline = viewingPublishedSnapshot
+    ? (typeof snapshotTemplate?.delivery_deadline === 'string' || snapshotTemplate?.delivery_deadline === null
+      ? snapshotTemplate.delivery_deadline
+      : template?.delivery_deadline)
+    : template?.delivery_deadline;
+  const displayUpdatedAt = viewingPublishedSnapshot
+    ? (typeof snapshotTemplate?.updated_at === 'string' || snapshotTemplate?.updated_at === null
+      ? snapshotTemplate.updated_at
+      : historicalVersionDetail?.published_at ?? template?.updated_at)
+    : template?.updated_at;
+  const displayTitle = viewingPublishedSnapshot
+    ? (typeof snapshotTemplate?.name === 'string' && snapshotTemplate.name.trim() !== ''
+      ? snapshotTemplate.name
+      : template?.name)
+    : template?.name;
   const showVersionHistory = publishedVersionCount !== null && publishedVersionCount > 0;
 
   const canEdit = isOwner && isDraft && !viewingPublishedSnapshot;
@@ -437,18 +479,18 @@ export function TemplatePreviewPage() {
       ) : null}
       {authorDisplay}
       {' · '}
-      {visibilityLabel(template.visibility_level)}
+      {displayVisibility ? visibilityLabel(displayVisibility) : '—'}
       {' · '}
-      Fecha límite de validación: {formatDate(template.delivery_deadline)}
+      Fecha límite de validación: {formatDate(displayDeadline)}
       {' · '}
-      Última edición: {formatDate(template.updated_at)}
+      Última edición: {formatDate(displayUpdatedAt)}
     </p>
   ) : null;
 
   return (
     <div className="min-h-full overflow-y-auto">
       <PageTitle
-        title={template?.name ?? 'Plantilla'}
+        title={displayTitle ?? 'Plantilla'}
         subtitle="Previsualización"
         onBack={handleBack}
         backLabel={selectionMode ? 'Seleccionar plantilla' : 'Volver'}

--- a/frontend/src/pages/TemplatePreviewPage.tsx
+++ b/frontend/src/pages/TemplatePreviewPage.tsx
@@ -537,7 +537,7 @@ export function TemplatePreviewPage() {
           {!loading && !error && template && (
             <>
               <h1 className="text-2xl font-bold text-text-primary dark:text-text-dark-primary pb-4 mb-6 border-b border-ui-border dark:border-ui-dark-border">
-                {template.name}
+                {displayTitle ?? template.name}
               </h1>
               {blocks.length === 0 ? (
                 <p className="text-sm text-text-muted dark:text-text-dark-muted italic">

--- a/frontend/src/pages/TemplatePreviewPage.tsx
+++ b/frontend/src/pages/TemplatePreviewPage.tsx
@@ -22,6 +22,7 @@ import { Button, ConfirmDialog, PageTitle, statusBadgeClass } from '@maya/shared
 import { FavoriteButton } from '../components/FavoriteButton';
 import { VersionHistoryPanel } from '../components/VersionHistoryPanel';
 import { useUserProfile } from '../features/user-profile';
+import { useHierarchy } from '../features/hierarchy';
 
 type ReviewComment = {
   id: string;
@@ -128,6 +129,7 @@ export function TemplatePreviewPage() {
   const [deleteLoading, setDeleteLoading] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
   const [processLabel, setProcessLabel] = useState<string | null>(null);
+  const { hierarchy } = useHierarchy();
   const [historicalVersionDetail, setHistoricalVersionDetail] = useState<TemplateVersionDetail | null>(null);
 
   // Review comments (only loaded when owner & has_review_comments)
@@ -480,6 +482,18 @@ export function TemplatePreviewPage() {
       {authorDisplay}
       {' · '}
       {displayVisibility ? visibilityLabel(displayVisibility) : '—'}
+      {displayVisibility === 'study_type' && template.study_type_id ? (
+        <> ({(hierarchy.find((t: any) => String(t.id) === String(template.study_type_id))?.name ?? template.study_type_id)})</>
+      ) : null}
+      {displayVisibility === 'study' && template.study_id ? (
+        <> ({(hierarchy.flatMap((t: any) => t.studies ?? []).find((s: any) => String(s.id) === String(template.study_id))?.name ?? template.study_id)})</>
+      ) : null}
+      {displayVisibility === 'module' && template.module_id ? (
+        <> ({(hierarchy.flatMap((t: any) => t.studies ?? []).flatMap((s: any) => s.course_modules ?? []).find((m: any) => String(m.id) === String(template.module_id))?.name ?? template.module_id)})</>
+      ) : null}
+      {displayVisibility === 'team' && (template.team?.name || template.team_id) ? (
+        <> ({template.team?.name ?? template.team_id})</>
+      ) : null}
       {' · '}
       Fecha límite de validación: {formatDate(displayDeadline)}
       {' · '}

--- a/frontend/src/pages/TemplatePreviewPage.tsx
+++ b/frontend/src/pages/TemplatePreviewPage.tsx
@@ -236,7 +236,7 @@ export function TemplatePreviewPage() {
     'Autor desconocido';
 
   const viewingPublishedSnapshot = snapshotVersionNumber !== null;
-  const showVersionHistory = publishedVersionCount !== null && publishedVersionCount > 1;
+  const showVersionHistory = publishedVersionCount !== null && publishedVersionCount > 0;
 
   const canEdit = isOwner && isDraft && !viewingPublishedSnapshot;
   /** Igual que `TemplatePolicy::delete` (backend): creador o `templates.delete`, cualquier estado. */

--- a/frontend/src/types/documents.ts
+++ b/frontend/src/types/documents.ts
@@ -31,6 +31,7 @@ export type Document = {
   share_permission?: string | null;
   team?: unknown;
   has_review_comments?: boolean;
+  can_clone?: boolean;
   working_version_id?: string | null;
   latest_published_version_id?: string | null;
   latest_published_version_number?: number | null;

--- a/frontend/src/types/documents.ts
+++ b/frontend/src/types/documents.ts
@@ -31,6 +31,10 @@ export type Document = {
   share_permission?: string | null;
   team?: unknown;
   has_review_comments?: boolean;
+  latest_published_version_id?: string | null;
+  latest_published_version_number?: number | null;
+  list_variant?: 'live' | 'published_fallback';
+  list_row_id?: string;
 };
 
 /**

--- a/frontend/src/types/documents.ts
+++ b/frontend/src/types/documents.ts
@@ -31,6 +31,7 @@ export type Document = {
   share_permission?: string | null;
   team?: unknown;
   has_review_comments?: boolean;
+  working_version_id?: string | null;
   latest_published_version_id?: string | null;
   latest_published_version_number?: number | null;
   list_variant?: 'live' | 'published_fallback';

--- a/frontend/src/types/documents.ts
+++ b/frontend/src/types/documents.ts
@@ -13,6 +13,7 @@ export type Document = {
   study_type_id: string | null;
   study_id: string | null;
   module_id: string | null;
+  team_id: string | null;
   delivery_deadline?: string | null;
   created_by: string;
   owner_id: string;

--- a/frontend/src/types/templates.ts
+++ b/frontend/src/types/templates.ts
@@ -29,6 +29,12 @@ export type Template = {
   module_id: string | null;
   team_id: string | null;
   process_id: string | null;
+  team?: {
+    id: string;
+    name: string;
+    is_department: boolean;
+    description?: string | null;
+  } | null;
   created_by: string;
   author_name?: string | null;
   status: TemplateStatus;

--- a/frontend/src/types/templates.ts
+++ b/frontend/src/types/templates.ts
@@ -44,6 +44,10 @@ export type Template = {
   reviewers?: TemplateReviewer[];
   document_reviewers?: string[];
   has_review_comments?: boolean;
+  latest_published_version_id?: string | null;
+  latest_published_version_number?: number | null;
+  list_variant?: 'live' | 'published_fallback';
+  list_row_id?: string;
   /** Alineado con `TemplatePolicy::clone` en el servidor. */
   can_clone?: boolean;
   created_at?: string;
@@ -66,6 +70,7 @@ export type TemplatesListResponse = {
 export type TemplateListFilters = {
   visibility_level?: string;
   status?: string;
+  usable_for_documents?: boolean;
   study_type_id?: string;
   study_id?: string;
   module_id?: string;

--- a/frontend/src/types/templates.ts
+++ b/frontend/src/types/templates.ts
@@ -18,6 +18,11 @@ export type TemplateReviewer = {
   status?: 'pending' | 'approved' | 'rejected';
 };
 
+export type TemplateDocumentReviewerUser = {
+  user_id: string;
+  user_name?: string | null;
+};
+
 export type Template = {
   id: string;
   name: string;
@@ -43,6 +48,7 @@ export type Template = {
   review_mode: ReviewMode;
   reviewers?: TemplateReviewer[];
   document_reviewers?: string[];
+  document_reviewer_users?: TemplateDocumentReviewerUser[];
   has_review_comments?: boolean;
   latest_published_version_id?: string | null;
   latest_published_version_number?: number | null;


### PR DESCRIPTION
- Se consolidó el modelo de versionado para que la última versión publicada siga visible y usable aunque exista una live en draft/in_review.
- Se implementó descarte de versión en curso sin borrar la entidad:
       - DELETE /templates/{template}/versions/{versionId}
       - DELETE /documents/{document}/versions/{versionId}
- Se restaura correctamente el estado publicado al descartar:
        - metadatos (head snapshot),
        - bloques (documentos),
        - revisores/validadores asociados (plantillas),
        - limpieza de revisiones activas cuando aplica.
- Se corrigieron múltiples desalineaciones front/back en vistas de proceso y previsualización:
        - fallback publicado en tablas/listados,
        - navegación a versión histórica,
        - nueva versión en documentos abre en Propiedades (paridad con plantillas),
        - botón Clonar en preview de documentos con permiso real (can_clone).
- Se corrigió representación de validadores de documento en wizard de plantillas:
         - mostrar nombre en lugar de UUID cuando está disponible.
- Se eliminó un process_id hardcodeado en creación de documentos desde módulo y se usa el proceso real de la opción seleccionada.
- Se redujo sobrecarga en listados de documentos evitando evaluación de policy por fila en index para can_clone.
- Se añadieron/ajustaron pruebas para cubrir:
       - coexistencia live/publicada,
       - descarte de versión en templates/documents,
       - regresiones de visibilidad y flujo.