### PR TITLE
Feature/refactor filtros plantillas documentos

### DIFF
--- a/backend/app/DTOs/Templates/FilterTemplatesDto.php
+++ b/backend/app/DTOs/Templates/FilterTemplatesDto.php
@@ -17,6 +17,8 @@ readonly class FilterTemplatesDto
         public ?string $teamId = null,
         public ?string $authorName = null,
         public ?string $deliveryDeadline = null,
+        /** Fecha calendario (Y-m-d): última publicación (`max(published_at)`) en ese día o posterior. */
+        public ?string $publishedOn = null,
         public ?string $processId = null,
     ) {}
 }

--- a/backend/app/DTOs/Templates/FilterTemplatesDto.php
+++ b/backend/app/DTOs/Templates/FilterTemplatesDto.php
@@ -16,6 +16,7 @@ readonly class FilterTemplatesDto
         public ?string $moduleId = null,
         public ?string $teamId = null,
         public ?string $authorName = null,
+        /** Fecha calendario (Y-m-d): cabezal con `delivery_deadline` en esa fecha o anterior (inclusive). */
         public ?string $deliveryDeadline = null,
         /** Fecha calendario (Y-m-d): última publicación (`max(published_at)`) en ese día o posterior. */
         public ?string $publishedOn = null,

--- a/backend/app/Http/Controllers/Api/TemplateController.php
+++ b/backend/app/Http/Controllers/Api/TemplateController.php
@@ -24,7 +24,6 @@ use Illuminate\Http\Resources\Json\ResourceCollection;
 use Illuminate\Http\Response;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Gate;
 
 /**
@@ -47,7 +46,6 @@ class TemplateController extends Controller
     public function index(IndexTemplateRequest $request): AnonymousResourceCollection
     {
         $templates = $this->templateService->listFiltered($request->toFilterDto());
-        $this->attachLatestPublishedVersionMeta($templates);
         $this->attachCanCloneMeta($templates, $request);
 
         $this->apiTeamEmbedService->embedOnTemplates(
@@ -82,73 +80,6 @@ class TemplateController extends Controller
         foreach ($templates as $template) {
             $attach($template);
         }
-    }
-
-    /**
-     * Adjunta metadatos de última versión publicada por plantilla para construir vistas fallback.
-     *
-     * @param  \Illuminate\Support\Collection<int, Template>  $templates
-     */
-    private function attachLatestPublishedVersionMeta(\Illuminate\Support\Collection $templates): void
-    {
-        if ($templates->isEmpty()) {
-            return;
-        }
-
-        $ids = $templates->pluck('id')->filter(fn ($id) => is_string($id) && $id !== '')->values()->all();
-        if ($ids === []) {
-            return;
-        }
-
-        $rows = DB::table('entity_versions')
-            ->where('versionable_type', Template::class)
-            ->whereIn('versionable_id', $ids)
-            ->where('status', 'published')
-            ->where('version_number', '>', 0)
-            ->orderByDesc('version_number')
-            ->get(['versionable_id', 'id', 'version_number', 'snapshot_data']);
-
-        /** @var array<string, object{versionable_id:string,id:string,version_number:int}> $latestByTemplate */
-        $latestByTemplate = [];
-        foreach ($rows as $row) {
-            $templateId = (string) $row->versionable_id;
-            if (! isset($latestByTemplate[$templateId])) {
-                $latestByTemplate[$templateId] = (object) [
-                    'versionable_id' => $templateId,
-                    'id' => (string) $row->id,
-                    'version_number' => (int) $row->version_number,
-                    'name' => $this->extractPublishedTemplateNameFromSnapshotRow($row->snapshot_data),
-                ];
-            }
-        }
-
-        foreach ($templates as $template) {
-            $meta = $latestByTemplate[(string) $template->id] ?? null;
-            $template->setAttribute('latest_published_version_id', $meta?->id);
-            $template->setAttribute('latest_published_version_number', $meta?->version_number);
-            $template->setAttribute('latest_published_name', $meta?->name);
-        }
-    }
-
-    private function extractPublishedTemplateNameFromSnapshotRow(mixed $snapshot): ?string
-    {
-        if (is_string($snapshot) && $snapshot !== '') {
-            $decoded = json_decode($snapshot, true);
-            if (is_array($decoded)) {
-                $snapshot = $decoded;
-            }
-        }
-
-        if (! is_array($snapshot)) {
-            return null;
-        }
-
-        $name = data_get($snapshot, 'template.name');
-        if (! is_string($name) || trim($name) === '') {
-            return null;
-        }
-
-        return $name;
     }
 
     /**

--- a/backend/app/Http/Requests/Templates/IndexTemplateRequest.php
+++ b/backend/app/Http/Requests/Templates/IndexTemplateRequest.php
@@ -38,6 +38,7 @@ class IndexTemplateRequest extends FormRequest
             'team_id'          => ['sometimes', 'nullable', 'uuid', 'exists:teams,id'],
             'author_name'      => ['sometimes', 'nullable', 'string', 'max:255'],
             'delivery_deadline' => ['sometimes', 'nullable', 'date'],
+            'published_on'     => ['sometimes', 'nullable', 'date'],
             'process_id'       => ['sometimes', 'nullable', 'uuid', 'exists:processes,id'],
         ];
     }
@@ -59,6 +60,7 @@ class IndexTemplateRequest extends FormRequest
             teamId: $v['team_id'] ?? null,
             authorName: $v['author_name'] ?? null,
             deliveryDeadline: $v['delivery_deadline'] ?? null,
+            publishedOn: $v['published_on'] ?? null,
             processId: $v['process_id'] ?? null,
         );
     }

--- a/backend/app/Http/Resources/TemplateResource.php
+++ b/backend/app/Http/Resources/TemplateResource.php
@@ -5,6 +5,7 @@ namespace App\Http\Resources;
 use App\Support\ApiEmbeddedTeamResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Carbon;
 
 class TemplateResource extends JsonResource
 {
@@ -63,6 +64,26 @@ class TemplateResource extends JsonResource
             'can_clone' => (bool) ($this->resource->getAttribute('can_clone') ?? false),
             'working_version_id' => $this->head_entity_version_id,
             'latest_published_name' => $this->resource->getAttribute('latest_published_name'),
+            'latest_published_at' => $this->formatOptionalIso($this->resource->getAttribute('latest_published_at')),
         ];
+    }
+
+    private function formatOptionalIso(mixed $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+        if ($value instanceof Carbon) {
+            return $value->toIso8601String();
+        }
+        if (is_string($value) && $value !== '') {
+            try {
+                return Carbon::parse($value)->toIso8601String();
+            } catch (\Throwable) {
+                return null;
+            }
+        }
+
+        return null;
     }
 }

--- a/backend/app/Repositories/Contracts/TemplateRepositoryInterface.php
+++ b/backend/app/Repositories/Contracts/TemplateRepositoryInterface.php
@@ -38,6 +38,13 @@ interface TemplateRepositoryInterface
     public function listFiltered(FilterTemplatesDto $filters): Collection;
 
     /**
+     * Rellena en memoria `latest_published_*` desde `entity_versions` (última versión publicada por plantilla).
+     *
+     * @param  Collection<int, Template>  $templates
+     */
+    public function attachLatestPublishedVersionMeta(Collection $templates): void;
+
+    /**
      * Crea una plantilla con los atributos dados.
      *
      * @param  array<string, mixed>  $attributes

--- a/backend/app/Repositories/Eloquent/TemplateRepository.php
+++ b/backend/app/Repositories/Eloquent/TemplateRepository.php
@@ -6,6 +6,7 @@ use App\DTOs\Templates\FilterTemplatesDto;
 use App\Models\Template;
 use App\Models\TemplateBlock;
 use App\Repositories\Contracts\TemplateRepositoryInterface;
+use App\Support\SearchAccentFold;
 use App\Support\TemplateHeadSnapshot;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Support\Collection;
@@ -108,8 +109,13 @@ class TemplateRepository implements TemplateRepositoryInterface
         if ($filters->teamId !== null) {
             $query->where('template_head_ev.snapshot_data->template->team_id', $filters->teamId);
         }
-        if ($filters->authorName !== null) {
-            $query->where('users.name', 'ilike', '%'.$filters->authorName.'%');
+        if ($filters->authorName !== null && trim($filters->authorName) !== '') {
+            $needle = SearchAccentFold::fold($filters->authorName);
+            if ($needle !== '') {
+                [$expr, $tr] = SearchAccentFold::sqlFoldedLowerColumn('users.name');
+                $like = '%'.SearchAccentFold::escapeLike($needle).'%';
+                $query->whereRaw("{$expr} LIKE ?", [$tr[0], $tr[1], $like]);
+            }
         }
         if ($filters->deliveryDeadline !== null) {
             $deadlineExpr = TemplateHeadSnapshot::jsonTemplateFieldExpression('template_head_ev', 'delivery_deadline');

--- a/backend/app/Repositories/Eloquent/TemplateRepository.php
+++ b/backend/app/Repositories/Eloquent/TemplateRepository.php
@@ -117,6 +117,12 @@ class TemplateRepository implements TemplateRepositoryInterface
                 $filters->deliveryDeadline,
             );
         }
+        if ($filters->publishedOn !== null) {
+            $query->whereRaw(
+                '(select max(published_at)::date from entity_versions where versionable_id = templates.id and versionable_type = ? and status = ? and version_number > 0) >= ?::date',
+                [Template::class, 'published', $filters->publishedOn],
+            );
+        }
         if ($filters->processId !== null) {
             $query->where('templates.process_id', $filters->processId);
         }
@@ -133,6 +139,81 @@ class TemplateRepository implements TemplateRepositoryInterface
             ->get();
 
         return $rows;
+    }
+
+    /**
+     * Rellena en memoria `latest_published_*` desde `entity_versions` (última versión publicada por plantilla).
+     *
+     * @param  Collection<int, Template>  $templates
+     * {@inheritDoc}
+     */
+    public function attachLatestPublishedVersionMeta(Collection $templates): void
+    {
+        if ($templates->isEmpty()) {
+            return;
+        }
+
+        $ids = $templates->pluck('id')->filter(fn ($id) => is_string($id) && $id !== '')->values()->all();
+        if ($ids === []) {
+            return;
+        }
+
+        $placeholders = implode(',', array_fill(0, count($ids), '?'));
+        $bindings = array_merge([Template::class], $ids);
+        $sql = '
+            SELECT DISTINCT ON (versionable_id)
+                versionable_id::text AS versionable_id,
+                id::text AS id,
+                version_number,
+                snapshot_data,
+                published_at
+            FROM entity_versions
+            WHERE versionable_type = ?
+              AND versionable_id IN ('.$placeholders.')
+              AND status = \'published\'
+              AND version_number > 0
+            ORDER BY versionable_id, version_number DESC
+        ';
+
+        $rows = DB::select($sql, $bindings);
+
+        /** @var array<string, object> $latestByTemplate */
+        $latestByTemplate = [];
+        foreach ($rows as $row) {
+            $templateId = (string) $row->versionable_id;
+            $latestByTemplate[$templateId] = $row;
+        }
+
+        foreach ($templates as $template) {
+            $meta = $latestByTemplate[(string) $template->id] ?? null;
+            $template->setAttribute('latest_published_version_id', $meta !== null ? (string) $meta->id : null);
+            $template->setAttribute('latest_published_version_number', $meta !== null ? (int) $meta->version_number : null);
+            $template->setAttribute('latest_published_name', $meta !== null
+                ? $this->extractPublishedTemplateNameFromSnapshotRow($meta->snapshot_data)
+                : null);
+            $template->setAttribute('latest_published_at', $meta->published_at ?? null);
+        }
+    }
+
+    private function extractPublishedTemplateNameFromSnapshotRow(mixed $snapshot): ?string
+    {
+        if (is_string($snapshot) && $snapshot !== '') {
+            $decoded = json_decode($snapshot, true);
+            if (is_array($decoded)) {
+                $snapshot = $decoded;
+            }
+        }
+
+        if (! is_array($snapshot)) {
+            return null;
+        }
+
+        $name = data_get($snapshot, 'template.name');
+        if (! is_string($name) || trim($name) === '') {
+            return null;
+        }
+
+        return $name;
     }
 
     /**

--- a/backend/app/Repositories/Eloquent/TemplateRepository.php
+++ b/backend/app/Repositories/Eloquent/TemplateRepository.php
@@ -166,19 +166,33 @@ class TemplateRepository implements TemplateRepositoryInterface
 
         $placeholders = implode(',', array_fill(0, count($ids), '?'));
         $bindings = array_merge([Template::class], $ids);
+        // ROW_NUMBER + CAST: portable entre PostgreSQL (prod) y SQLite (:memory: en tests).
+        // Evita DISTINCT ON y ::text, solo soportados en PG.
         $sql = '
-            SELECT DISTINCT ON (versionable_id)
-                versionable_id::text AS versionable_id,
-                id::text AS id,
+            SELECT
+                CAST(versionable_id AS TEXT) AS versionable_id,
+                CAST(id AS TEXT) AS id,
                 version_number,
                 snapshot_data,
                 published_at
-            FROM entity_versions
-            WHERE versionable_type = ?
-              AND versionable_id IN ('.$placeholders.')
-              AND status = \'published\'
-              AND version_number > 0
-            ORDER BY versionable_id, version_number DESC
+            FROM (
+                SELECT
+                    versionable_id,
+                    id,
+                    version_number,
+                    snapshot_data,
+                    published_at,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY versionable_id
+                        ORDER BY version_number DESC
+                    ) AS rn
+                FROM entity_versions
+                WHERE versionable_type = ?
+                  AND versionable_id IN ('.$placeholders.')
+                  AND status = \'published\'
+                  AND version_number > 0
+            ) AS ranked
+            WHERE ranked.rn = 1
         ';
 
         $rows = DB::select($sql, $bindings);

--- a/backend/app/Repositories/Eloquent/TemplateRepository.php
+++ b/backend/app/Repositories/Eloquent/TemplateRepository.php
@@ -112,10 +112,16 @@ class TemplateRepository implements TemplateRepositoryInterface
             $query->where('users.name', 'ilike', '%'.$filters->authorName.'%');
         }
         if ($filters->deliveryDeadline !== null) {
-            $query->whereDate(
-                DB::raw(TemplateHeadSnapshot::jsonTemplateFieldExpression('template_head_ev', 'delivery_deadline')),
-                $filters->deliveryDeadline,
+            $deadlineExpr = TemplateHeadSnapshot::jsonTemplateFieldExpression('template_head_ev', 'delivery_deadline');
+            $statusExpr = TemplateHeadSnapshot::jsonTemplateFieldExpression('template_head_ev', 'status');
+            $cap = $filters->deliveryDeadline;
+            // Comparación por prefijo Y-m-d (ISO) para sqlite/mysql/pgsql sin depender de casts de fecha por motor.
+            $query->whereRaw(
+                "nullif(trim({$deadlineExpr}), '') is not null and substr(trim({$deadlineExpr}), 1, 10) <= ?",
+                [$cap],
             );
+            // No mezclar publicadas: el plazo de validación no se muestra en UI para ese estado.
+            $query->whereRaw("trim({$statusExpr}) <> ?", ['published']);
         }
         if ($filters->publishedOn !== null) {
             $query->whereRaw(

--- a/backend/app/Repositories/Eloquent/TemplateRepository.php
+++ b/backend/app/Repositories/Eloquent/TemplateRepository.php
@@ -109,7 +109,7 @@ class TemplateRepository implements TemplateRepositoryInterface
             $query->where('template_head_ev.snapshot_data->template->team_id', $filters->teamId);
         }
         if ($filters->authorName !== null) {
-            $query->where('users.name', 'like', '%'.$filters->authorName.'%');
+            $query->where('users.name', 'ilike', '%'.$filters->authorName.'%');
         }
         if ($filters->deliveryDeadline !== null) {
             $query->whereDate(

--- a/backend/app/Services/TemplateService.php
+++ b/backend/app/Services/TemplateService.php
@@ -133,10 +133,14 @@ class TemplateService implements TemplateServiceInterface
 
     /**
      * Listado con filtros (sin paginación en servidor; el front pagina en cliente).
+     * Enriquece cada plantilla con metadatos de la última versión publicada para el API.
      */
     public function listFiltered(FilterTemplatesDto $filters): Collection
     {
-        return $this->templateRepository->listFiltered($filters);
+        $templates = $this->templateRepository->listFiltered($filters);
+        $this->templateRepository->attachLatestPublishedVersionMeta($templates);
+
+        return $templates;
     }
 
     /**

--- a/backend/app/Support/SearchAccentFold.php
+++ b/backend/app/Support/SearchAccentFold.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+/**
+ * Plegado de acentos alineado entre PHP y SQL (translate + replace) para LIKE
+ * en PostgreSQL (prod) y SQLite (tests).
+ */
+final class SearchAccentFold
+{
+    /**
+     * Map de caracteres UTF-8 (tras mb_strtolower) → caracteres base (translate 1:1).
+     * 
+     * @return array<string, string> un carácter (tras mb_strtolower) → un carácter base (translate 1:1)
+     */
+    private static function translateCharMap(): array
+    {
+        static $map = null;
+
+        if ($map !== null) {
+            return $map;
+        }
+
+        $pairs = [
+            ['á', 'a'], ['à', 'a'], ['â', 'a'], ['ã', 'a'], ['ä', 'a'], ['å', 'a'], ['ā', 'a'], ['ă', 'a'],
+            ['ą', 'a'], ['ǎ', 'a'], ['ǟ', 'a'], ['ǡ', 'a'], ['ǻ', 'a'],
+            ['é', 'e'], ['è', 'e'], ['ê', 'e'], ['ë', 'e'], ['ē', 'e'], ['ė', 'e'], ['ę', 'e'], ['ě', 'e'],
+            ['í', 'i'], ['ì', 'i'], ['î', 'i'], ['ï', 'i'], ['ī', 'i'], ['į', 'i'], ['ǐ', 'i'],
+            ['ó', 'o'], ['ò', 'o'], ['ô', 'o'], ['õ', 'o'], ['ö', 'o'], ['ō', 'o'], ['ő', 'o'], ['ǒ', 'o'],
+            ['ǫ', 'o'], ['ǭ', 'o'],
+            ['ú', 'u'], ['ù', 'u'], ['û', 'u'], ['ü', 'u'], ['ū', 'u'], ['ů', 'u'], ['ű', 'u'], ['ǔ', 'u'],
+            ['ǖ', 'u'], ['ǘ', 'u'], ['ǚ', 'u'], ['ǜ', 'u'],
+            ['ñ', 'n'], ['ń', 'n'], ['ň', 'n'], ['ņ', 'n'],
+            ['ç', 'c'], ['ć', 'c'], ['č', 'c'], ['ĉ', 'c'], ['ċ', 'c'],
+            ['ý', 'y'], ['ÿ', 'y'], ['ỳ', 'y'], ['ŷ', 'y'], ['ȳ', 'y'],
+            ['ß', 's'],
+            ['ł', 'l'], ['ľ', 'l'], ['ļ', 'l'], ['ŀ', 'l'],
+            ['đ', 'd'], ['ď', 'd'],
+            ['ř', 'r'], ['ŕ', 'r'], ['ŗ', 'r'],
+            ['ś', 's'], ['š', 's'], ['ş', 's'], ['ș', 's'],
+            ['ź', 'z'], ['ž', 'z'], ['ż', 'z'],
+            ['ğ', 'g'], ['ǧ', 'g'], ['ģ', 'g'],
+            ['ķ', 'k'],
+        ];
+
+        $map = [];
+        foreach ($pairs as [$from, $to]) {
+            if (mb_strlen($from, 'UTF-8') !== 1 || mb_strlen($to, 'UTF-8') !== 1) {
+                continue;
+            }
+            if (! isset($map[$from])) {
+                $map[$from] = $to;
+            }
+        }
+
+        return $map;
+    }
+
+    /**
+     * Plegado de acentos: œ/æ → oe/ae y caracteres UTF-8 (tras mb_strtolower) → caracteres base (translate 1:1).
+     * 
+     * @param string $value el valor a plegar
+     * @return string el valor plegado
+     */
+    public static function fold(string $value): string
+    {
+        $s = mb_strtolower(trim($value), 'UTF-8');
+        $s = str_replace(['ß', 'ẞ'], 'ss', $s);
+        $s = strtr($s, ['œ' => 'oe', 'æ' => 'ae']);
+        $s = strtr($s, self::translateCharMap());
+
+        return $s;
+    }
+
+    /**
+     * Argumentos para translate(from, to) — solo pares 1:1.
+     * 
+     * @return array{0: string, 1: string} argumentos para translate(from, to) — solo pares 1:1
+     */
+    public static function sqlTranslatePair(): array
+    {
+        $m = self::translateCharMap();
+        ksort($m, SORT_STRING);
+        $from = '';
+        $to = '';
+        foreach ($m as $f => $t) {
+            $from .= $f;
+            $to .= $t;
+        }
+
+        return [$from, $to];
+    }
+
+    /**
+     * Expresión SQL: columna en minúsculas, sin acentos (aprox.) y œ/æ → oe/ae.
+     *
+     * @return array{0: string, 1: list<string>} SQL y bindings [from, to] del translate
+     */
+    public static function sqlFoldedLowerColumn(string $columnSql): array
+    {
+        [$from, $to] = self::sqlTranslatePair();
+        $expr = "translate(lower({$columnSql}), ?, ?)";
+        $expr = "replace(replace(replace(replace({$expr}, 'œ', 'oe'), 'æ', 'ae'), 'ß', 'ss'), 'ẞ', 'ss')";
+
+        return [$expr, [$from, $to]];
+    }
+
+    /**
+     * Escapar comodines para LIKE.
+     * 
+     * @param string $value el valor a escapar
+     * @return string el valor escapado
+     */
+    public static function escapeLike(string $value): string
+    {
+        return addcslashes($value, '%_\\');
+    }
+}

--- a/backend/tests/Feature/AcademicHierarchyApiTest.php
+++ b/backend/tests/Feature/AcademicHierarchyApiTest.php
@@ -5,7 +5,6 @@ namespace Tests\Feature;
 use App\Repositories\Contracts\AcademicHierarchyRepositoryInterface;
 use App\Services\Contracts\UserProfileServiceInterface;
 use Illuminate\Support\Facades\Cache;
-use Lcobucci\JWT\Signer\Key\InMemory;
 use Maya\Auth\Contracts\JwksServiceInterface;
 use Tests\Concerns\BuildsTestJwt;
 use Tests\TestCase;
@@ -39,7 +38,7 @@ class AcademicHierarchyApiTest extends TestCase
 
         $this->mock(JwksServiceInterface::class)
             ->shouldReceive('getPublicKey')
-            ->andReturn(InMemory::plainText($publicPem));
+            ->andReturn($publicPem);
 
         $token = $this->buildJwtForSub(
             $privatePem,

--- a/backend/tests/Feature/DashboardApiTest.php
+++ b/backend/tests/Feature/DashboardApiTest.php
@@ -12,7 +12,6 @@ use Database\Seeders\UsersSourceSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Str;
-use Lcobucci\JWT\Signer\Key\InMemory;
 use Maya\Auth\Contracts\JwksServiceInterface;
 use Tests\Concerns\AssignsTestUserPermissions;
 use Tests\Concerns\BuildsTestJwt;
@@ -83,7 +82,7 @@ class DashboardApiTest extends TestCase
  
         $this->mock(JwksServiceInterface::class)
             ->shouldReceive('getPublicKey')
-            ->andReturn(InMemory::plainText($publicPem));
+            ->andReturn($publicPem);
  
         $token = $this->buildJwtForSub(
             $privatePem,

--- a/backend/tests/Feature/DocumentModifiableBlockVersionApiTest.php
+++ b/backend/tests/Feature/DocumentModifiableBlockVersionApiTest.php
@@ -17,7 +17,6 @@ use Database\Seeders\UsersSourceSeeder;
 use Maya\Auth\Contracts\JwksServiceInterface;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Str;
-use Lcobucci\JWT\Signer\Key\InMemory;
 use Tests\Concerns\AssignsTestUserPermissions;
 use Tests\Concerns\BuildsTestJwt;
 use Tests\Concerns\SeedsTemplatePublicationAnchor;
@@ -59,7 +58,7 @@ class DocumentModifiableBlockVersionApiTest extends TestCase
 
         $this->mock(JwksServiceInterface::class)
             ->shouldReceive('getPublicKey')
-            ->andReturn(InMemory::plainText($publicPem));
+            ->andReturn($publicPem);
 
         $token = $this->buildJwtForSub(
             $privatePem,

--- a/backend/tests/Feature/DocumentReviewModeFlowTest.php
+++ b/backend/tests/Feature/DocumentReviewModeFlowTest.php
@@ -14,7 +14,6 @@ use Maya\Auth\Contracts\JwksServiceInterface;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
-use Lcobucci\JWT\Signer\Key\InMemory;
 use Maya\Messaging\Publishers\AuditPublisher;
 use Database\Seeders\PermissionsSeeder;
 use Tests\Concerns\AssignsTestUserPermissions;
@@ -226,7 +225,7 @@ class DocumentReviewModeFlowTest extends TestCase
 
         $this->mock(JwksServiceInterface::class)
             ->shouldReceive('getPublicKey')
-            ->andReturn(InMemory::plainText($pub));
+            ->andReturn($pub);
 
         $hOwner = $this->bearerFor($ctx['ownerId'], $priv, $pub, 'own');
         $hR1 = $this->bearerFor($ctx['rev1'], $priv, $pub, 'r1', ['documents.review']);
@@ -312,7 +311,7 @@ class DocumentReviewModeFlowTest extends TestCase
         [$priv, $pub] = $this->generateRsaKeyPairForTests();
         $this->mock(JwksServiceInterface::class)
             ->shouldReceive('getPublicKey')
-            ->andReturn(InMemory::plainText($pub));
+            ->andReturn($pub);
 
         $headersReviewer = $this->bearerFor(
             $reviewerId,
@@ -335,7 +334,7 @@ class DocumentReviewModeFlowTest extends TestCase
 
         $this->mock(JwksServiceInterface::class)
             ->shouldReceive('getPublicKey')
-            ->andReturn(InMemory::plainText($pub));
+            ->andReturn($pub);
 
         $hOwner = $this->bearerFor($ctx['ownerId'], $priv, $pub, 'own');
         $hR1 = $this->bearerFor($ctx['rev1'], $priv, $pub, 'r1', ['documents.review']);
@@ -363,7 +362,7 @@ class DocumentReviewModeFlowTest extends TestCase
 
         $this->mock(JwksServiceInterface::class)
             ->shouldReceive('getPublicKey')
-            ->andReturn(InMemory::plainText($pub));
+            ->andReturn($pub);
 
         $templateHead = EntityVersion::query()
             ->where('versionable_type', Template::class)
@@ -402,7 +401,7 @@ class DocumentReviewModeFlowTest extends TestCase
 
         $this->mock(JwksServiceInterface::class)
             ->shouldReceive('getPublicKey')
-            ->andReturn(InMemory::plainText($pub));
+            ->andReturn($pub);
 
         $hOwner = $this->bearerFor($ctx['ownerId'], $priv, $pub, 'own');
         $hR1 = $this->bearerFor($ctx['rev1'], $priv, $pub, 'r1', ['documents.review']);
@@ -429,7 +428,7 @@ class DocumentReviewModeFlowTest extends TestCase
 
         $this->mock(JwksServiceInterface::class)
             ->shouldReceive('getPublicKey')
-            ->andReturn(InMemory::plainText($pub));
+            ->andReturn($pub);
 
         $hOwner = $this->bearerFor($ctx['ownerId'], $priv, $pub, 'own');
         $hR1 = $this->bearerFor($ctx['rev1'], $priv, $pub, 'r1', ['documents.review']);
@@ -464,7 +463,7 @@ class DocumentReviewModeFlowTest extends TestCase
 
         $this->mock(JwksServiceInterface::class)
             ->shouldReceive('getPublicKey')
-            ->andReturn(InMemory::plainText($pub));
+            ->andReturn($pub);
 
         $hOwner = $this->bearerFor($ctx['ownerId'], $priv, $pub, 'own');
         $hR1 = $this->bearerFor($ctx['rev1'], $priv, $pub, 'r1', ['documents.review']);
@@ -503,7 +502,7 @@ class DocumentReviewModeFlowTest extends TestCase
 
         $this->mock(JwksServiceInterface::class)
             ->shouldReceive('getPublicKey')
-            ->andReturn(InMemory::plainText($pub));
+            ->andReturn($pub);
 
         $hOwner = $this->bearerFor($ctx['ownerId'], $priv, $pub, 'own');
         $hR2 = $this->bearerFor($ctx['rev2'], $priv, $pub, 'r2', ['documents.review']);
@@ -556,7 +555,7 @@ class DocumentReviewModeFlowTest extends TestCase
 
         $this->mock(JwksServiceInterface::class)
             ->shouldReceive('getPublicKey')
-            ->andReturn(InMemory::plainText($pub));
+            ->andReturn($pub);
 
         $hOwner = $this->bearerFor($ctx['ownerId'], $priv, $pub, 'own');
         $hR1 = $this->bearerFor($ctx['rev1'], $priv, $pub, 'r1', ['documents.review']);

--- a/backend/tests/Feature/DocumentShareApiTest.php
+++ b/backend/tests/Feature/DocumentShareApiTest.php
@@ -17,7 +17,6 @@ use Database\Seeders\UsersSourceSeeder;
 use Maya\Auth\Contracts\JwksServiceInterface;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Str;
-use Lcobucci\JWT\Signer\Key\InMemory;
 use Tests\Concerns\AssignsTestUserPermissions;
 use Tests\Concerns\BuildsTestJwt;
 use Tests\Concerns\SeedsTemplatePublicationAnchor;
@@ -70,7 +69,7 @@ class DocumentShareApiTest extends TestCase
 
         $this->mock(JwksServiceInterface::class)
             ->shouldReceive('getPublicKey')
-            ->andReturn(InMemory::plainText($publicPem));
+            ->andReturn($publicPem);
 
         $token = $this->buildJwtForSub(
             $privatePem,

--- a/backend/tests/Feature/DocumentSoDHttpAcceptanceTest.php
+++ b/backend/tests/Feature/DocumentSoDHttpAcceptanceTest.php
@@ -11,7 +11,6 @@ use Maya\Auth\Contracts\JwksServiceInterface;
 use Maya\Messaging\Publishers\AuditPublisher;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Str;
-use Lcobucci\JWT\Signer\Key\InMemory;
 use Tests\Concerns\BuildsTestJwt;
 use Tests\TestCase;
 
@@ -79,7 +78,7 @@ class DocumentSoDHttpAcceptanceTest extends TestCase
 
         $this->mock(JwksServiceInterface::class)
             ->shouldReceive('getPublicKey')
-            ->andReturn(InMemory::plainText($publicPem));
+            ->andReturn($publicPem);
 
         $this->postJson(
             "/api/v1/documents/{$documentId}/submit",
@@ -173,7 +172,7 @@ class DocumentSoDHttpAcceptanceTest extends TestCase
 
         $this->mock(JwksServiceInterface::class)
             ->shouldReceive('getPublicKey')
-            ->andReturn(InMemory::plainText($publicPem));
+            ->andReturn($publicPem);
 
         $this->postJson(
             "/api/v1/documents/{$documentId}/submit",
@@ -203,7 +202,7 @@ class DocumentSoDHttpAcceptanceTest extends TestCase
 
         $this->mock(JwksServiceInterface::class)
             ->shouldReceive('getPublicKey')
-            ->andReturn(InMemory::plainText($publicPem));
+            ->andReturn($publicPem);
 
         $response = $this->postJson(
             "/api/v1/templates/{$templateId}/submit-review",
@@ -257,7 +256,7 @@ class DocumentSoDHttpAcceptanceTest extends TestCase
 
         $this->mock(JwksServiceInterface::class)
             ->shouldReceive('getPublicKey')
-            ->andReturn(InMemory::plainText($publicPem));
+            ->andReturn($publicPem);
 
         $this->postJson(
             "/api/v1/documents/{$documentId}/submit",
@@ -311,7 +310,7 @@ class DocumentSoDHttpAcceptanceTest extends TestCase
 
         $this->mock(JwksServiceInterface::class)
             ->shouldReceive('getPublicKey')
-            ->andReturn(InMemory::plainText($publicPem));
+            ->andReturn($publicPem);
 
         $this->postJson(
             "/api/v1/documents/{$documentId}/submit",

--- a/backend/tests/Feature/DocumentsModuleCreationApiTest.php
+++ b/backend/tests/Feature/DocumentsModuleCreationApiTest.php
@@ -13,7 +13,6 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
-use Lcobucci\JWT\Signer\Key\InMemory;
 use Tests\Concerns\BuildsTestJwt;
 use Tests\TestCase;
 
@@ -65,7 +64,7 @@ class DocumentsModuleCreationApiTest extends TestCase
 
         $this->mock(JwksServiceInterface::class)
             ->shouldReceive('getPublicKey')
-            ->andReturn(InMemory::plainText($publicPem));
+            ->andReturn($publicPem);
 
         $token = $this->buildJwtForSub(
             $privatePem,

--- a/backend/tests/Feature/DocumentsTemplateVersionApiTest.php
+++ b/backend/tests/Feature/DocumentsTemplateVersionApiTest.php
@@ -23,7 +23,6 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
-use Lcobucci\JWT\Signer\Key\InMemory;
 use Tests\Concerns\AssignsTestUserPermissions;
 use Tests\Concerns\BuildsTestJwt;
 use Tests\TestCase;
@@ -110,7 +109,7 @@ class DocumentsTemplateVersionApiTest extends TestCase
 
         $this->mock(JwksServiceInterface::class)
             ->shouldReceive('getPublicKey')
-            ->andReturn(InMemory::plainText($publicPem));
+            ->andReturn($publicPem);
 
         $token = $this->buildJwtForSub(
             $privatePem,
@@ -145,7 +144,7 @@ class DocumentsTemplateVersionApiTest extends TestCase
 
         $this->mock(JwksServiceInterface::class)
             ->shouldReceive('getPublicKey')
-            ->andReturn(InMemory::plainText($publicPem));
+            ->andReturn($publicPem);
 
         $tokenCreator = $this->buildJwtForSub(
             $privatePem,

--- a/backend/tests/Feature/GlobalScopesIsolationTest.php
+++ b/backend/tests/Feature/GlobalScopesIsolationTest.php
@@ -16,7 +16,6 @@ use Maya\Auth\Contracts\JwksServiceInterface;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
-use Lcobucci\JWT\Signer\Key\InMemory;
 use Tests\Concerns\AssignsTestUserPermissions;
 use Tests\Concerns\BuildsTestJwt;
 use Tests\TestCase;
@@ -91,7 +90,7 @@ class GlobalScopesIsolationTest extends TestCase
 
         $this->mock(JwksServiceInterface::class)
             ->shouldReceive('getPublicKey')
-            ->andReturn(InMemory::plainText($publicPem));
+            ->andReturn($publicPem);
 
         return $token;
     }

--- a/backend/tests/Feature/JwtMiddlewareTest.php
+++ b/backend/tests/Feature/JwtMiddlewareTest.php
@@ -117,7 +117,7 @@ class JwtMiddlewareTest extends TestCase
 
         $this->mock(JwksServiceInterface::class)
             ->shouldReceive('getPublicKey')
-            ->andReturn(InMemory::plainText($publicPem));
+            ->andReturn($publicPem);
 
         $middleware = app(JwtMiddleware::class);
 
@@ -141,7 +141,7 @@ class JwtMiddlewareTest extends TestCase
 
         $this->mock(JwksServiceInterface::class)
             ->shouldReceive('getPublicKey')
-            ->andReturn(InMemory::plainText($publicPem));
+            ->andReturn($publicPem);
 
         config([
             'auth.jwt_issuer'   => 'test-issuer',
@@ -162,7 +162,7 @@ class JwtMiddlewareTest extends TestCase
 
         $this->mock(JwksServiceInterface::class)
             ->shouldReceive('getPublicKey')
-            ->andReturn(InMemory::plainText($publicPem));
+            ->andReturn($publicPem);
 
         config([
             'auth.jwt_issuer'   => 'expected-issuer',
@@ -183,7 +183,7 @@ class JwtMiddlewareTest extends TestCase
 
         $this->mock(JwksServiceInterface::class)
             ->shouldReceive('getPublicKey')
-            ->andReturn(InMemory::plainText($publicPem));
+            ->andReturn($publicPem);
 
         config([
             'auth.jwt_issuer'   => 'test-issuer',

--- a/backend/tests/Feature/JwtValidationTest.php
+++ b/backend/tests/Feature/JwtValidationTest.php
@@ -28,7 +28,7 @@ class JwtValidationTest extends TestCase
 
         $this->mock(JwksServiceInterface::class)
             ->shouldReceive('getPublicKey')
-            ->andReturn(InMemory::plainText($publicPem));
+            ->andReturn($publicPem);
 
         $middleware = app(JwtMiddleware::class);
         $method     = (new \ReflectionClass(JwtMiddleware::class))
@@ -79,7 +79,7 @@ class JwtValidationTest extends TestCase
 
         $this->mock(JwksServiceInterface::class)
             ->shouldReceive('getPublicKey')
-            ->andReturn(InMemory::plainText($publicPem));
+            ->andReturn($publicPem);
 
         $middleware = app(JwtMiddleware::class);
         $method     = (new \ReflectionClass(JwtMiddleware::class))
@@ -165,7 +165,7 @@ class JwtValidationTest extends TestCase
 
         $this->mock(JwksServiceInterface::class)
             ->shouldReceive('getPublicKey')
-            ->andReturn(InMemory::plainText($publicPem));
+            ->andReturn($publicPem);
 
         config([
             'auth.jwt_issuer'   => 'test-issuer',

--- a/backend/tests/Feature/MeProfileApiTest.php
+++ b/backend/tests/Feature/MeProfileApiTest.php
@@ -4,7 +4,6 @@ namespace Tests\Feature;
 
 use App\Services\Contracts\UserProfileServiceInterface;
 use Illuminate\Support\Facades\Cache;
-use Lcobucci\JWT\Signer\Key\InMemory;
 use Maya\Auth\Contracts\JwksServiceInterface;
 use Tests\Concerns\BuildsTestJwt;
 use Tests\TestCase;
@@ -39,7 +38,7 @@ class MeProfileApiTest extends TestCase
 
         $this->mock(JwksServiceInterface::class)
             ->shouldReceive('getPublicKey')
-            ->andReturn(InMemory::plainText($publicPem));
+            ->andReturn($publicPem);
 
         $token = $this->buildJwtForSub(
             $privatePem,

--- a/backend/tests/Feature/TemplateBlockStatePerformanceTest.php
+++ b/backend/tests/Feature/TemplateBlockStatePerformanceTest.php
@@ -8,7 +8,6 @@ use Database\Seeders\PermissionsSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Str;
-use Lcobucci\JWT\Signer\Key\InMemory;
 use Maya\Auth\Contracts\JwksServiceInterface;
 use Tests\Concerns\AssignsTestUserPermissions;
 use Tests\Concerns\BuildsTestJwt;
@@ -42,7 +41,7 @@ class TemplateBlockStatePerformanceTest extends TestCase
 
         $this->mock(JwksServiceInterface::class)
             ->shouldReceive('getPublicKey')
-            ->andReturn(InMemory::plainText($publicPem));
+            ->andReturn($publicPem);
 
         $token = $this->buildJwtForSub(
             $privatePem,

--- a/backend/tests/Feature/TemplateBlocksApiTest.php
+++ b/backend/tests/Feature/TemplateBlocksApiTest.php
@@ -10,7 +10,6 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
-use Lcobucci\JWT\Signer\Key\InMemory;
 use Maya\Auth\Contracts\JwksServiceInterface;
 use Maya\Messaging\Publishers\AuditPublisher;
 use Tests\Concerns\BuildsTestJwt;
@@ -57,7 +56,7 @@ class TemplateBlocksApiTest extends TestCase
 
         $this->mock(JwksServiceInterface::class)
             ->shouldReceive('getPublicKey')
-            ->andReturn(InMemory::plainText($publicPem));
+            ->andReturn($publicPem);
 
         $token = $this->buildJwtForSub(
             $privatePem,

--- a/backend/tests/Feature/TemplatesApiTest.php
+++ b/backend/tests/Feature/TemplatesApiTest.php
@@ -24,7 +24,6 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
-use Lcobucci\JWT\Signer\Key\InMemory;
 use Tests\Concerns\AssignsTestUserPermissions;
 use Tests\Concerns\BuildsTestJwt;
 use Tests\TestCase;
@@ -100,7 +99,7 @@ class TemplatesApiTest extends TestCase
 
         $this->mock(JwksServiceInterface::class)
             ->shouldReceive('getPublicKey')
-            ->andReturn(InMemory::plainText($publicPem));
+            ->andReturn($publicPem);
 
         $token = $this->buildJwtForSub(
             $privatePem,
@@ -137,7 +136,7 @@ class TemplatesApiTest extends TestCase
 
         $this->mock(JwksServiceInterface::class)
             ->shouldReceive('getPublicKey')
-            ->andReturn(InMemory::plainText($publicPem));
+            ->andReturn($publicPem);
 
         $tokenCreator = $this->buildJwtForSub(
             $privatePem,

--- a/backend/tests/Feature/UserFavoriteApiTest.php
+++ b/backend/tests/Feature/UserFavoriteApiTest.php
@@ -11,7 +11,6 @@ use Database\Seeders\UsersSourceSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Str;
-use Lcobucci\JWT\Signer\Key\InMemory;
 use Maya\Auth\Contracts\JwksServiceInterface;
 use Tests\Concerns\AssignsTestUserPermissions;
 use Tests\Concerns\BuildsTestJwt;
@@ -53,7 +52,7 @@ class UserFavoriteApiTest extends TestCase
 
         $this->mock(JwksServiceInterface::class)
             ->shouldReceive('getPublicKey')
-            ->andReturn(InMemory::plainText($publicPem));
+            ->andReturn($publicPem);
 
         $token = $this->buildJwtForSub(
             $privatePem,

--- a/backend/tests/Feature/UsersSearchApiTest.php
+++ b/backend/tests/Feature/UsersSearchApiTest.php
@@ -7,7 +7,6 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
-use Lcobucci\JWT\Signer\Key\InMemory;
 use Maya\Auth\Contracts\JwksServiceInterface;
 use Tests\Concerns\BuildsTestJwt;
 use Tests\TestCase;
@@ -55,7 +54,7 @@ class UsersSearchApiTest extends TestCase
 
         $this->mock(JwksServiceInterface::class)
             ->shouldReceive('getPublicKey')
-            ->andReturn(InMemory::plainText($publicPem));
+            ->andReturn($publicPem);
 
         $token = $this->buildJwtForSub(
             $privatePem,

--- a/frontend/src/api/templates.ts
+++ b/frontend/src/api/templates.ts
@@ -67,6 +67,9 @@ function buildListQuery(filters: TemplateListFilters): string {
   if (filters.delivery_deadline) {
     q.set('delivery_deadline', filters.delivery_deadline);
   }
+  if (filters.published_on) {
+    q.set('published_on', filters.published_on);
+  }
   if (filters.process_id) {
     q.set('process_id', filters.process_id);
   }

--- a/frontend/src/components/DocumentsContent.tsx
+++ b/frontend/src/components/DocumentsContent.tsx
@@ -26,6 +26,7 @@ import { normalizeBlockContentForEditor } from '../features/documents/lib/normal
 import { BlockContentHtml } from '../features/templates/components/BlockContentHtml';
 import { useUserProfile } from '../features/user-profile';
 import type { Document, DocumentStatus } from '../types/documents';
+import { formatCalendarDateForBrowser } from '../utils/formatCalendarDate';
 import { BLOCK_STATE_LABELS, type BlockState } from '../types/blocks';
 
 function snapshotBlockStateLabel(raw: string | undefined): string {
@@ -331,7 +332,7 @@ export function DocumentsContent() {
         align: 'left',
         cell: (d: Document) => (
           <span className="text-xs text-text-muted dark:text-text-dark-muted">
-            {d.delivery_deadline ? d.delivery_deadline.slice(0, 10) : '—'}
+            {d.delivery_deadline ? formatCalendarDateForBrowser(d.delivery_deadline) : '—'}
           </span>
         ),
       },

--- a/frontend/src/components/FavoriteButton.tsx
+++ b/frontend/src/components/FavoriteButton.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
+import { FAVORITE_STAR_FILLED_CHAR, FAVORITE_STAR_OUTLINE_CHAR } from '@maya/shared-ui-react';
 import {
   addDocumentFavorite,
   addTemplateFavorite,
@@ -65,19 +66,15 @@ export function FavoriteButton({ entityType, entityId }: Props) {
       disabled={loading || toggling}
       onClick={() => void onClick()}
       title={isFavorite ? 'Quitar de favoritos' : 'Añadir a favoritos'}
-      className="flex items-center justify-center w-7 h-7 rounded-md text-text-muted dark:text-text-dark-muted hover:text-warning-dark dark:hover:text-warning-light transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+      className={`flex items-center justify-center w-7 h-7 rounded-lg text-lg leading-none transition-all cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-ui-dark-card ${
+        isFavorite
+          ? 'bg-warning-light dark:bg-warning-dark/40 text-warning-dark dark:text-warning shadow-sm hover:bg-danger-light/40 dark:hover:bg-danger-dark/25 hover:ring-2 hover:ring-inset hover:ring-danger/30 hover:text-danger-dark dark:hover:text-danger hover:shadow-md focus-visible:ring-danger/50'
+          : 'border border-ui-border dark:border-ui-dark-border text-text-secondary dark:text-text-dark-secondary hover:text-warning-dark dark:hover:text-warning hover:border-warning/60 hover:bg-warning-light/50 dark:hover:bg-warning-dark/20 focus-visible:ring-ui-border'
+      }`}
       aria-pressed={isFavorite}
       aria-busy={loading || toggling}
     >
-      {isFavorite ? (
-        <svg viewBox="0 0 20 20" fill="currentColor" className="w-4 h-4 text-warning-dark dark:text-warning-light">
-          <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
-        </svg>
-      ) : (
-        <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.5" className="w-4 h-4">
-          <path strokeLinecap="round" strokeLinejoin="round" d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
-        </svg>
-      )}
+      {isFavorite ? FAVORITE_STAR_FILLED_CHAR : FAVORITE_STAR_OUTLINE_CHAR}
     </button>
   );
 }

--- a/frontend/src/components/FavoriteInlineMark.tsx
+++ b/frontend/src/components/FavoriteInlineMark.tsx
@@ -1,16 +1,6 @@
-/**
- * Indicador sólo lectura en listados (tabla): estrella rellena si el recurso está en favoritos.
- */
+import { FavoriteStarFilled } from '@maya/shared-ui-react';
+
+/** Marca de favorito en listados DMS; misma estética que maya_dashboard (glifo ★). */
 export function FavoriteInlineMark() {
-  return (
-    <span
-      className="inline-flex shrink-0 text-yellow-500 dark:text-yellow-400"
-      title="En favoritos"
-      aria-label="En favoritos"
-    >
-      <svg viewBox="0 0 20 20" fill="currentColor" className="w-4 h-4" aria-hidden>
-        <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
-      </svg>
-    </span>
-  );
+  return <FavoriteStarFilled title="En favoritos" aria-label="En favoritos" />;
 }

--- a/frontend/src/features/documents/components/DocumentsTable.tsx
+++ b/frontend/src/features/documents/components/DocumentsTable.tsx
@@ -22,6 +22,7 @@ import { useUserProfile } from '../../../features/user-profile';
 import { useHierarchy } from '../../../features/hierarchy';
 import { formatCalendarDateForBrowser } from '../../../utils/formatCalendarDate';
 import { formatListRowVisibilityCaption, listRowSearchMatches } from '../../../utils/academicContextSearch';
+import { normalizeForSearch } from '../../../utils/normalizeForSearch';
 import type { AcademicHierarchy } from '../../../types/hierarchy';
 
 // Estado y visibilidad: clases provenientes del módulo compartido `badges`
@@ -69,8 +70,8 @@ function applyClientFilters(
       return false;
     }
     if (filters.name) {
-      const title = (doc.title ?? '').toLowerCase();
-      if (!title.includes(filters.name.toLowerCase())) return false;
+      const needle = normalizeForSearch(filters.name);
+      if (!normalizeForSearch(doc.title ?? '').includes(needle)) return false;
     }
     if (filters.status && doc.status !== filters.status) return false;
     if (filters.academicContext) {
@@ -92,8 +93,8 @@ function applyClientFilters(
       }
     }
     if (filters.authorName) {
-      const name = (doc.owner_name ?? '').toLowerCase();
-      if (!name.includes(filters.authorName.toLowerCase())) return false;
+      const needle = normalizeForSearch(filters.authorName);
+      if (!normalizeForSearch(doc.owner_name ?? '').includes(needle)) return false;
     }
     if (filters.date) {
       // La validación no aplica a publicados (no mostramos plazo en columna); no mezclar con `delivery_deadline` residual del API.

--- a/frontend/src/features/documents/components/DocumentsTable.tsx
+++ b/frontend/src/features/documents/components/DocumentsTable.tsx
@@ -14,12 +14,15 @@ import {
   type ColumnDef,
 } from '@maya/shared-ui-react';
 import type { Document, DocumentStatus } from '../../../types/documents';
-import { FAVORITES_FILTER_OPTIONS, VISIBILITY_OPTIONS, visibilityLabel } from '../../templates/constants';
+import { FAVORITES_FILTER_OPTIONS, visibilityLabel } from '../../templates/constants';
 import type { TemplateVisibilityLevel } from '../../../types/templates';
 import { useFavoritesIds } from '../../../hooks/useFavoritesIds';
 import { FavoriteInlineMark } from '../../../components/FavoriteInlineMark';
 import { useUserProfile } from '../../../features/user-profile';
+import { useHierarchy } from '../../../features/hierarchy';
 import { formatCalendarDateForBrowser } from '../../../utils/formatCalendarDate';
+import { listRowSearchMatches } from '../../../utils/academicContextSearch';
+import type { AcademicHierarchy } from '../../../types/hierarchy';
 
 // Estado y visibilidad: clases provenientes del módulo compartido `badges`
 // (los colores hex viven en `maya_infra/configs/styles/index.css`).
@@ -37,12 +40,6 @@ const STATUS_FILTER_OPTIONS: { value: string; label: string }[] = [
   { value: 'published', label: 'Publicado' },
 ];
 
-const VISIBILITY_FILTER_OPTIONS: { value: string; label: string }[] = [
-  { value: '', label: 'Todas' },
-  ...VISIBILITY_OPTIONS,
-];
-
-
 /** `delivery_deadline` presente y día calendario ≤ cap (Y-m-d), inclusive. */
 function deliveryDeadlineOnOrBefore(iso: string | null | undefined, capYmd: string): boolean {
   const ymd = (iso ?? '').slice(0, 10);
@@ -52,7 +49,8 @@ function deliveryDeadlineOnOrBefore(iso: string | null | undefined, capYmd: stri
 
 type Filters = {
   name: string;
-  visibility: string;
+  /** Texto libre sobre contexto académico vinculado (jerarquía + equipo), no la etiqueta de visibilidad. */
+  academicContext: string;
   status: string;
   authorName: string;
   date: string;
@@ -64,6 +62,7 @@ function applyClientFilters(
   docs: Document[],
   filters: Filters,
   favoriteDocumentIds: ReadonlySet<string>,
+  hierarchy: AcademicHierarchy,
 ): Document[] {
   return docs.filter((doc) => {
     if (filters.favorites === 'favorites' && !favoriteDocumentIds.has(doc.id)) {
@@ -74,7 +73,24 @@ function applyClientFilters(
       if (!title.includes(filters.name.toLowerCase())) return false;
     }
     if (filters.status && doc.status !== filters.status) return false;
-    if (filters.visibility && doc.visibility_level !== filters.visibility) return false;
+    if (filters.academicContext) {
+      if (
+        !listRowSearchMatches(
+          hierarchy,
+          {
+            visibility_level: doc.visibility_level ?? undefined,
+            study_type_id: doc.study_type_id,
+            study_id: doc.study_id,
+            module_id: doc.module_id,
+            team_id: doc.team_id,
+            team: doc.team,
+          },
+          filters.academicContext,
+        )
+      ) {
+        return false;
+      }
+    }
     if (filters.authorName) {
       const name = (doc.owner_name ?? '').toLowerCase();
       if (!name.includes(filters.authorName.toLowerCase())) return false;
@@ -101,6 +117,7 @@ type Props = {
 export function DocumentsTable({ processId }: Props = {}) {
   const navigate = useNavigate();
   const { profile, hasPermission } = useUserProfile();
+  const { hierarchy } = useHierarchy();
   const { documentIds: favoriteDocumentIds } = useFavoritesIds();
   const { hiddenIds, toggleHidden, sortBy, setSortBy, pageSize, setPageSize } = useTablePreferences({
     storageKey: 'maya:dms:documents-table',
@@ -168,16 +185,18 @@ export function DocumentsTable({ processId }: Props = {}) {
 
   const [filters, setFilters] = useState<Filters>({
     name: '',
-    visibility: '',
+    academicContext: '',
     status: '',
     authorName: '',
     date: '',
     favorites: '',
   });
   const [nameInput, setNameInput] = useState('');
+  const [academicContextInput, setAcademicContextInput] = useState('');
   const [authorInput, setAuthorInput] = useState('');
   const [page, setPage] = useState(1);
   const nameDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const academicContextDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const authorDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const displayDocuments = useMemo(() => {
@@ -217,8 +236,8 @@ export function DocumentsTable({ processId }: Props = {}) {
   }, [documents, hasPermission, profile?.id]);
 
   const filtered = useMemo(
-    () => applyClientFilters(displayDocuments, filters, favoriteDocumentIds),
-    [displayDocuments, filters, favoriteDocumentIds],
+    () => applyClientFilters(displayDocuments, filters, favoriteDocumentIds, hierarchy),
+    [displayDocuments, filters, favoriteDocumentIds, hierarchy],
   );
 
   const sorted = useMemo(() => {
@@ -252,7 +271,7 @@ export function DocumentsTable({ processId }: Props = {}) {
 
   const filtersActiveCount =
     (filters.favorites ? 1 : 0) +
-    [filters.name, filters.visibility, filters.status, filters.authorName, filters.date].filter(Boolean).length;
+    [filters.name, filters.academicContext, filters.status, filters.authorName, filters.date].filter(Boolean).length;
 
   const handleFilterChange = (patch: Partial<Filters>) => {
     setFilters((f) => ({ ...f, ...patch }));
@@ -277,12 +296,23 @@ export function DocumentsTable({ processId }: Props = {}) {
     }, 400);
   };
 
+  const handleAcademicContextChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setAcademicContextInput(value);
+    if (academicContextDebounceRef.current) clearTimeout(academicContextDebounceRef.current);
+    academicContextDebounceRef.current = setTimeout(() => {
+      handleFilterChange({ academicContext: value });
+    }, 400);
+  };
+
   const clearFilters = () => {
     if (nameDebounceRef.current) clearTimeout(nameDebounceRef.current);
+    if (academicContextDebounceRef.current) clearTimeout(academicContextDebounceRef.current);
     if (authorDebounceRef.current) clearTimeout(authorDebounceRef.current);
     setNameInput('');
+    setAcademicContextInput('');
     setAuthorInput('');
-    setFilters({ name: '', visibility: '', status: '', authorName: '', date: '', favorites: '' });
+    setFilters({ name: '', academicContext: '', status: '', authorName: '', date: '', favorites: '' });
     setPage(1);
   };
 
@@ -334,16 +364,14 @@ export function DocumentsTable({ processId }: Props = {}) {
                 onChange={handleNameChange}
               />
             </FilterField>
-            <FilterField label="Visibilidad">
-              <Select
+            <FilterField label="Contexto académico">
+              <TextInput
                 fieldSize="sm"
-                value={filters.visibility}
-                onChange={(e) => handleFilterChange({ visibility: e.target.value })}
-              >
-                {VISIBILITY_FILTER_OPTIONS.map((o) => (
-                  <option key={o.value} value={o.value}>{o.label}</option>
-                ))}
-              </Select>
+                type="search"
+                placeholder="Global, personal, equipo, nombre de equipo o contexto académico…"
+                value={academicContextInput}
+                onChange={handleAcademicContextChange}
+              />
             </FilterField>
             <FilterField label="Estado">
               <Select

--- a/frontend/src/features/documents/components/DocumentsTable.tsx
+++ b/frontend/src/features/documents/components/DocumentsTable.tsx
@@ -14,7 +14,7 @@ import {
   type ColumnDef,
 } from '@maya/shared-ui-react';
 import type { Document, DocumentStatus } from '../../../types/documents';
-import { VISIBILITY_OPTIONS, visibilityLabel } from '../../templates/constants';
+import { FAVORITES_FILTER_OPTIONS, VISIBILITY_OPTIONS, visibilityLabel } from '../../templates/constants';
 import type { TemplateVisibilityLevel } from '../../../types/templates';
 import { useFavoritesIds } from '../../../hooks/useFavoritesIds';
 import { FavoriteInlineMark } from '../../../components/FavoriteInlineMark';
@@ -53,10 +53,19 @@ type Filters = {
   status: string;
   authorName: string;
   date: string;
+  /** '' = sin filtro; 'favorites' = solo marcados como favoritos */
+  favorites: string;
 };
 
-function applyClientFilters(docs: Document[], filters: Filters): Document[] {
+function applyClientFilters(
+  docs: Document[],
+  filters: Filters,
+  favoriteDocumentIds: ReadonlySet<string>,
+): Document[] {
   return docs.filter((doc) => {
+    if (filters.favorites === 'favorites' && !favoriteDocumentIds.has(doc.id)) {
+      return false;
+    }
     if (filters.name) {
       const title = (doc.title ?? '').toLowerCase();
       if (!title.includes(filters.name.toLowerCase())) return false;
@@ -154,6 +163,7 @@ export function DocumentsTable({ processId }: Props = {}) {
     status: '',
     authorName: '',
     date: '',
+    favorites: '',
   });
   const [nameInput, setNameInput] = useState('');
   const [authorInput, setAuthorInput] = useState('');
@@ -197,7 +207,10 @@ export function DocumentsTable({ processId }: Props = {}) {
     return out;
   }, [documents, hasPermission, profile?.id]);
 
-  const filtered = useMemo(() => applyClientFilters(displayDocuments, filters), [displayDocuments, filters]);
+  const filtered = useMemo(
+    () => applyClientFilters(displayDocuments, filters, favoriteDocumentIds),
+    [displayDocuments, filters, favoriteDocumentIds],
+  );
 
   const sorted = useMemo(() => {
     if (!sortBy) return filtered;
@@ -228,7 +241,9 @@ export function DocumentsTable({ processId }: Props = {}) {
   const safePage = Math.min(page, totalPages);
   const pageSlice = sorted.slice((safePage - 1) * pageSize, safePage * pageSize);
 
-  const filtersActiveCount = [filters.name, filters.visibility, filters.status, filters.authorName, filters.date].filter(Boolean).length;
+  const filtersActiveCount =
+    (filters.favorites ? 1 : 0) +
+    [filters.name, filters.visibility, filters.status, filters.authorName, filters.date].filter(Boolean).length;
 
   const handleFilterChange = (patch: Partial<Filters>) => {
     setFilters((f) => ({ ...f, ...patch }));
@@ -258,7 +273,7 @@ export function DocumentsTable({ processId }: Props = {}) {
     if (authorDebounceRef.current) clearTimeout(authorDebounceRef.current);
     setNameInput('');
     setAuthorInput('');
-    setFilters({ name: '', visibility: '', status: '', authorName: '', date: '' });
+    setFilters({ name: '', visibility: '', status: '', authorName: '', date: '', favorites: '' });
     setPage(1);
   };
 
@@ -339,6 +354,19 @@ export function DocumentsTable({ processId }: Props = {}) {
                 value={authorInput}
                 onChange={handleAuthorChange}
               />
+            </FilterField>
+            <FilterField label="Favoritos">
+              <Select
+                fieldSize="sm"
+                value={filters.favorites}
+                onChange={(e) => handleFilterChange({ favorites: e.target.value })}
+              >
+                {FAVORITES_FILTER_OPTIONS.map((o) => (
+                  <option key={o.value || 'all'} value={o.value}>
+                    {o.label}
+                  </option>
+                ))}
+              </Select>
             </FilterField>
             <FilterField label="Fecha">
               <DatePicker

--- a/frontend/src/features/documents/components/DocumentsTable.tsx
+++ b/frontend/src/features/documents/components/DocumentsTable.tsx
@@ -19,6 +19,7 @@ import type { TemplateVisibilityLevel } from '../../../types/templates';
 import { useFavoritesIds } from '../../../hooks/useFavoritesIds';
 import { FavoriteInlineMark } from '../../../components/FavoriteInlineMark';
 import { useUserProfile } from '../../../features/user-profile';
+import { formatCalendarDateForBrowser } from '../../../utils/formatCalendarDate';
 
 // Estado y visibilidad: clases provenientes del módulo compartido `badges`
 // (los colores hex viven en `maya_infra/configs/styles/index.css`).
@@ -42,9 +43,11 @@ const VISIBILITY_FILTER_OPTIONS: { value: string; label: string }[] = [
 ];
 
 
-function formatDate(iso: string | null | undefined): string {
-  if (!iso) return '—';
-  return iso.slice(0, 10);
+/** `delivery_deadline` presente y día calendario ≤ cap (Y-m-d), inclusive. */
+function deliveryDeadlineOnOrBefore(iso: string | null | undefined, capYmd: string): boolean {
+  const ymd = (iso ?? '').slice(0, 10);
+  if (!ymd) return false;
+  return ymd <= capYmd;
 }
 
 type Filters = {
@@ -76,10 +79,14 @@ function applyClientFilters(
       const name = (doc.owner_name ?? '').toLowerCase();
       if (!name.includes(filters.authorName.toLowerCase())) return false;
     }
-    if (filters.date && doc.delivery_deadline) {
-      if (!doc.delivery_deadline.startsWith(filters.date)) return false;
-    } else if (filters.date && !doc.delivery_deadline) {
-      return false;
+    if (filters.date) {
+      // La validación no aplica a publicados (no mostramos plazo en columna); no mezclar con `delivery_deadline` residual del API.
+      if (doc.status === 'published') {
+        return false;
+      }
+      if (!deliveryDeadlineOnOrBefore(doc.delivery_deadline, filters.date)) {
+        return false;
+      }
     }
     return true;
   });
@@ -147,10 +154,12 @@ export function DocumentsTable({ processId }: Props = {}) {
       },
       {
         id: 'delivery_deadline',
-        header: 'Fecha',
+        header: 'Fecha de validación',
         sortable: true,
         cell: (doc) => (
-          <span className="text-xs text-text-secondary dark:text-text-dark-secondary">{formatDate(doc.delivery_deadline)}</span>
+          <span className="text-xs text-text-secondary dark:text-text-dark-secondary">
+            {doc.status === 'published' ? '—' : formatCalendarDateForBrowser(doc.delivery_deadline)}
+          </span>
         ),
       },
     ],
@@ -224,8 +233,8 @@ export function DocumentsTable({ processId }: Props = {}) {
       if (columnId === 'title') {
         return (a.title ?? '').localeCompare(b.title ?? '', 'es') * dir;
       } else if (columnId === 'delivery_deadline') {
-        valA = a.delivery_deadline ?? '';
-        valB = b.delivery_deadline ?? '';
+        valA = a.status === 'published' ? '9999-12-31' : (a.delivery_deadline ?? '').slice(0, 10);
+        valB = b.status === 'published' ? '9999-12-31' : (b.delivery_deadline ?? '').slice(0, 10);
       } else if (columnId === 'status') {
         valA = a.status ?? '';
         valB = b.status ?? '';
@@ -368,11 +377,12 @@ export function DocumentsTable({ processId }: Props = {}) {
                 ))}
               </Select>
             </FilterField>
-            <FilterField label="Fecha">
+            <FilterField label="Fecha de validación (hasta)">
               <DatePicker
                 value={filters.date || null}
                 onChange={(d) => handleFilterChange({ date: d ?? '' })}
-                placeholder="Seleccionar fecha..."
+                placeholder="Cualquier plazo…"
+                ariaLabel="Documentos no publicados cuya fecha límite de validación sea esta fecha o anterior (las filas publicadas no aplican)"
               />
             </FilterField>
           </>

--- a/frontend/src/features/documents/components/DocumentsTable.tsx
+++ b/frontend/src/features/documents/components/DocumentsTable.tsx
@@ -14,14 +14,14 @@ import {
   type ColumnDef,
 } from '@maya/shared-ui-react';
 import type { Document, DocumentStatus } from '../../../types/documents';
-import { FAVORITES_FILTER_OPTIONS, visibilityLabel } from '../../templates/constants';
+import { FAVORITES_FILTER_OPTIONS } from '../../templates/constants';
 import type { TemplateVisibilityLevel } from '../../../types/templates';
 import { useFavoritesIds } from '../../../hooks/useFavoritesIds';
 import { FavoriteInlineMark } from '../../../components/FavoriteInlineMark';
 import { useUserProfile } from '../../../features/user-profile';
 import { useHierarchy } from '../../../features/hierarchy';
 import { formatCalendarDateForBrowser } from '../../../utils/formatCalendarDate';
-import { listRowSearchMatches } from '../../../utils/academicContextSearch';
+import { formatListRowVisibilityCaption, listRowSearchMatches } from '../../../utils/academicContextSearch';
 import type { AcademicHierarchy } from '../../../types/hierarchy';
 
 // Estado y visibilidad: clases provenientes del módulo compartido `badges`
@@ -142,10 +142,25 @@ export function DocumentsTable({ processId }: Props = {}) {
         id: 'visibility_level',
         header: 'Visibilidad',
         cell: (doc) => {
-          const visLevel = (doc.visibility_level ?? 'personal') as TemplateVisibilityLevel;
+          const visLevel = doc.visibility_level;
+          if (visLevel == null) {
+            return <span className="text-xs text-text-secondary dark:text-text-dark-secondary">—</span>;
+          }
+          const level = visLevel as TemplateVisibilityLevel;
+          const caption = formatListRowVisibilityCaption(hierarchy, {
+            visibility_level: level,
+            study_type_id: doc.study_type_id,
+            study_id: doc.study_id,
+            module_id: doc.module_id,
+            team_id: doc.team_id,
+            team: doc.team,
+          });
           return (
-            <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${visibilityBadgeClass(visLevel)}`}>
-              {visibilityLabel(visLevel)}
+            <span
+              className={`inline-flex max-w-full min-w-0 text-xs font-medium px-2 py-0.5 rounded-full ${visibilityBadgeClass(level)}`}
+              title={caption}
+            >
+              <span className="truncate">{caption}</span>
             </span>
           );
         },
@@ -180,7 +195,7 @@ export function DocumentsTable({ processId }: Props = {}) {
         ),
       },
     ],
-    [favoriteDocumentIds],
+    [favoriteDocumentIds, hierarchy],
   );
 
   const [filters, setFilters] = useState<Filters>({

--- a/frontend/src/features/templates/components/TemplateCard.tsx
+++ b/frontend/src/features/templates/components/TemplateCard.tsx
@@ -2,8 +2,9 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Button, ConfirmDialog } from '@maya/shared-ui-react';
 import type { Template, TemplateStatus } from '../../../types/templates';
-import { visibilityLabel } from '../constants';
 import { useUserProfile } from '../../../features/user-profile';
+import { useHierarchy } from '../../../features/hierarchy';
+import { formatListRowVisibilityCaption } from '../../../utils/academicContextSearch';
 
 const STATUS_LABEL: Record<TemplateStatus, string> = {
   draft: 'Borrador',
@@ -21,6 +22,15 @@ type Props = {
 export function TemplateCard({ template: t, onDelete, onClone }: Props) {
   const navigate = useNavigate();
   const { profile, hasPermission } = useUserProfile();
+  const { hierarchy } = useHierarchy();
+  const visibilityCaption = formatListRowVisibilityCaption(hierarchy, {
+    visibility_level: t.visibility_level,
+    study_type_id: t.study_type_id,
+    study_id: t.study_id,
+    module_id: t.module_id,
+    team_id: t.team_id,
+    team: t.team,
+  });
   const [dialog, setDialog] = useState<'delete' | 'clone' | null>(null);
   const [dialogLoading, setDialogLoading] = useState(false);
   const canClone = t.can_clone === true;
@@ -106,8 +116,11 @@ export function TemplateCard({ template: t, onDelete, onClone }: Props) {
             <p className="text-xs text-text-secondary dark:text-text-dark-secondary line-clamp-2">{t.description}</p>
           ) : null}
           <div className="flex flex-wrap gap-2 text-xs text-text-muted dark:text-text-dark-muted font-medium">
-            <span className="rounded bg-ui-body dark:bg-ui-dark-bg px-2 py-0.5 border border-ui-border dark:border-ui-dark-border">
-              {visibilityLabel(t.visibility_level)}
+            <span
+              className="rounded bg-ui-body dark:bg-ui-dark-bg px-2 py-0.5 border border-ui-border dark:border-ui-dark-border max-w-full min-w-0 truncate inline-block align-bottom"
+              title={visibilityCaption}
+            >
+              {visibilityCaption}
             </span>
             {t.author_name ? (
               <span className="rounded bg-ui-body dark:bg-ui-dark-bg px-2 py-0.5 border border-ui-border dark:border-ui-dark-border opacity-70">

--- a/frontend/src/features/templates/components/TemplatePreviewModal.tsx
+++ b/frontend/src/features/templates/components/TemplatePreviewModal.tsx
@@ -6,16 +6,12 @@ import { visibilityLabel } from '../constants';
 import { normalizeBlockContentForEditor } from '../../documents/lib/normalizeBlockContent';
 import { PaperPreviewLayout } from '../../documents/components/PaperPreviewLayout';
 import { PaperBlocksArticle, type PaperArticleBlock } from '../../documents/components/PaperBlocksArticle';
+import { formatCalendarDateForBrowser } from '../../../utils/formatCalendarDate';
 
 interface Props {
   template: Template;
   blocks: TemplateBlock[];
   onClose: () => void;
-}
-
-function formatDate(iso: string | null | undefined): string {
-  if (!iso) return '—';
-  return iso.slice(0, 10);
 }
 
 /**
@@ -64,7 +60,9 @@ export function TemplatePreviewModal({ template, blocks, onClose }: Props) {
       {visibilityLabel(template.visibility_level)}
       {' · '}
       {blocks.length} {blocks.length === 1 ? 'bloque' : 'bloques'}
-      {template.delivery_deadline ? <>{' · '}Fecha límite: {formatDate(template.delivery_deadline)}</> : null}
+      {template.delivery_deadline ? (
+        <>{' · '}Fecha límite: {formatCalendarDateForBrowser(template.delivery_deadline)}</>
+      ) : null}
     </p>
   );
 

--- a/frontend/src/features/templates/components/TemplatesContent.tsx
+++ b/frontend/src/features/templates/components/TemplatesContent.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
   Button,
@@ -16,16 +16,17 @@ import {
   type ColumnDef,
 } from '@maya/shared-ui-react';
 import { useTemplates } from '../hooks/useTemplates';
-import { STATUS_OPTIONS, VISIBILITY_OPTIONS, visibilityLabel } from '../constants';
+import { buildTemplatesListMeta, sliceTemplatesPage } from '../clientTemplatePagination';
+import { STATUS_OPTIONS, visibilityLabel } from '../constants';
 import { TemplateCard } from './TemplateCard';
 import { TemplateHierarchyFields } from './TemplateHierarchyFields';
 import { useUserProfile } from '../../../features/user-profile';
+import { useHierarchy } from '../../../features/hierarchy';
+import { listRowSearchMatches } from '../../../utils/academicContextSearch';
 import type { Template, TemplateStatus } from '../../../types/templates';
 import { useFavoritesIds } from '../../../hooks/useFavoritesIds';
 import { FavoriteInlineMark } from '../../../components/FavoriteInlineMark';
 import { formatCalendarDateForBrowser } from '../../../utils/formatCalendarDate';
-
-const HIERARCHY_VIS = new Set(['study_type', 'study', 'module']);
 
 const STATUS_LABEL: Record<TemplateStatus, string> = {
   draft: 'Borrador',
@@ -42,12 +43,12 @@ const STATUS_LABEL: Record<TemplateStatus, string> = {
 export function TemplatesContent() {
   const navigate = useNavigate();
   const { profile } = useUserProfile();
+  const { hierarchy } = useHierarchy();
   const { hiddenIds, toggleHidden, sortBy, setSortBy, pageSize, setPageSize } =
     useTablePreferences({ storageKey: 'maya:dms:templates-content' });
   const { templateIds: favoriteTemplateIds } = useFavoritesIds();
   const {
-    templates,
-    meta,
+    catalogSorted,
     filters,
     loading,
     listError,
@@ -65,6 +66,48 @@ export function TemplatesContent() {
   const [authorInput, setAuthorInput] = useState(filters.author_name ?? '');
   const authorDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  const [academicContextInput, setAcademicContextInput] = useState('');
+  const [academicContextFilter, setAcademicContextFilter] = useState('');
+  const academicContextDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const listPage = filters.page ?? 1;
+  const listPerPage = filters.per_page ?? pageSize;
+
+  const clientFilteredCatalog = useMemo(() => {
+    if (!academicContextFilter.trim()) return catalogSorted;
+    return catalogSorted.filter((t) =>
+      listRowSearchMatches(
+        hierarchy,
+        {
+          visibility_level: t.visibility_level,
+          study_type_id: t.study_type_id,
+          study_id: t.study_id,
+          module_id: t.module_id,
+          team_id: t.team_id,
+          team: t.team,
+        },
+        academicContextFilter,
+      ),
+    );
+  }, [catalogSorted, academicContextFilter, hierarchy]);
+
+  useEffect(() => {
+    const last = Math.max(1, Math.ceil(clientFilteredCatalog.length / Math.max(1, listPerPage)));
+    if (listPage > last) {
+      applyFilters({ page: last });
+    }
+  }, [clientFilteredCatalog.length, listPage, listPerPage, applyFilters]);
+
+  const pagedSource = useMemo(
+    () => sliceTemplatesPage(clientFilteredCatalog, listPage, listPerPage),
+    [clientFilteredCatalog, listPage, listPerPage],
+  );
+
+  const listMeta = useMemo(
+    () => buildTemplatesListMeta(clientFilteredCatalog.length, listPage, listPerPage),
+    [clientFilteredCatalog.length, listPage, listPerPage],
+  );
+
   const handleAuthorChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
     setAuthorInput(value);
@@ -74,9 +117,17 @@ export function TemplatesContent() {
     }, 400);
   };
 
+  const handleAcademicContextChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setAcademicContextInput(value);
+    if (academicContextDebounceRef.current) clearTimeout(academicContextDebounceRef.current);
+    academicContextDebounceRef.current = setTimeout(() => {
+      setAcademicContextFilter(value);
+    }, 400);
+  };
+
   const filterUi = useMemo(
     () => ({
-      visibility: filters.visibility_level ?? '',
       status: filters.status ?? '',
       studyTypeId: filters.study_type_id ?? '',
       studyId: filters.study_id ?? '',
@@ -89,7 +140,7 @@ export function TemplatesContent() {
   );
 
   const filtersActiveCount = [
-    filterUi.visibility,
+    academicContextFilter,
     filterUi.status,
     filterUi.studyTypeId,
     filterUi.studyId,
@@ -101,7 +152,10 @@ export function TemplatesContent() {
 
   const clearFilters = () => {
     if (authorDebounceRef.current) clearTimeout(authorDebounceRef.current);
+    if (academicContextDebounceRef.current) clearTimeout(academicContextDebounceRef.current);
     setAuthorInput('');
+    setAcademicContextInput('');
+    setAcademicContextFilter('');
     applyFilters({
       visibility_level: undefined,
       status: undefined,
@@ -114,12 +168,9 @@ export function TemplatesContent() {
     });
   };
 
-  const showTeamFilter = filterUi.visibility === 'team';
-  const showHierarchyFilter = HIERARCHY_VIS.has(filterUi.visibility);
-
   const displayTemplates = useMemo(() => {
     const out: Template[] = [];
-    for (const t of templates) {
+    for (const t of pagedSource) {
       const hasPublishedFallback =
         t.status !== 'published' &&
         !!t.latest_published_version_id;
@@ -152,7 +203,7 @@ export function TemplatesContent() {
       return out.filter((row) => row.status !== 'published');
     }
     return out;
-  }, [templates, profile?.id, filters.delivery_deadline]);
+  }, [pagedSource, profile?.id, filters.delivery_deadline]);
 
   const handleRowClick = (t: Template) => {
     if (t.list_variant === 'published_fallback' && t.latest_published_version_id) {
@@ -286,7 +337,7 @@ export function TemplatesContent() {
       <DataTable<Template>
         columns={columns}
         rows={displayTemplates}
-        loading={loading && templates.length === 0}
+        loading={loading && catalogSorted.length === 0}
         rowKey={(t) => t.list_row_id ?? t.id}
         hiddenColumnIds={hiddenIds}
         onToggleHiddenColumn={toggleHidden}
@@ -308,27 +359,14 @@ export function TemplatesContent() {
         filtersStorageKey="maya:dms:templates-content"
         filtersPanel={
           <>
-            <FilterField label="Visibilidad">
-              <Select
+            <FilterField label="Contexto académico">
+              <TextInput
                 fieldSize="sm"
-                value={filterUi.visibility}
-                onChange={(e) =>
-                  applyFilters({
-                    visibility_level: e.target.value || undefined,
-                    study_type_id: undefined,
-                    study_id: undefined,
-                    module_id: undefined,
-                    team_id: undefined,
-                  })
-                }
-              >
-                <option value="">Todas</option>
-                {VISIBILITY_OPTIONS.map((o) => (
-                  <option key={o.value} value={o.value}>
-                    {o.label}
-                  </option>
-                ))}
-              </Select>
+                type="search"
+                placeholder="Global, personal, equipo, nombre de equipo o contexto académico…"
+                value={academicContextInput}
+                onChange={handleAcademicContextChange}
+              />
             </FilterField>
             <FilterField label="Estado">
               <Select
@@ -359,38 +397,36 @@ export function TemplatesContent() {
                 ariaLabel="Plantillas no publicadas cuya fecha límite de validación sea esta fecha o anterior (las publicadas no aplican)"
               />
             </FilterField>
-            {(showHierarchyFilter || showTeamFilter) && (
-              <div className="col-span-full pt-2 border-t border-ui-border/50 dark:border-ui-dark-border/50">
-                <FieldLabel>Vinculación</FieldLabel>
-                <TemplateHierarchyFields
-                  values={{
-                    study_type_id: filterUi.studyTypeId,
-                    study_id: filterUi.studyId,
-                    module_id: filterUi.moduleId,
-                    team_id: filterUi.teamId,
-                  }}
-                  onFieldChange={(key, value) =>
-                    applyFilters({ [key]: value.trim() === '' ? undefined : value.trim() })
-                  }
-                  gridClassName="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3"
-                  filterMode={true}
-                  maxLevel={showHierarchyFilter ? (filterUi.visibility as 'study_type' | 'study' | 'module') : null}
-                  showTeam={showTeamFilter}
-                />
-              </div>
-            )}
+            <div className="col-span-full pt-2 border-t border-ui-border/50 dark:border-ui-dark-border/50">
+              <FieldLabel>Vinculación</FieldLabel>
+              <TemplateHierarchyFields
+                values={{
+                  study_type_id: filterUi.studyTypeId,
+                  study_id: filterUi.studyId,
+                  module_id: filterUi.moduleId,
+                  team_id: filterUi.teamId,
+                }}
+                onFieldChange={(key, value) =>
+                  applyFilters({ [key]: value.trim() === '' ? undefined : value.trim() })
+                }
+                gridClassName="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3"
+                filterMode={true}
+                maxLevel={undefined}
+                showTeam={true}
+              />
+            </div>
           </>
         }
       />
 
-      {meta && (
+      {listMeta && (
         <Pagination
-          currentPage={meta.current_page}
-          totalPages={meta.last_page}
+          currentPage={listMeta.current_page}
+          totalPages={listMeta.last_page}
           onChange={goToPage}
           info={
-            meta.total > 0
-              ? `${(meta.current_page - 1) * meta.per_page + 1}–${Math.min(meta.current_page * meta.per_page, meta.total)} de ${meta.total} plantillas`
+            listMeta.total > 0
+              ? `${(listMeta.current_page - 1) * listMeta.per_page + 1}–${Math.min(listMeta.current_page * listMeta.per_page, listMeta.total)} de ${listMeta.total} plantillas`
               : undefined
           }
         />

--- a/frontend/src/features/templates/components/TemplatesContent.tsx
+++ b/frontend/src/features/templates/components/TemplatesContent.tsx
@@ -17,12 +17,12 @@ import {
 } from '@maya/shared-ui-react';
 import { useTemplates } from '../hooks/useTemplates';
 import { buildTemplatesListMeta, sliceTemplatesPage } from '../clientTemplatePagination';
-import { STATUS_OPTIONS, visibilityLabel } from '../constants';
+import { STATUS_OPTIONS } from '../constants';
 import { TemplateCard } from './TemplateCard';
 import { TemplateHierarchyFields } from './TemplateHierarchyFields';
 import { useUserProfile } from '../../../features/user-profile';
 import { useHierarchy } from '../../../features/hierarchy';
-import { listRowSearchMatches } from '../../../utils/academicContextSearch';
+import { formatListRowVisibilityCaption, listRowSearchMatches } from '../../../utils/academicContextSearch';
 import type { Template, TemplateStatus } from '../../../types/templates';
 import { useFavoritesIds } from '../../../hooks/useFavoritesIds';
 import { FavoriteInlineMark } from '../../../components/FavoriteInlineMark';
@@ -240,11 +240,24 @@ export function TemplatesContent() {
       {
         id: 'visibility_level',
         header: 'Visibilidad',
-        cell: (t) => (
-          <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${visibilityBadgeClass(t.visibility_level)}`}>
-            {visibilityLabel(t.visibility_level)}
-          </span>
-        ),
+        cell: (t) => {
+          const caption = formatListRowVisibilityCaption(hierarchy, {
+            visibility_level: t.visibility_level,
+            study_type_id: t.study_type_id,
+            study_id: t.study_id,
+            module_id: t.module_id,
+            team_id: t.team_id,
+            team: t.team,
+          });
+          return (
+            <span
+              className={`inline-flex max-w-full min-w-0 text-xs font-medium px-2 py-0.5 rounded-full ${visibilityBadgeClass(t.visibility_level)}`}
+              title={caption}
+            >
+              <span className="truncate">{caption}</span>
+            </span>
+          );
+        },
       },
       {
         id: 'author_name',
@@ -279,7 +292,7 @@ export function TemplatesContent() {
         ),
       },
     ],
-    [profile, favoriteTemplateIds],
+    [profile, favoriteTemplateIds, hierarchy],
   );
 
   return (

--- a/frontend/src/features/templates/components/TemplatesContent.tsx
+++ b/frontend/src/features/templates/components/TemplatesContent.tsx
@@ -44,8 +44,9 @@ export function TemplatesContent() {
   const navigate = useNavigate();
   const { profile } = useUserProfile();
   const { hierarchy } = useHierarchy();
-  const { hiddenIds, toggleHidden, sortBy, setSortBy, pageSize, setPageSize } =
-    useTablePreferences({ storageKey: 'maya:dms:templates-content' });
+  const { hiddenIds, toggleHidden, pageSize, setPageSize } = useTablePreferences({
+    storageKey: 'maya:dms:templates-content',
+  });
   const { templateIds: favoriteTemplateIds } = useFavoritesIds();
   const {
     catalogSorted,
@@ -61,7 +62,7 @@ export function TemplatesContent() {
     goToPage,
     deleteTemplate,
     cloneTemplate,
-  } = useTemplates(undefined, sortBy);
+  } = useTemplates(undefined);
 
   const [authorInput, setAuthorInput] = useState(filters.author_name ?? '');
   const authorDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -225,7 +226,6 @@ export function TemplatesContent() {
       {
         id: 'name',
         header: 'Nombre',
-        sortable: true,
         alwaysVisible: true,
         cell: (t) => (
           <span className="flex items-center gap-2 min-w-0">
@@ -276,7 +276,6 @@ export function TemplatesContent() {
       {
         id: 'status',
         header: 'Estado',
-        sortable: true,
         cell: (t) => {
           const status = t.status as TemplateStatus;
           return (
@@ -289,7 +288,6 @@ export function TemplatesContent() {
       {
         id: 'delivery_deadline',
         header: 'Fecha de validación',
-        sortable: true,
         cell: (t) => (
           <span className="text-xs text-text-secondary dark:text-text-dark-secondary">
             {t.status === 'published' ? '—' : formatCalendarDateForBrowser(t.delivery_deadline)}
@@ -359,8 +357,6 @@ export function TemplatesContent() {
         rowKey={(t) => t.list_row_id ?? t.id}
         hiddenColumnIds={hiddenIds}
         onToggleHiddenColumn={toggleHidden}
-        sortBy={sortBy}
-        onSortChange={setSortBy}
         pageSize={pageSize}
         onPageSizeChange={(size) => {
           setPageSize(size);

--- a/frontend/src/features/templates/components/TemplatesContent.tsx
+++ b/frontend/src/features/templates/components/TemplatesContent.tsx
@@ -169,6 +169,9 @@ export function TemplatesContent() {
   };
 
   const displayTemplates = useMemo(() => {
+    /** Con filtro de estado ≠ publicada, no mostrar la fila sintética de última publicada (siempre `published`). */
+    const includePublishedFallbackRow = !filters.status || filters.status === 'published';
+
     const out: Template[] = [];
     for (const t of pagedSource) {
       const hasPublishedFallback =
@@ -197,13 +200,15 @@ export function TemplatesContent() {
       if (canSeeLive) {
         out.push({ ...t, list_variant: 'live', list_row_id: `${t.id}:live` });
       }
-      out.push(publishedFallback);
+      if (includePublishedFallbackRow) {
+        out.push(publishedFallback);
+      }
     }
     if (filters.delivery_deadline) {
       return out.filter((row) => row.status !== 'published');
     }
     return out;
-  }, [pagedSource, profile?.id, filters.delivery_deadline]);
+  }, [pagedSource, profile?.id, filters.delivery_deadline, filters.status]);
 
   const handleRowClick = (t: Template) => {
     if (t.list_variant === 'published_fallback' && t.latest_published_version_id) {

--- a/frontend/src/features/templates/components/TemplatesContent.tsx
+++ b/frontend/src/features/templates/components/TemplatesContent.tsx
@@ -23,6 +23,7 @@ import { useUserProfile } from '../../../features/user-profile';
 import type { Template, TemplateStatus } from '../../../types/templates';
 import { useFavoritesIds } from '../../../hooks/useFavoritesIds';
 import { FavoriteInlineMark } from '../../../components/FavoriteInlineMark';
+import { formatCalendarDateForBrowser } from '../../../utils/formatCalendarDate';
 
 const HIERARCHY_VIS = new Set(['study_type', 'study', 'module']);
 
@@ -34,11 +35,6 @@ const STATUS_LABEL: Record<TemplateStatus, string> = {
 };
 
 // Estado y visibilidad: clases en `@maya/shared-ui-react/badges`.
-
-function formatDate(iso: string | null | undefined): string {
-  if (!iso) return '—';
-  return iso.slice(0, 10);
-}
 
 /**
  * Gestión de plantillas normativas: datos vía {@link useTemplates}.
@@ -152,8 +148,11 @@ export function TemplatesContent() {
       }
       out.push(publishedFallback);
     }
+    if (filters.delivery_deadline) {
+      return out.filter((row) => row.status !== 'published');
+    }
     return out;
-  }, [templates, profile?.id]);
+  }, [templates, profile?.id, filters.delivery_deadline]);
 
   const handleRowClick = (t: Template) => {
     if (t.list_variant === 'published_fallback' && t.latest_published_version_id) {
@@ -220,11 +219,11 @@ export function TemplatesContent() {
       },
       {
         id: 'delivery_deadline',
-        header: 'Fecha límite',
+        header: 'Fecha de validación',
         sortable: true,
         cell: (t) => (
           <span className="text-xs text-text-secondary dark:text-text-dark-secondary">
-            {formatDate(t.delivery_deadline)}
+            {t.status === 'published' ? '—' : formatCalendarDateForBrowser(t.delivery_deadline)}
           </span>
         ),
       },
@@ -352,12 +351,12 @@ export function TemplatesContent() {
                 onChange={handleAuthorChange}
               />
             </FilterField>
-            <FilterField label="Fecha límite">
+            <FilterField label="Fecha de validación (hasta)">
               <DatePicker
                 value={filterUi.deliveryDeadline || null}
                 onChange={(d) => applyFilters({ delivery_deadline: d ?? undefined })}
-                placeholder="Seleccionar fecha…"
-                ariaLabel="Filtrar por fecha límite"
+                placeholder="Cualquier plazo…"
+                ariaLabel="Plantillas no publicadas cuya fecha límite de validación sea esta fecha o anterior (las publicadas no aplican)"
               />
             </FilterField>
             {(showHierarchyFilter || showTeamFilter) && (

--- a/frontend/src/features/templates/components/TemplatesTable.tsx
+++ b/frontend/src/features/templates/components/TemplatesTable.tsx
@@ -15,9 +15,11 @@ import {
 } from '@maya/shared-ui-react';
 import { useTemplates } from '../hooks/useTemplates';
 import { buildTemplatesListMeta, sliceTemplatesPage } from '../clientTemplatePagination';
-import { FAVORITES_FILTER_OPTIONS, STATUS_OPTIONS, VISIBILITY_OPTIONS, visibilityLabel } from '../constants';
+import { FAVORITES_FILTER_OPTIONS, STATUS_OPTIONS, visibilityLabel } from '../constants';
 import type { Template, TemplateStatus, TemplateVisibilityLevel } from '../../../types/templates';
 import { useUserProfile } from '../../../features/user-profile';
+import { useHierarchy } from '../../../features/hierarchy';
+import { listRowSearchMatches } from '../../../utils/academicContextSearch';
 import { useFavoritesIds } from '../../../hooks/useFavoritesIds';
 import { FavoriteInlineMark } from '../../../components/FavoriteInlineMark';
 import { formatCalendarDateForBrowser } from '../../../utils/formatCalendarDate';
@@ -39,6 +41,7 @@ type Props = {
 export function TemplatesTable({ processId }: Props = {}) {
   const navigate = useNavigate();
   const { profile } = useUserProfile();
+  const { hierarchy } = useHierarchy();
 
   const { hiddenIds, toggleHidden, sortBy, setSortBy, pageSize, setPageSize } =
     useTablePreferences({ storageKey: 'maya:dms:templates-table' });
@@ -63,6 +66,10 @@ export function TemplatesTable({ processId }: Props = {}) {
   const [authorInput, setAuthorInput] = useState(filters.author_name ?? '');
   const authorDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  const [academicContextInput, setAcademicContextInput] = useState('');
+  const [academicContextFilter, setAcademicContextFilter] = useState('');
+  const academicContextDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   const listPage = filters.page ?? 1;
   const listPerPage = filters.per_page ?? 20;
 
@@ -75,8 +82,24 @@ export function TemplatesTable({ processId }: Props = {}) {
       const needle = nameFilter.toLowerCase();
       list = list.filter((t) => (t.name ?? '').toLowerCase().includes(needle));
     }
+    if (academicContextFilter.trim()) {
+      list = list.filter((t) =>
+        listRowSearchMatches(
+          hierarchy,
+          {
+            visibility_level: t.visibility_level,
+            study_type_id: t.study_type_id,
+            study_id: t.study_id,
+            module_id: t.module_id,
+            team_id: t.team_id,
+            team: t.team,
+          },
+          academicContextFilter,
+        ),
+      );
+    }
     return list;
-  }, [catalogSorted, favoritesFilter, nameFilter, favoriteTemplateIds]);
+  }, [catalogSorted, favoritesFilter, nameFilter, academicContextFilter, favoriteTemplateIds, hierarchy]);
 
   useEffect(() => {
     const last = Math.max(1, Math.ceil(clientFilteredCatalog.length / Math.max(1, listPerPage)));
@@ -134,7 +157,6 @@ export function TemplatesTable({ processId }: Props = {}) {
 
   const filterUi = useMemo(
     () => ({
-      visibility: filters.visibility_level ?? '',
       status: filters.status ?? '',
       deliveryDeadline: filters.delivery_deadline ?? '',
     }),
@@ -143,7 +165,7 @@ export function TemplatesTable({ processId }: Props = {}) {
 
   const filtersActiveCount =
     (favoritesFilter ? 1 : 0) +
-    [nameFilter, filterUi.visibility, filterUi.status, filterUi.deliveryDeadline, authorInput].filter((v) => v && v !== '')
+    [nameFilter, academicContextFilter, filterUi.status, filterUi.deliveryDeadline, authorInput].filter((v) => v && v !== '')
       .length;
 
   const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -164,11 +186,23 @@ export function TemplatesTable({ processId }: Props = {}) {
     }, 400);
   };
 
+  const handleAcademicContextChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setAcademicContextInput(value);
+    if (academicContextDebounceRef.current) clearTimeout(academicContextDebounceRef.current);
+    academicContextDebounceRef.current = setTimeout(() => {
+      setAcademicContextFilter(value);
+    }, 400);
+  };
+
   const clearFilters = () => {
     if (nameDebounceRef.current) clearTimeout(nameDebounceRef.current);
+    if (academicContextDebounceRef.current) clearTimeout(academicContextDebounceRef.current);
     if (authorDebounceRef.current) clearTimeout(authorDebounceRef.current);
     setNameInput('');
     setNameFilter('');
+    setAcademicContextInput('');
+    setAcademicContextFilter('');
     setFavoritesFilter('');
     setAuthorInput('');
     applyFilters({
@@ -308,21 +342,14 @@ export function TemplatesTable({ processId }: Props = {}) {
                 onChange={handleNameChange}
               />
             </FilterField>
-            <FilterField label="Visibilidad">
-              <Select
+            <FilterField label="Contexto académico">
+              <TextInput
                 fieldSize="sm"
-                value={filterUi.visibility}
-                onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
-                  applyFilters({ visibility_level: (e.target.value as any) || undefined })
-                }
-              >
-                <option value="">Todas</option>
-                {VISIBILITY_OPTIONS.map((o) => (
-                  <option key={o.value} value={o.value}>
-                    {o.label}
-                  </option>
-                ))}
-              </Select>
+                type="search"
+                placeholder="Global, personal, equipo, nombre de equipo o contexto académico…"
+                value={academicContextInput}
+                onChange={handleAcademicContextChange}
+              />
             </FilterField>
             <FilterField label="Estado">
               <Select

--- a/frontend/src/features/templates/components/TemplatesTable.tsx
+++ b/frontend/src/features/templates/components/TemplatesTable.tsx
@@ -119,6 +119,9 @@ export function TemplatesTable({ processId }: Props = {}) {
   );
 
   const displayTemplates = useMemo(() => {
+    /** Con filtro de estado ≠ publicada, no mostrar la fila sintética de última publicada (siempre `published`). */
+    const includePublishedFallbackRow = !filters.status || filters.status === 'published';
+
     const out: Template[] = [];
     for (const t of pagedCatalog) {
       const hasPublishedFallback =
@@ -147,13 +150,15 @@ export function TemplatesTable({ processId }: Props = {}) {
       if (canSeeLive) {
         out.push({ ...t, list_variant: 'live', list_row_id: `${t.id}:live` });
       }
-      out.push(publishedFallback);
+      if (includePublishedFallbackRow) {
+        out.push(publishedFallback);
+      }
     }
     if (filters.delivery_deadline) {
       return out.filter((row) => row.status !== 'published');
     }
     return out;
-  }, [pagedCatalog, profile?.id, filters.delivery_deadline]);
+  }, [pagedCatalog, profile?.id, filters.delivery_deadline, filters.status]);
 
   const filterUi = useMemo(
     () => ({

--- a/frontend/src/features/templates/components/TemplatesTable.tsx
+++ b/frontend/src/features/templates/components/TemplatesTable.tsx
@@ -43,8 +43,9 @@ export function TemplatesTable({ processId }: Props = {}) {
   const { profile } = useUserProfile();
   const { hierarchy } = useHierarchy();
 
-  const { hiddenIds, toggleHidden, sortBy, setSortBy, pageSize, setPageSize } =
-    useTablePreferences({ storageKey: 'maya:dms:templates-table' });
+  const { hiddenIds, toggleHidden, pageSize, setPageSize } = useTablePreferences({
+    storageKey: 'maya:dms:templates-table',
+  });
   const { templateIds: favoriteTemplateIds } = useFavoritesIds();
   const {
     catalogSorted,
@@ -55,7 +56,7 @@ export function TemplatesTable({ processId }: Props = {}) {
     clearActionError,
     applyFilters,
     goToPage,
-  } = useTemplates(processId, sortBy);
+  } = useTemplates(processId);
 
   const [nameInput, setNameInput] = useState('');
   const [nameFilter, setNameFilter] = useState('');
@@ -240,7 +241,6 @@ export function TemplatesTable({ processId }: Props = {}) {
       {
         id: 'name',
         header: 'Nombre',
-        sortable: true,
         alwaysVisible: true,
         cell: (t) => (
           <span className="flex items-center gap-2 min-w-0">
@@ -292,7 +292,6 @@ export function TemplatesTable({ processId }: Props = {}) {
       {
         id: 'status',
         header: 'Estado',
-        sortable: true,
         cell: (t) => {
           const status = t.status as TemplateStatus;
           return (
@@ -305,7 +304,6 @@ export function TemplatesTable({ processId }: Props = {}) {
       {
         id: 'delivery_deadline',
         header: 'Fecha de validación',
-        sortable: true,
         cell: (t) => (
           <span className="text-xs text-text-secondary dark:text-text-dark-secondary">
             {t.status === 'published' ? '—' : formatCalendarDateForBrowser(t.delivery_deadline)}
@@ -339,8 +337,6 @@ export function TemplatesTable({ processId }: Props = {}) {
         rowKey={(t) => t.list_row_id ?? t.id}
         hiddenColumnIds={hiddenIds}
         onToggleHiddenColumn={toggleHidden}
-        sortBy={sortBy}
-        onSortChange={setSortBy}
         pageSize={pageSize}
         onPageSizeChange={(size) => {
           setPageSize(size);

--- a/frontend/src/features/templates/components/TemplatesTable.tsx
+++ b/frontend/src/features/templates/components/TemplatesTable.tsx
@@ -20,6 +20,7 @@ import type { Template, TemplateStatus, TemplateVisibilityLevel } from '../../..
 import { useUserProfile } from '../../../features/user-profile';
 import { useFavoritesIds } from '../../../hooks/useFavoritesIds';
 import { FavoriteInlineMark } from '../../../components/FavoriteInlineMark';
+import { formatCalendarDateForBrowser } from '../../../utils/formatCalendarDate';
 
 const STATUS_LABEL: Record<TemplateStatus, string> = {
   draft: 'Borrador',
@@ -29,11 +30,6 @@ const STATUS_LABEL: Record<TemplateStatus, string> = {
 };
 
 // Estado y visibilidad: clases en `@maya/shared-ui-react/badges`.
-
-function formatDate(iso: string | null | undefined): string {
-  if (!iso) return '—';
-  return iso.slice(0, 10);
-}
 
 type Props = {
   /** Filtra el listado por proceso. No se expone en el panel de filtros. */
@@ -130,8 +126,11 @@ export function TemplatesTable({ processId }: Props = {}) {
       }
       out.push(publishedFallback);
     }
+    if (filters.delivery_deadline) {
+      return out.filter((row) => row.status !== 'published');
+    }
     return out;
-  }, [pagedCatalog, profile?.id]);
+  }, [pagedCatalog, profile?.id, filters.delivery_deadline]);
 
   const filterUi = useMemo(
     () => ({
@@ -252,11 +251,11 @@ export function TemplatesTable({ processId }: Props = {}) {
       },
       {
         id: 'delivery_deadline',
-        header: 'Fecha límite',
+        header: 'Fecha de validación',
         sortable: true,
         cell: (t) => (
           <span className="text-xs text-text-secondary dark:text-text-dark-secondary">
-            {formatDate(t.delivery_deadline)}
+            {t.status === 'published' ? '—' : formatCalendarDateForBrowser(t.delivery_deadline)}
           </span>
         ),
       },
@@ -364,14 +363,14 @@ export function TemplatesTable({ processId }: Props = {}) {
                 ))}
               </Select>
             </FilterField>
-            <FilterField label="Fecha límite">
+            <FilterField label="Fecha de validación (hasta)">
               <DatePicker
                 value={filterUi.deliveryDeadline || null}
                 onChange={(d: string | null) =>
-                  applyFilters({ delivery_deadline: d ?? undefined })
+                  applyFilters({ delivery_deadline: d ?? undefined, page: 1 })
                 }
-                placeholder="Cualquier fecha"
-                ariaLabel="Filtrar por fecha límite"
+                placeholder="Cualquier plazo…"
+                ariaLabel="Plantillas no publicadas cuya fecha límite de validación sea esta fecha o anterior (las publicadas no aplican)"
               />
             </FilterField>
           </>

--- a/frontend/src/features/templates/components/TemplatesTable.tsx
+++ b/frontend/src/features/templates/components/TemplatesTable.tsx
@@ -71,7 +71,7 @@ export function TemplatesTable({ processId }: Props = {}) {
   const academicContextDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const listPage = filters.page ?? 1;
-  const listPerPage = filters.per_page ?? 20;
+  const listPerPage = filters.per_page ?? pageSize;
 
   const clientFilteredCatalog = useMemo(() => {
     let list = catalogSorted;

--- a/frontend/src/features/templates/components/TemplatesTable.tsx
+++ b/frontend/src/features/templates/components/TemplatesTable.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
   Button,
@@ -14,7 +14,8 @@ import {
   type ColumnDef,
 } from '@maya/shared-ui-react';
 import { useTemplates } from '../hooks/useTemplates';
-import { STATUS_OPTIONS, VISIBILITY_OPTIONS, visibilityLabel } from '../constants';
+import { buildTemplatesListMeta, sliceTemplatesPage } from '../clientTemplatePagination';
+import { FAVORITES_FILTER_OPTIONS, STATUS_OPTIONS, VISIBILITY_OPTIONS, visibilityLabel } from '../constants';
 import type { Template, TemplateStatus, TemplateVisibilityLevel } from '../../../types/templates';
 import { useUserProfile } from '../../../features/user-profile';
 import { useFavoritesIds } from '../../../hooks/useFavoritesIds';
@@ -47,8 +48,7 @@ export function TemplatesTable({ processId }: Props = {}) {
     useTablePreferences({ storageKey: 'maya:dms:templates-table' });
   const { templateIds: favoriteTemplateIds } = useFavoritesIds();
   const {
-    templates,
-    meta,
+    catalogSorted,
     filters,
     loading,
     listError,
@@ -62,12 +62,46 @@ export function TemplatesTable({ processId }: Props = {}) {
   const [nameFilter, setNameFilter] = useState('');
   const nameDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  const [favoritesFilter, setFavoritesFilter] = useState('');
+
   const [authorInput, setAuthorInput] = useState(filters.author_name ?? '');
   const authorDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  const listPage = filters.page ?? 1;
+  const listPerPage = filters.per_page ?? 20;
+
+  const clientFilteredCatalog = useMemo(() => {
+    let list = catalogSorted;
+    if (favoritesFilter === 'favorites') {
+      list = list.filter((t) => favoriteTemplateIds.has(t.id));
+    }
+    if (nameFilter.trim()) {
+      const needle = nameFilter.toLowerCase();
+      list = list.filter((t) => (t.name ?? '').toLowerCase().includes(needle));
+    }
+    return list;
+  }, [catalogSorted, favoritesFilter, nameFilter, favoriteTemplateIds]);
+
+  useEffect(() => {
+    const last = Math.max(1, Math.ceil(clientFilteredCatalog.length / Math.max(1, listPerPage)));
+    if (listPage > last) {
+      applyFilters({ page: last });
+    }
+  }, [clientFilteredCatalog.length, listPage, listPerPage, applyFilters]);
+
+  const pagedCatalog = useMemo(
+    () => sliceTemplatesPage(clientFilteredCatalog, listPage, listPerPage),
+    [clientFilteredCatalog, listPage, listPerPage],
+  );
+
+  const meta = useMemo(
+    () => buildTemplatesListMeta(clientFilteredCatalog.length, listPage, listPerPage),
+    [clientFilteredCatalog.length, listPage, listPerPage],
+  );
+
   const displayTemplates = useMemo(() => {
     const out: Template[] = [];
-    for (const t of templates) {
+    for (const t of pagedCatalog) {
       const hasPublishedFallback =
         t.status !== 'published' &&
         !!t.latest_published_version_id;
@@ -97,13 +131,7 @@ export function TemplatesTable({ processId }: Props = {}) {
       out.push(publishedFallback);
     }
     return out;
-  }, [templates, profile?.id]);
-
-  const filteredTemplates = useMemo(() => {
-    if (!nameFilter) return displayTemplates;
-    const needle = nameFilter.toLowerCase();
-    return displayTemplates.filter((t) => (t.name ?? '').toLowerCase().includes(needle));
-  }, [displayTemplates, nameFilter]);
+  }, [pagedCatalog, profile?.id]);
 
   const filterUi = useMemo(
     () => ({
@@ -114,13 +142,10 @@ export function TemplatesTable({ processId }: Props = {}) {
     [filters],
   );
 
-  const filtersActiveCount = [
-    nameFilter,
-    filterUi.visibility,
-    filterUi.status,
-    filterUi.deliveryDeadline,
-    authorInput,
-  ].filter((v) => v && v !== '').length;
+  const filtersActiveCount =
+    (favoritesFilter ? 1 : 0) +
+    [nameFilter, filterUi.visibility, filterUi.status, filterUi.deliveryDeadline, authorInput].filter((v) => v && v !== '')
+      .length;
 
   const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
@@ -145,6 +170,7 @@ export function TemplatesTable({ processId }: Props = {}) {
     if (authorDebounceRef.current) clearTimeout(authorDebounceRef.current);
     setNameInput('');
     setNameFilter('');
+    setFavoritesFilter('');
     setAuthorInput('');
     applyFilters({
       visibility_level: undefined,
@@ -256,8 +282,8 @@ export function TemplatesTable({ processId }: Props = {}) {
 
       <DataTable<Template>
         columns={columns}
-        rows={filteredTemplates}
-        loading={loading && templates.length === 0}
+        rows={displayTemplates}
+        loading={loading && catalogSorted.length === 0}
         rowKey={(t) => t.list_row_id ?? t.id}
         hiddenColumnIds={hiddenIds}
         onToggleHiddenColumn={toggleHidden}
@@ -321,6 +347,22 @@ export function TemplatesTable({ processId }: Props = {}) {
                 value={authorInput}
                 onChange={handleAuthorChange}
               />
+            </FilterField>
+            <FilterField label="Favoritos">
+              <Select
+                fieldSize="sm"
+                value={favoritesFilter}
+                onChange={(e: React.ChangeEvent<HTMLSelectElement>) => {
+                  setFavoritesFilter(e.target.value);
+                  applyFilters({ page: 1 });
+                }}
+              >
+                {FAVORITES_FILTER_OPTIONS.map((o) => (
+                  <option key={o.value || 'all'} value={o.value}>
+                    {o.label}
+                  </option>
+                ))}
+              </Select>
             </FilterField>
             <FilterField label="Fecha límite">
               <DatePicker

--- a/frontend/src/features/templates/components/TemplatesTable.tsx
+++ b/frontend/src/features/templates/components/TemplatesTable.tsx
@@ -23,6 +23,7 @@ import { formatListRowVisibilityCaption, listRowSearchMatches } from '../../../u
 import { useFavoritesIds } from '../../../hooks/useFavoritesIds';
 import { FavoriteInlineMark } from '../../../components/FavoriteInlineMark';
 import { formatCalendarDateForBrowser } from '../../../utils/formatCalendarDate';
+import { normalizeForSearch } from '../../../utils/normalizeForSearch';
 
 const STATUS_LABEL: Record<TemplateStatus, string> = {
   draft: 'Borrador',
@@ -80,8 +81,8 @@ export function TemplatesTable({ processId }: Props = {}) {
       list = list.filter((t) => favoriteTemplateIds.has(t.id));
     }
     if (nameFilter.trim()) {
-      const needle = nameFilter.toLowerCase();
-      list = list.filter((t) => (t.name ?? '').toLowerCase().includes(needle));
+      const needle = normalizeForSearch(nameFilter.trim());
+      list = list.filter((t) => normalizeForSearch(t.name ?? '').includes(needle));
     }
     if (academicContextFilter.trim()) {
       list = list.filter((t) =>

--- a/frontend/src/features/templates/components/TemplatesTable.tsx
+++ b/frontend/src/features/templates/components/TemplatesTable.tsx
@@ -15,11 +15,11 @@ import {
 } from '@maya/shared-ui-react';
 import { useTemplates } from '../hooks/useTemplates';
 import { buildTemplatesListMeta, sliceTemplatesPage } from '../clientTemplatePagination';
-import { FAVORITES_FILTER_OPTIONS, STATUS_OPTIONS, visibilityLabel } from '../constants';
+import { FAVORITES_FILTER_OPTIONS, STATUS_OPTIONS } from '../constants';
 import type { Template, TemplateStatus, TemplateVisibilityLevel } from '../../../types/templates';
 import { useUserProfile } from '../../../features/user-profile';
 import { useHierarchy } from '../../../features/hierarchy';
-import { listRowSearchMatches } from '../../../utils/academicContextSearch';
+import { formatListRowVisibilityCaption, listRowSearchMatches } from '../../../utils/academicContextSearch';
 import { useFavoritesIds } from '../../../hooks/useFavoritesIds';
 import { FavoriteInlineMark } from '../../../components/FavoriteInlineMark';
 import { formatCalendarDateForBrowser } from '../../../utils/formatCalendarDate';
@@ -255,11 +255,25 @@ export function TemplatesTable({ processId }: Props = {}) {
       {
         id: 'visibility_level',
         header: 'Visibilidad',
-        cell: (t) => (
-          <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${visibilityBadgeClass(t.visibility_level as TemplateVisibilityLevel)}`}>
-            {visibilityLabel(t.visibility_level as TemplateVisibilityLevel)}
-          </span>
-        ),
+        cell: (t) => {
+          const level = t.visibility_level as TemplateVisibilityLevel;
+          const caption = formatListRowVisibilityCaption(hierarchy, {
+            visibility_level: level,
+            study_type_id: t.study_type_id,
+            study_id: t.study_id,
+            module_id: t.module_id,
+            team_id: t.team_id,
+            team: t.team,
+          });
+          return (
+            <span
+              className={`inline-flex max-w-full min-w-0 text-xs font-medium px-2 py-0.5 rounded-full ${visibilityBadgeClass(level)}`}
+              title={caption}
+            >
+              <span className="truncate">{caption}</span>
+            </span>
+          );
+        },
       },
       {
         id: 'author_name',
@@ -294,7 +308,7 @@ export function TemplatesTable({ processId }: Props = {}) {
         ),
       },
     ],
-    [profile, favoriteTemplateIds],
+    [profile, favoriteTemplateIds, hierarchy],
   );
 
   return (

--- a/frontend/src/features/templates/constants.ts
+++ b/frontend/src/features/templates/constants.ts
@@ -12,6 +12,7 @@ export const VISIBILITY_OPTIONS: { value: TemplateVisibilityLevel; label: string
 export const STATUS_OPTIONS = [
   { value: '', label: 'Todos' },
   { value: 'draft', label: 'Borrador' },
+  { value: 'in_review', label: 'En revisión' },
   { value: 'published', label: 'Publicada' },
   { value: 'archived', label: 'Archivada' },
 ] as const;
@@ -25,3 +26,4 @@ export const FAVORITES_FILTER_OPTIONS: { value: string; label: string }[] = [
 export function visibilityLabel(v: TemplateVisibilityLevel): string {
   return VISIBILITY_OPTIONS.find((o) => o.value === v)?.label ?? v;
 }
+

--- a/frontend/src/features/templates/constants.ts
+++ b/frontend/src/features/templates/constants.ts
@@ -16,6 +16,12 @@ export const STATUS_OPTIONS = [
   { value: 'archived', label: 'Archivada' },
 ] as const;
 
+/** Valor '' = todos; 'favorites' = solo favoritos del usuario (listados DMS). */
+export const FAVORITES_FILTER_OPTIONS: { value: string; label: string }[] = [
+  { value: '', label: 'Todos' },
+  { value: 'favorites', label: 'Solo favoritos' },
+];
+
 export function visibilityLabel(v: TemplateVisibilityLevel): string {
   return VISIBILITY_OPTIONS.find((o) => o.value === v)?.label ?? v;
 }

--- a/frontend/src/features/templates/hooks/useTemplates.ts
+++ b/frontend/src/features/templates/hooks/useTemplates.ts
@@ -63,6 +63,7 @@ export function useTemplates(processId?: string, sortBy?: { columnId: string; di
     filters.team_id,
     filters.author_name,
     filters.delivery_deadline,
+    filters.published_on,
     filters.process_id,
     processId,
   ]);

--- a/frontend/src/features/templates/hooks/useTemplates.ts
+++ b/frontend/src/features/templates/hooks/useTemplates.ts
@@ -40,7 +40,7 @@ const DEFAULT_PER_PAGE = 10;
  * @param processId Si se aporta, se aplica como filtro `process_id` permanente
  *   (no se expone en el panel de filtros — viene del contexto de la URL).
  */
-export function useTemplates(processId?: string, sortBy?: { columnId: string; direction: 'asc' | 'desc' } | null) {
+export function useTemplates(processId?: string) {
   const [fullList, setFullList] = useState<Template[]>([]);
   /** Sin `per_page` por defecto: las pantallas usan `filters.per_page ?? pageSize` (preferencias de tabla). */
   const [filters, setFilters] = useState<TemplateListFilters>({});
@@ -72,37 +72,9 @@ export function useTemplates(processId?: string, sortBy?: { columnId: string; di
   const page = filters.page ?? 1;
   const perPage = filters.per_page ?? DEFAULT_PER_PAGE;
 
-  const sortedList = useMemo(() => {
-    if (!sortBy) return fullList;
-    const { columnId, direction } = sortBy;
-    const dir = direction === 'asc' ? 1 : -1;
-
-    return [...fullList].sort((a, b) => {
-      let valA: string | number = '';
-      let valB: string | number = '';
-
-      if (columnId === 'name') {
-        return (a.name ?? '').localeCompare(b.name ?? '', 'es') * dir;
-      } else if (columnId === 'delivery_deadline') {
-        valA = a.status === 'published' ? '9999-12-31' : (a.delivery_deadline ?? '').slice(0, 10);
-        valB = b.status === 'published' ? '9999-12-31' : (b.delivery_deadline ?? '').slice(0, 10);
-      } else if (columnId === 'status') {
-        valA = a.status ?? '';
-        valB = b.status ?? '';
-      } else if (columnId === 'version') {
-        valA = a.version ?? 0;
-        valB = b.version ?? 0;
-      }
-
-      if (valA < valB) return -1 * dir;
-      if (valA > valB) return 1 * dir;
-      return 0;
-    });
-  }, [fullList, sortBy]);
-
   const templates = useMemo(
-    () => sliceTemplatesPage(sortedList, page, perPage),
-    [sortedList, page, perPage],
+    () => sliceTemplatesPage(fullList, page, perPage),
+    [fullList, page, perPage],
   );
 
   const meta = useMemo(
@@ -214,8 +186,8 @@ export function useTemplates(processId?: string, sortBy?: { columnId: string; di
 
   return {
     templates,
-    /** Lista completa ordenada (misma que alimenta la paginación en cliente). Útil para filtros adicionales en la tabla. */
-    catalogSorted: sortedList,
+    /** Catálogo completo en el orden devuelto por la API; la paginación/filtros extra son en cliente. */
+    catalogSorted: fullList,
     meta,
     filters,
     loading,

--- a/frontend/src/features/templates/hooks/useTemplates.ts
+++ b/frontend/src/features/templates/hooks/useTemplates.ts
@@ -31,7 +31,7 @@ function formatActionError(err: unknown): string {
   return err instanceof Error ? err.message : 'Error desconocido';
 }
 
-const DEFAULT_PER_PAGE = 20;
+const DEFAULT_PER_PAGE = 10;
 
 /**
  * Listado y mutaciones de plantillas normativas.
@@ -42,7 +42,8 @@ const DEFAULT_PER_PAGE = 20;
  */
 export function useTemplates(processId?: string, sortBy?: { columnId: string; direction: 'asc' | 'desc' } | null) {
   const [fullList, setFullList] = useState<Template[]>([]);
-  const [filters, setFilters] = useState<TemplateListFilters>({ per_page: DEFAULT_PER_PAGE });
+  /** Sin `per_page` por defecto: las pantallas usan `filters.per_page ?? pageSize` (preferencias de tabla). */
+  const [filters, setFilters] = useState<TemplateListFilters>({});
   const [loading, setLoading] = useState(true);
   const [listError, setListError] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
@@ -128,7 +129,14 @@ export function useTemplates(processId?: string, sortBy?: { columnId: string; di
   }, [load]);
 
   const applyFilters = useCallback((patch: Partial<TemplateListFilters>) => {
-    setFilters((f) => ({ ...f, ...patch, page: 1 }));
+    setFilters((f) => {
+      const next = { ...f, ...patch };
+      // Solo reiniciar a la página 1 cuando el cambio no fija ya `page` (p. ej. corrección al acortar el listado).
+      if (!Object.prototype.hasOwnProperty.call(patch, 'page')) {
+        next.page = 1;
+      }
+      return next;
+    });
   }, []);
 
   const goToPage = useCallback((page: number) => {

--- a/frontend/src/features/templates/hooks/useTemplates.ts
+++ b/frontend/src/features/templates/hooks/useTemplates.ts
@@ -205,6 +205,8 @@ export function useTemplates(processId?: string, sortBy?: { columnId: string; di
 
   return {
     templates,
+    /** Lista completa ordenada (misma que alimenta la paginación en cliente). Útil para filtros adicionales en la tabla. */
+    catalogSorted: sortedList,
     meta,
     filters,
     loading,

--- a/frontend/src/features/templates/hooks/useTemplates.ts
+++ b/frontend/src/features/templates/hooks/useTemplates.ts
@@ -83,8 +83,8 @@ export function useTemplates(processId?: string, sortBy?: { columnId: string; di
       if (columnId === 'name') {
         return (a.name ?? '').localeCompare(b.name ?? '', 'es') * dir;
       } else if (columnId === 'delivery_deadline') {
-        valA = a.delivery_deadline ?? '';
-        valB = b.delivery_deadline ?? '';
+        valA = a.status === 'published' ? '9999-12-31' : (a.delivery_deadline ?? '').slice(0, 10);
+        valB = b.status === 'published' ? '9999-12-31' : (b.delivery_deadline ?? '').slice(0, 10);
       } else if (columnId === 'status') {
         valA = a.status ?? '';
         valB = b.status ?? '';

--- a/frontend/src/pages/DocumentPreviewPage.tsx
+++ b/frontend/src/pages/DocumentPreviewPage.tsx
@@ -28,6 +28,7 @@ import { useUserProfile } from '../features/user-profile';
 import { PaperPreviewLayout } from '../features/documents/components/PaperPreviewLayout';
 import { PaperBlocksArticle, type PaperArticleBlock } from '../features/documents/components/PaperBlocksArticle';
 import type { Process } from '../types/processes';
+import { formatCalendarDateForBrowser } from '../utils/formatCalendarDate';
 
 // Estado: clases en `statusBadgeClass` (módulo `@maya/shared-ui-react/badges`).
 
@@ -41,11 +42,6 @@ function blockContentForPreview(block: DocumentDisplayBlock): unknown[] {
   const fromContent = normalizeBlockContentForEditor(block.content);
   if (fromContent.length > 0) return fromContent;
   return normalizeBlockContentForEditor(block.default_content);
-}
-
-function formatDate(iso: string | null | undefined): string {
-  if (!iso) return '—';
-  return iso.slice(0, 10);
 }
 
 const DOCUMENT_REJECT_REASON_MIN_LEN = 5;
@@ -644,9 +640,9 @@ export function DocumentPreviewPage({ mode = 'preview' }: Props = {}) {
       {' · '}
       {detail.visibility_level ? visibilityLabel(detail.visibility_level) : (detail.is_shared_with_me ? 'Compartida' : 'Personal')}
       {' · '}
-      Fecha límite: {formatDate(detail.delivery_deadline)}
+      Fecha límite: {formatCalendarDateForBrowser(detail.delivery_deadline)}
       {' · '}
-      Última edición: {formatDate(versionSnapshot?.createdAt ?? detail.updated_at)}
+      Última edición: {formatCalendarDateForBrowser(versionSnapshot?.createdAt ?? detail.updated_at)}
     </p>
   ) : null;
 

--- a/frontend/src/pages/NuevaProgramacionSelectorPage.tsx
+++ b/frontend/src/pages/NuevaProgramacionSelectorPage.tsx
@@ -24,9 +24,26 @@ import {
   type ColumnDef,
 } from '@maya/shared-ui-react';
 
-function formatDate(iso: string | null | undefined): string {
+/** Fecha corta según el locale del navegador (d-m-y con guiones). */
+function formatPublicationDateForLocale(iso: string | null | undefined): string {
   if (!iso) return '—';
-  return iso.slice(0, 10);
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '—';
+  const locale = typeof navigator !== 'undefined' && navigator.language ? navigator.language : 'es';
+  try {
+    const parts = new Intl.DateTimeFormat(locale, {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+    }).formatToParts(d);
+    const day = parts.find((p) => p.type === 'day')?.value ?? '';
+    const month = parts.find((p) => p.type === 'month')?.value ?? '';
+    const year = parts.find((p) => p.type === 'year')?.value ?? '';
+    if (!day || !month || !year) return '—';
+    return `${day}-${month}-${year}`;
+  } catch {
+    return '—';
+  }
 }
 
 export function NuevaProgramacionSelectorPage() {
@@ -82,7 +99,7 @@ export function NuevaProgramacionSelectorPage() {
           usable_for_documents: true,
           visibility_level: filters.visibility_level,
           author_name: filters.author_name,
-          delivery_deadline: filters.delivery_deadline,
+          published_on: filters.published_on,
           ...(selectedProcessId ? { process_id: selectedProcessId } : {}),
         });
         if (!cancelled) {
@@ -102,7 +119,7 @@ export function NuevaProgramacionSelectorPage() {
   }, [
     filters.visibility_level,
     filters.author_name,
-    filters.delivery_deadline,
+    filters.published_on,
     selectedProcessId,
   ]);
 
@@ -145,9 +162,9 @@ export function NuevaProgramacionSelectorPage() {
 
       if (columnId === 'name') {
         return (a.name ?? '').localeCompare(b.name ?? '', 'es') * dir;
-      } else if (columnId === 'delivery_deadline') {
-        valA = a.delivery_deadline ?? '';
-        valB = b.delivery_deadline ?? '';
+      } else if (columnId === 'latest_published_at') {
+        valA = a.latest_published_at ?? '';
+        valB = b.latest_published_at ?? '';
       } else if (columnId === 'version') {
         valA = a.version ?? 0;
         valB = b.version ?? 0;
@@ -209,12 +226,12 @@ export function NuevaProgramacionSelectorPage() {
         ),
       },
       {
-        id: 'delivery_deadline',
-        header: 'Fecha límite de validación',
+        id: 'latest_published_at',
+        header: 'Fecha de publicación',
         sortable: true,
         cell: (t) => (
           <span className="text-xs text-text-secondary dark:text-text-dark-secondary">
-            {formatDate(t.delivery_deadline)}
+            {formatPublicationDateForLocale(t.latest_published_at)}
           </span>
         ),
       },
@@ -263,14 +280,14 @@ export function NuevaProgramacionSelectorPage() {
   const filterUi = useMemo(
     () => ({
       visibility: filters.visibility_level ?? '',
-      deliveryDeadline: filters.delivery_deadline ?? '',
+      publishedOn: filters.published_on ?? '',
     }),
     [filters],
   );
 
   const filtersActiveCount =
     (favoritesFilter ? 1 : 0) +
-    [filters.visibility_level, filters.author_name, filters.delivery_deadline].filter(Boolean).length;
+    [filters.visibility_level, filters.author_name, filters.published_on].filter(Boolean).length;
 
   return (
     <div className="min-h-full overflow-y-auto p-6 space-y-4">
@@ -371,11 +388,12 @@ export function NuevaProgramacionSelectorPage() {
                 ))}
               </Select>
             </FilterField>
-            <FilterField label="Fecha límite de validación">
+            <FilterField label="Publicadas desde">
               <DatePicker
-                value={filterUi.deliveryDeadline || null}
-                onChange={(d) => applyFilters({ delivery_deadline: d ?? undefined })}
-                placeholder="Seleccionar fecha…"
+                value={filterUi.publishedOn || null}
+                onChange={(d) => applyFilters({ published_on: d ?? undefined })}
+                placeholder="Elegir día inicial…"
+                ariaLabel="Filtrar plantillas publicadas desde esta fecha (inclusive)"
               />
             </FilterField>
           </>

--- a/frontend/src/pages/NuevaProgramacionSelectorPage.tsx
+++ b/frontend/src/pages/NuevaProgramacionSelectorPage.tsx
@@ -6,12 +6,14 @@ import {
   buildTemplatesListMeta,
   sliceTemplatesPage,
 } from '../features/templates/clientTemplatePagination';
-import { FAVORITES_FILTER_OPTIONS, VISIBILITY_OPTIONS, visibilityLabel } from '../features/templates/constants';
+import { FAVORITES_FILTER_OPTIONS, visibilityLabel } from '../features/templates/constants';
 import type { Template, TemplateListFilters } from '../types/templates';
 import { useFavoritesIds } from '../hooks/useFavoritesIds';
 import { FavoriteInlineMark } from '../components/FavoriteInlineMark';
 import type { Process } from '../types/processes';
 import { formatCalendarDateForBrowser } from '../utils/formatCalendarDate';
+import { useHierarchy } from '../features/hierarchy';
+import { listRowSearchMatches } from '../utils/academicContextSearch';
 import {
   DataTable,
   DatePicker,
@@ -28,6 +30,7 @@ import {
 export function NuevaProgramacionSelectorPage() {
   const navigate = useNavigate();
   const location = useLocation();
+  const { hierarchy } = useHierarchy();
   const locationState = location.state as { moduleId?: string; processId?: string } | null;
   const selectedModuleId = locationState?.moduleId;
   const selectedProcessId = locationState?.processId;
@@ -48,6 +51,9 @@ export function NuevaProgramacionSelectorPage() {
   const [listError, setListError] = useState<string | null>(null);
   const [authorInput, setAuthorInput] = useState('');
   const authorDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [academicContextInput, setAcademicContextInput] = useState('');
+  const [academicContextFilter, setAcademicContextFilter] = useState('');
+  const academicContextDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     if (!selectedProcessId) {
@@ -76,7 +82,6 @@ export function NuevaProgramacionSelectorPage() {
       try {
         const res = await fetchTemplates({
           usable_for_documents: true,
-          visibility_level: filters.visibility_level,
           author_name: filters.author_name,
           published_on: filters.published_on,
           ...(selectedProcessId ? { process_id: selectedProcessId } : {}),
@@ -95,12 +100,7 @@ export function NuevaProgramacionSelectorPage() {
     };
     void load();
     return () => { cancelled = true; };
-  }, [
-    filters.visibility_level,
-    filters.author_name,
-    filters.published_on,
-    selectedProcessId,
-  ]);
+  }, [filters.author_name, filters.published_on, selectedProcessId]);
 
   const listPage = filters.page ?? 1;
   const listPerPage = filters.per_page ?? pageSize;
@@ -130,12 +130,30 @@ export function NuevaProgramacionSelectorPage() {
     return mappedTemplates.filter((t) => favoriteTemplateIds.has(t.id));
   }, [mappedTemplates, favoritesFilter, favoriteTemplateIds]);
 
+  const afterAcademicContext = useMemo(() => {
+    if (!academicContextFilter.trim()) return afterFavorites;
+    return afterFavorites.filter((t) =>
+      listRowSearchMatches(
+        hierarchy,
+        {
+          visibility_level: t.visibility_level,
+          study_type_id: t.study_type_id,
+          study_id: t.study_id,
+          module_id: t.module_id,
+          team_id: t.team_id,
+          team: t.team,
+        },
+        academicContextFilter,
+      ),
+    );
+  }, [afterFavorites, academicContextFilter, hierarchy]);
+
   const sortedTemplates = useMemo(() => {
-    if (!sortBy) return afterFavorites;
+    if (!sortBy) return afterAcademicContext;
     const { columnId, direction } = sortBy;
     const dir = direction === 'asc' ? 1 : -1;
 
-    return [...afterFavorites].sort((a, b) => {
+    return [...afterAcademicContext].sort((a, b) => {
       let valA: string | number = '';
       let valB: string | number = '';
 
@@ -153,7 +171,7 @@ export function NuevaProgramacionSelectorPage() {
       if (valA > valB) return 1 * dir;
       return 0;
     });
-  }, [afterFavorites, sortBy]);
+  }, [afterAcademicContext, sortBy]);
 
   useEffect(() => {
     const last = Math.max(1, Math.ceil(sortedTemplates.length / Math.max(1, listPerPage)));
@@ -249,16 +267,28 @@ export function NuevaProgramacionSelectorPage() {
     }, 400);
   };
 
+  const handleAcademicContextChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setAcademicContextInput(value);
+    if (academicContextDebounceRef.current) clearTimeout(academicContextDebounceRef.current);
+    academicContextDebounceRef.current = setTimeout(() => {
+      setAcademicContextFilter(value);
+      setFilters((f) => ({ ...f, page: 1 }));
+    }, 400);
+  };
+
   const clearFilters = () => {
     if (authorDebounceRef.current) clearTimeout(authorDebounceRef.current);
+    if (academicContextDebounceRef.current) clearTimeout(academicContextDebounceRef.current);
     setAuthorInput('');
+    setAcademicContextInput('');
+    setAcademicContextFilter('');
     setFavoritesFilter('');
     setFilters({ usable_for_documents: true, per_page: pageSize, page: 1 });
   };
 
   const filterUi = useMemo(
     () => ({
-      visibility: filters.visibility_level ?? '',
       publishedOn: filters.published_on ?? '',
     }),
     [filters],
@@ -266,7 +296,7 @@ export function NuevaProgramacionSelectorPage() {
 
   const filtersActiveCount =
     (favoritesFilter ? 1 : 0) +
-    [filters.visibility_level, filters.author_name, filters.published_on].filter(Boolean).length;
+    [academicContextFilter, filters.author_name, filters.published_on].filter((v) => v && String(v).trim() !== '').length;
 
   return (
     <div className="min-h-full overflow-y-auto p-6 space-y-4">
@@ -326,17 +356,14 @@ export function NuevaProgramacionSelectorPage() {
         }}
         filtersPanel={
           <>
-            <FilterField label="Visibilidad">
-              <Select
+            <FilterField label="Contexto académico">
+              <TextInput
                 fieldSize="sm"
-                value={filterUi.visibility}
-                onChange={(e) => applyFilters({ visibility_level: e.target.value || undefined })}
-              >
-                <option value="">Todas</option>
-                {VISIBILITY_OPTIONS.map((o) => (
-                  <option key={o.value} value={o.value}>{o.label}</option>
-                ))}
-              </Select>
+                type="search"
+                placeholder="Global, personal, equipo, nombre de equipo o contexto académico…"
+                value={academicContextInput}
+                onChange={handleAcademicContextChange}
+              />
             </FilterField>
             <FilterField label="Autor">
               <TextInput

--- a/frontend/src/pages/NuevaProgramacionSelectorPage.tsx
+++ b/frontend/src/pages/NuevaProgramacionSelectorPage.tsx
@@ -6,14 +6,14 @@ import {
   buildTemplatesListMeta,
   sliceTemplatesPage,
 } from '../features/templates/clientTemplatePagination';
-import { FAVORITES_FILTER_OPTIONS, visibilityLabel } from '../features/templates/constants';
+import { FAVORITES_FILTER_OPTIONS } from '../features/templates/constants';
 import type { Template, TemplateListFilters } from '../types/templates';
 import { useFavoritesIds } from '../hooks/useFavoritesIds';
 import { FavoriteInlineMark } from '../components/FavoriteInlineMark';
 import type { Process } from '../types/processes';
 import { formatCalendarDateForBrowser } from '../utils/formatCalendarDate';
 import { useHierarchy } from '../features/hierarchy';
-import { listRowSearchMatches } from '../utils/academicContextSearch';
+import { formatListRowVisibilityCaption, listRowSearchMatches } from '../utils/academicContextSearch';
 import {
   DataTable,
   DatePicker,
@@ -207,11 +207,24 @@ export function NuevaProgramacionSelectorPage() {
       {
         id: 'visibility_level',
         header: 'Visibilidad',
-        cell: (t) => (
-          <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${visibilityBadgeClass(t.visibility_level)}`}>
-            {visibilityLabel(t.visibility_level)}
-          </span>
-        ),
+        cell: (t) => {
+          const caption = formatListRowVisibilityCaption(hierarchy, {
+            visibility_level: t.visibility_level,
+            study_type_id: t.study_type_id,
+            study_id: t.study_id,
+            module_id: t.module_id,
+            team_id: t.team_id,
+            team: t.team,
+          });
+          return (
+            <span
+              className={`inline-flex max-w-full min-w-0 text-xs font-medium px-2 py-0.5 rounded-full ${visibilityBadgeClass(t.visibility_level)}`}
+              title={caption}
+            >
+              <span className="truncate">{caption}</span>
+            </span>
+          );
+        },
       },
       {
         id: 'author_name',
@@ -240,7 +253,7 @@ export function NuevaProgramacionSelectorPage() {
         ),
       },
     ],
-    [favoriteTemplateIds],
+    [favoriteTemplateIds, hierarchy],
   );
 
   useEffect(() => {

--- a/frontend/src/pages/NuevaProgramacionSelectorPage.tsx
+++ b/frontend/src/pages/NuevaProgramacionSelectorPage.tsx
@@ -6,8 +6,10 @@ import {
   buildTemplatesListMeta,
   sliceTemplatesPage,
 } from '../features/templates/clientTemplatePagination';
-import { VISIBILITY_OPTIONS, visibilityLabel } from '../features/templates/constants';
+import { FAVORITES_FILTER_OPTIONS, VISIBILITY_OPTIONS, visibilityLabel } from '../features/templates/constants';
 import type { Template, TemplateListFilters } from '../types/templates';
+import { useFavoritesIds } from '../hooks/useFavoritesIds';
+import { FavoriteInlineMark } from '../components/FavoriteInlineMark';
 import type { Process } from '../types/processes';
 import {
   DataTable,
@@ -27,51 +29,6 @@ function formatDate(iso: string | null | undefined): string {
   return iso.slice(0, 10);
 }
 
-const COLUMNS: ColumnDef<Template>[] = [
-  {
-    id: 'name',
-    header: 'Nombre',
-    alwaysVisible: true,
-    cell: (t) => <span className="font-medium">{t.name}</span>,
-    sortable: true,
-  },
-  {
-    id: 'visibility_level',
-    header: 'Visibilidad',
-    cell: (t) => (
-      <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${visibilityBadgeClass(t.visibility_level)}`}>
-        {visibilityLabel(t.visibility_level)}
-      </span>
-    ),
-  },
-  {
-    id: 'author_name',
-    header: 'Autor',
-    cell: (t) => (
-      <span className="text-xs text-text-secondary dark:text-text-dark-secondary">
-        {t.author_name ?? '—'}
-      </span>
-    ),
-  },
-  {
-    id: 'delivery_deadline',
-    header: 'Fecha límite de validación',
-    sortable: true,
-    cell: (t) => (
-      <span className="text-xs text-text-secondary dark:text-text-dark-secondary">
-        {formatDate(t.delivery_deadline)}
-      </span>
-    ),
-  },
-  {
-    id: 'version',
-    header: 'Versión',
-    cell: (t) => (
-      <span className="text-xs text-text-secondary dark:text-text-dark-secondary">v{t.version}</span>
-    ),
-  },
-];
-
 export function NuevaProgramacionSelectorPage() {
   const navigate = useNavigate();
   const location = useLocation();
@@ -83,7 +40,9 @@ export function NuevaProgramacionSelectorPage() {
   const { hiddenIds, toggleHidden, sortBy, setSortBy, pageSize, setPageSize } = useTablePreferences({
     storageKey: 'maya:dms:nueva-programacion-selector',
   });
+  const { templateIds: favoriteTemplateIds } = useFavoritesIds();
 
+  const [favoritesFilter, setFavoritesFilter] = useState('');
   const [filters, setFilters] = useState<TemplateListFilters>({
     usable_for_documents: true,
     per_page: pageSize,
@@ -150,8 +109,8 @@ export function NuevaProgramacionSelectorPage() {
   const listPage = filters.page ?? 1;
   const listPerPage = filters.per_page ?? pageSize;
 
-  const sortedTemplates = useMemo(() => {
-    const displayTemplates = allTemplates.map((t) => {
+  const mappedTemplates = useMemo(() => {
+    return allTemplates.map((t) => {
       if (t.status !== 'published' && t.latest_published_version_id) {
         return {
           ...t,
@@ -168,12 +127,19 @@ export function NuevaProgramacionSelectorPage() {
         list_row_id: `${t.id}:live`,
       };
     });
+  }, [allTemplates]);
 
-    if (!sortBy) return displayTemplates;
+  const afterFavorites = useMemo(() => {
+    if (favoritesFilter !== 'favorites') return mappedTemplates;
+    return mappedTemplates.filter((t) => favoriteTemplateIds.has(t.id));
+  }, [mappedTemplates, favoritesFilter, favoriteTemplateIds]);
+
+  const sortedTemplates = useMemo(() => {
+    if (!sortBy) return afterFavorites;
     const { columnId, direction } = sortBy;
     const dir = direction === 'asc' ? 1 : -1;
 
-    return [...displayTemplates].sort((a, b) => {
+    return [...afterFavorites].sort((a, b) => {
       let valA: string | number = '';
       let valB: string | number = '';
 
@@ -191,7 +157,14 @@ export function NuevaProgramacionSelectorPage() {
       if (valA > valB) return 1 * dir;
       return 0;
     });
-  }, [allTemplates, sortBy]);
+  }, [afterFavorites, sortBy]);
+
+  useEffect(() => {
+    const last = Math.max(1, Math.ceil(sortedTemplates.length / Math.max(1, listPerPage)));
+    if (listPage > last) {
+      setFilters((f) => ({ ...f, page: last }));
+    }
+  }, [sortedTemplates.length, listPage, listPerPage]);
 
   const templates = useMemo(
     () => sliceTemplatesPage(sortedTemplates, listPage, listPerPage),
@@ -199,8 +172,61 @@ export function NuevaProgramacionSelectorPage() {
   );
 
   const meta = useMemo(
-    () => buildTemplatesListMeta(allTemplates.length, listPage, listPerPage),
-    [allTemplates.length, listPage, listPerPage],
+    () => buildTemplatesListMeta(sortedTemplates.length, listPage, listPerPage),
+    [sortedTemplates.length, listPage, listPerPage],
+  );
+
+  const columns: ColumnDef<Template>[] = useMemo(
+    () => [
+      {
+        id: 'name',
+        header: 'Nombre',
+        alwaysVisible: true,
+        cell: (t) => (
+          <span className="flex items-center gap-2 min-w-0">
+            {favoriteTemplateIds.has(t.id) && <FavoriteInlineMark />}
+            <span className="truncate font-medium">{t.name}</span>
+          </span>
+        ),
+        sortable: true,
+      },
+      {
+        id: 'visibility_level',
+        header: 'Visibilidad',
+        cell: (t) => (
+          <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${visibilityBadgeClass(t.visibility_level)}`}>
+            {visibilityLabel(t.visibility_level)}
+          </span>
+        ),
+      },
+      {
+        id: 'author_name',
+        header: 'Autor',
+        cell: (t) => (
+          <span className="text-xs text-text-secondary dark:text-text-dark-secondary">
+            {t.author_name ?? '—'}
+          </span>
+        ),
+      },
+      {
+        id: 'delivery_deadline',
+        header: 'Fecha límite de validación',
+        sortable: true,
+        cell: (t) => (
+          <span className="text-xs text-text-secondary dark:text-text-dark-secondary">
+            {formatDate(t.delivery_deadline)}
+          </span>
+        ),
+      },
+      {
+        id: 'version',
+        header: 'Versión',
+        cell: (t) => (
+          <span className="text-xs text-text-secondary dark:text-text-dark-secondary">v{t.version}</span>
+        ),
+      },
+    ],
+    [favoriteTemplateIds],
   );
 
   useEffect(() => {
@@ -230,6 +256,7 @@ export function NuevaProgramacionSelectorPage() {
   const clearFilters = () => {
     if (authorDebounceRef.current) clearTimeout(authorDebounceRef.current);
     setAuthorInput('');
+    setFavoritesFilter('');
     setFilters({ usable_for_documents: true, per_page: pageSize, page: 1 });
   };
 
@@ -241,11 +268,9 @@ export function NuevaProgramacionSelectorPage() {
     [filters],
   );
 
-  const filtersActiveCount = [
-    filters.visibility_level,
-    filters.author_name,
-    filters.delivery_deadline,
-  ].filter(Boolean).length;
+  const filtersActiveCount =
+    (favoritesFilter ? 1 : 0) +
+    [filters.visibility_level, filters.author_name, filters.delivery_deadline].filter(Boolean).length;
 
   return (
     <div className="min-h-full overflow-y-auto p-6 space-y-4">
@@ -271,10 +296,10 @@ export function NuevaProgramacionSelectorPage() {
       )}
 
       <DataTable
-        columns={COLUMNS}
+        columns={columns}
         rows={templates}
         loading={loading}
-        rowKey={(t) => t.id}
+        rowKey={(t) => t.list_row_id ?? t.id}
         hiddenColumnIds={hiddenIds}
         onToggleHiddenColumn={toggleHidden}
         pageSize={pageSize}
@@ -329,6 +354,22 @@ export function NuevaProgramacionSelectorPage() {
                 value={authorInput}
                 onChange={handleAuthorChange}
               />
+            </FilterField>
+            <FilterField label="Favoritos">
+              <Select
+                fieldSize="sm"
+                value={favoritesFilter}
+                onChange={(e) => {
+                  setFavoritesFilter(e.target.value);
+                  setFilters((f) => ({ ...f, page: 1 }));
+                }}
+              >
+                {FAVORITES_FILTER_OPTIONS.map((o) => (
+                  <option key={o.value || 'all'} value={o.value}>
+                    {o.label}
+                  </option>
+                ))}
+              </Select>
             </FilterField>
             <FilterField label="Fecha límite de validación">
               <DatePicker

--- a/frontend/src/pages/NuevaProgramacionSelectorPage.tsx
+++ b/frontend/src/pages/NuevaProgramacionSelectorPage.tsx
@@ -338,11 +338,6 @@ export function NuevaProgramacionSelectorPage() {
                 ))}
               </Select>
             </FilterField>
-            <FilterField label="Estado">
-              <Select fieldSize="sm" value="published" disabled>
-                <option value="published">Publicada</option>
-              </Select>
-            </FilterField>
             <FilterField label="Autor">
               <TextInput
                 fieldSize="sm"

--- a/frontend/src/pages/NuevaProgramacionSelectorPage.tsx
+++ b/frontend/src/pages/NuevaProgramacionSelectorPage.tsx
@@ -11,6 +11,7 @@ import type { Template, TemplateListFilters } from '../types/templates';
 import { useFavoritesIds } from '../hooks/useFavoritesIds';
 import { FavoriteInlineMark } from '../components/FavoriteInlineMark';
 import type { Process } from '../types/processes';
+import { formatCalendarDateForBrowser } from '../utils/formatCalendarDate';
 import {
   DataTable,
   DatePicker,
@@ -23,28 +24,6 @@ import {
   visibilityBadgeClass,
   type ColumnDef,
 } from '@maya/shared-ui-react';
-
-/** Fecha corta según el locale del navegador (d-m-y con guiones). */
-function formatPublicationDateForLocale(iso: string | null | undefined): string {
-  if (!iso) return '—';
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return '—';
-  const locale = typeof navigator !== 'undefined' && navigator.language ? navigator.language : 'es';
-  try {
-    const parts = new Intl.DateTimeFormat(locale, {
-      day: '2-digit',
-      month: '2-digit',
-      year: 'numeric',
-    }).formatToParts(d);
-    const day = parts.find((p) => p.type === 'day')?.value ?? '';
-    const month = parts.find((p) => p.type === 'month')?.value ?? '';
-    const year = parts.find((p) => p.type === 'year')?.value ?? '';
-    if (!day || !month || !year) return '—';
-    return `${day}-${month}-${year}`;
-  } catch {
-    return '—';
-  }
-}
 
 export function NuevaProgramacionSelectorPage() {
   const navigate = useNavigate();
@@ -231,7 +210,7 @@ export function NuevaProgramacionSelectorPage() {
         sortable: true,
         cell: (t) => (
           <span className="text-xs text-text-secondary dark:text-text-dark-secondary">
-            {formatPublicationDateForLocale(t.latest_published_at)}
+            {formatCalendarDateForBrowser(t.latest_published_at)}
           </span>
         ),
       },

--- a/frontend/src/pages/NuevaProgramacionSelectorPage.tsx
+++ b/frontend/src/pages/NuevaProgramacionSelectorPage.tsx
@@ -36,7 +36,7 @@ export function NuevaProgramacionSelectorPage() {
   const selectedProcessId = locationState?.processId;
   const [process, setProcess] = useState<Process | null>(null);
 
-  const { hiddenIds, toggleHidden, sortBy, setSortBy, pageSize, setPageSize } = useTablePreferences({
+  const { hiddenIds, toggleHidden, pageSize, setPageSize } = useTablePreferences({
     storageKey: 'maya:dms:nueva-programacion-selector',
   });
   const { templateIds: favoriteTemplateIds } = useFavoritesIds();
@@ -148,46 +148,21 @@ export function NuevaProgramacionSelectorPage() {
     );
   }, [afterFavorites, academicContextFilter, hierarchy]);
 
-  const sortedTemplates = useMemo(() => {
-    if (!sortBy) return afterAcademicContext;
-    const { columnId, direction } = sortBy;
-    const dir = direction === 'asc' ? 1 : -1;
-
-    return [...afterAcademicContext].sort((a, b) => {
-      let valA: string | number = '';
-      let valB: string | number = '';
-
-      if (columnId === 'name') {
-        return (a.name ?? '').localeCompare(b.name ?? '', 'es') * dir;
-      } else if (columnId === 'latest_published_at') {
-        valA = a.latest_published_at ?? '';
-        valB = b.latest_published_at ?? '';
-      } else if (columnId === 'version') {
-        valA = a.version ?? 0;
-        valB = b.version ?? 0;
-      }
-
-      if (valA < valB) return -1 * dir;
-      if (valA > valB) return 1 * dir;
-      return 0;
-    });
-  }, [afterAcademicContext, sortBy]);
-
   useEffect(() => {
-    const last = Math.max(1, Math.ceil(sortedTemplates.length / Math.max(1, listPerPage)));
+    const last = Math.max(1, Math.ceil(afterAcademicContext.length / Math.max(1, listPerPage)));
     if (listPage > last) {
       setFilters((f) => ({ ...f, page: last }));
     }
-  }, [sortedTemplates.length, listPage, listPerPage]);
+  }, [afterAcademicContext.length, listPage, listPerPage]);
 
   const templates = useMemo(
-    () => sliceTemplatesPage(sortedTemplates, listPage, listPerPage),
-    [sortedTemplates, listPage, listPerPage],
+    () => sliceTemplatesPage(afterAcademicContext, listPage, listPerPage),
+    [afterAcademicContext, listPage, listPerPage],
   );
 
   const meta = useMemo(
-    () => buildTemplatesListMeta(sortedTemplates.length, listPage, listPerPage),
-    [sortedTemplates.length, listPage, listPerPage],
+    () => buildTemplatesListMeta(afterAcademicContext.length, listPage, listPerPage),
+    [afterAcademicContext.length, listPage, listPerPage],
   );
 
   const columns: ColumnDef<Template>[] = useMemo(
@@ -202,7 +177,6 @@ export function NuevaProgramacionSelectorPage() {
             <span className="truncate font-medium">{t.name}</span>
           </span>
         ),
-        sortable: true,
       },
       {
         id: 'visibility_level',
@@ -238,7 +212,6 @@ export function NuevaProgramacionSelectorPage() {
       {
         id: 'latest_published_at',
         header: 'Fecha de publicación',
-        sortable: true,
         cell: (t) => (
           <span className="text-xs text-text-secondary dark:text-text-dark-secondary">
             {formatCalendarDateForBrowser(t.latest_published_at)}
@@ -343,8 +316,6 @@ export function NuevaProgramacionSelectorPage() {
         onToggleHiddenColumn={toggleHidden}
         pageSize={pageSize}
         onPageSizeChange={setPageSize}
-        sortBy={sortBy}
-        onSortChange={setSortBy}
         emptyMessage="No hay plantillas utilizables para crear documentos con los filtros actuales."
         filtersActiveCount={filtersActiveCount}
         onClearFilters={clearFilters}

--- a/frontend/src/pages/TemplatePreviewPage.tsx
+++ b/frontend/src/pages/TemplatePreviewPage.tsx
@@ -24,6 +24,7 @@ import { FavoriteButton } from '../components/FavoriteButton';
 import { VersionHistoryPanel } from '../components/VersionHistoryPanel';
 import { useUserProfile } from '../features/user-profile';
 import { useHierarchy } from '../features/hierarchy';
+import { formatCalendarDateForBrowser } from '../utils/formatCalendarDate';
 import { BlockCommentsCard } from '../features/templates/components/BlockCommentsCard';
 import type { BlockComment } from '../features/templates/components/BlockCommentsCard';
 
@@ -46,11 +47,6 @@ function blockContentNodes(block: TemplateBlock): unknown[] {
     return [];
   }
   return [];
-}
-
-function formatDate(iso: string | null | undefined): string {
-  if (!iso) return '—';
-  return iso.slice(0, 10);
 }
 
 function isTemplateVisibilityLevel(
@@ -535,9 +531,9 @@ export function TemplatePreviewPage() {
         <> ({template.team?.name ?? template.team_id})</>
       ) : null}
       {' · '}
-      Fecha límite de validación: {formatDate(displayDeadline)}
+      Fecha límite de validación: {formatCalendarDateForBrowser(displayDeadline)}
       {' · '}
-      Última edición: {formatDate(displayUpdatedAt)}
+      Última edición: {formatCalendarDateForBrowser(displayUpdatedAt)}
     </p>
   ) : null;
 

--- a/frontend/src/types/templates.ts
+++ b/frontend/src/types/templates.ts
@@ -60,6 +60,8 @@ export type Template = {
   created_at?: string;
   updated_at?: string;
   latest_published_name?: string | null;
+  /** Fecha de publicación de la versión publicada más reciente (solo listado / adjunta en índice). */
+  latest_published_at?: string | null;
 };
 
 export type TemplatesListMeta = {
@@ -85,6 +87,8 @@ export type TemplateListFilters = {
   team_id?: string;
   author_name?: string;
   delivery_deadline?: string;
+  /** Filtro por día de publicación de la última versión publicada (Y-m-d). */
+  published_on?: string;
   process_id?: string;
   page?: number;
   per_page?: number;

--- a/frontend/src/types/templates.ts
+++ b/frontend/src/types/templates.ts
@@ -86,6 +86,7 @@ export type TemplateListFilters = {
   module_id?: string;
   team_id?: string;
   author_name?: string;
+  /** Y-m-d: plantillas con fecha límite de validación en esa fecha o anterior (inclusive). */
   delivery_deadline?: string;
   /** Filtro por día de publicación de la última versión publicada (Y-m-d). */
   published_on?: string;

--- a/frontend/src/utils/academicContextSearch.ts
+++ b/frontend/src/utils/academicContextSearch.ts
@@ -1,0 +1,96 @@
+import type { AcademicHierarchy } from '../types/hierarchy';
+import type { TemplateVisibilityLevel } from '../types/templates';
+import { visibilityLabel } from '../features/templates/constants';
+
+export type AcademicContextLinkFields = {
+  study_type_id?: string | null;
+  study_id?: string | null;
+  module_id?: string | null;
+  team_id?: string | null;
+  /** Objeto `team` tal como lo devuelve el API (p. ej. DocumentResource / TemplateResource). */
+  team?: unknown;
+};
+
+/** Campos para búsqueda unificada: visibilidad + contexto académico + equipo (nombre e id). */
+export type ListRowSearchFields = AcademicContextLinkFields & {
+  visibility_level?: TemplateVisibilityLevel | null;
+};
+
+function teamDisplayName(team: unknown): string | null {
+  if (!team || typeof team !== 'object') return null;
+  const name = (team as { name?: unknown }).name;
+  return typeof name === 'string' && name.trim() ? name.trim() : null;
+}
+
+/**
+ * Texto en minúsculas para búsqueda por subcadena: nombres de jerarquía resueltos + UUIDs + nombre de equipo si existe.
+ */
+export function academicContextSearchHaystack(
+  hierarchy: AcademicHierarchy,
+  fields: AcademicContextLinkFields,
+): string {
+  const parts: string[] = [];
+  const stId = fields.study_type_id;
+  if (stId) {
+    const st = hierarchy.find((t) => String(t.id) === String(stId));
+    if (st?.name) parts.push(st.name);
+    parts.push(String(stId));
+  }
+  const sid = fields.study_id;
+  if (sid) {
+    for (const st of hierarchy) {
+      const s = st.studies.find((x) => String(x.id) === String(sid));
+      if (s?.name) {
+        parts.push(s.name);
+        break;
+      }
+    }
+    parts.push(String(sid));
+  }
+  const mid = fields.module_id;
+  if (mid) {
+    outer: for (const st of hierarchy) {
+      for (const s of st.studies) {
+        const m = s.course_modules.find((x) => String(x.id) === String(mid));
+        if (m?.name) {
+          parts.push(m.name);
+          break outer;
+        }
+      }
+    }
+    parts.push(String(mid));
+  }
+  if (fields.team_id) {
+    const embedded = teamDisplayName(fields.team);
+    if (embedded) parts.push(embedded);
+    parts.push(String(fields.team_id));
+  }
+  return parts.join(' ').toLowerCase();
+}
+
+function visibilitySearchFragments(level: TemplateVisibilityLevel | null | undefined): string[] {
+  if (level == null) return [];
+  const resolved = level as TemplateVisibilityLevel;
+  return [visibilityLabel(resolved), String(resolved)];
+}
+
+/**
+ * Texto en minúsculas: etiqueta y slug de visibilidad + contexto académico + nombre/id de equipo cuando aplica.
+ */
+export function listRowSearchHaystack(hierarchy: AcademicHierarchy, fields: ListRowSearchFields): string {
+  const visParts = visibilitySearchFragments(fields.visibility_level);
+  const academic = academicContextSearchHaystack(hierarchy, fields);
+  return [...visParts, academic].join(' ').toLowerCase();
+}
+
+/** Búsqueda insensible a mayúsculas: global/personal/equipo/…, nombre de equipo, jerarquía académica visible. */
+export function listRowSearchMatches(
+  hierarchy: AcademicHierarchy,
+  fields: ListRowSearchFields,
+  needle: string,
+): boolean {
+  const n = needle.trim().toLowerCase();
+  if (!n) return true;
+  return listRowSearchHaystack(hierarchy, fields).includes(n);
+}
+

--- a/frontend/src/utils/academicContextSearch.ts
+++ b/frontend/src/utils/academicContextSearch.ts
@@ -22,6 +22,68 @@ function teamDisplayName(team: unknown): string | null {
   return typeof name === 'string' && name.trim() ? name.trim() : null;
 }
 
+function resolveStudyTypeName(hierarchy: AcademicHierarchy, studyTypeId: string | null | undefined): string | null {
+  if (!studyTypeId) return null;
+  const st = hierarchy.find((t) => String(t.id) === String(studyTypeId));
+  return st?.name?.trim() ? st.name.trim() : null;
+}
+
+function resolveStudyName(hierarchy: AcademicHierarchy, studyId: string | null | undefined): string | null {
+  if (!studyId) return null;
+  for (const st of hierarchy) {
+    const s = st.studies.find((x) => String(x.id) === String(studyId));
+    if (s?.name?.trim()) return s.name.trim();
+  }
+  return null;
+}
+
+function resolveModuleName(hierarchy: AcademicHierarchy, moduleId: string | null | undefined): string | null {
+  if (!moduleId) return null;
+  for (const st of hierarchy) {
+    for (const s of st.studies) {
+      const m = s.course_modules.find((x) => String(x.id) === String(moduleId));
+      if (m?.name?.trim()) return m.name.trim();
+    }
+  }
+  return null;
+}
+
+/**
+ * Texto para columna «Visibilidad»: etiqueta de nivel + solo el vínculo de ese nivel
+ * (p. ej. `Módulo · Biología`), sin el resto de la jerarquía académica.
+ */
+export function formatListRowVisibilityCaption(
+  hierarchy: AcademicHierarchy,
+  fields: ListRowSearchFields,
+): string {
+  if (fields.visibility_level == null) {
+    return '—';
+  }
+  const level = fields.visibility_level;
+  const label = visibilityLabel(level);
+  const teamNm = teamDisplayName(fields.team);
+
+  if (level === 'global' || level === 'personal') {
+    return label;
+  }
+  if (level === 'team') {
+    return teamNm ? `${label} · ${teamNm}` : label;
+  }
+  if (level === 'study_type') {
+    const n = resolveStudyTypeName(hierarchy, fields.study_type_id);
+    return n ? `${label} · ${n}` : label;
+  }
+  if (level === 'study') {
+    const n = resolveStudyName(hierarchy, fields.study_id);
+    return n ? `${label} · ${n}` : label;
+  }
+  if (level === 'module') {
+    const n = resolveModuleName(hierarchy, fields.module_id);
+    return n ? `${label} · ${n}` : label;
+  }
+  return label;
+}
+
 /**
  * Texto en minúsculas para búsqueda por subcadena: nombres de jerarquía resueltos + UUIDs + nombre de equipo si existe.
  */

--- a/frontend/src/utils/academicContextSearch.ts
+++ b/frontend/src/utils/academicContextSearch.ts
@@ -1,4 +1,5 @@
 import type { AcademicHierarchy } from '../types/hierarchy';
+import { normalizeForSearch } from './normalizeForSearch';
 import type { TemplateVisibilityLevel } from '../types/templates';
 import { visibilityLabel } from '../features/templates/constants';
 
@@ -145,14 +146,14 @@ export function listRowSearchHaystack(hierarchy: AcademicHierarchy, fields: List
   return [...visParts, academic].join(' ').toLowerCase();
 }
 
-/** Búsqueda insensible a mayúsculas: global/personal/equipo/…, nombre de equipo, jerarquía académica visible. */
+/** Búsqueda insensible a mayúsculas y acentos: global/personal/equipo/…, nombre de equipo, jerarquía académica visible. */
 export function listRowSearchMatches(
   hierarchy: AcademicHierarchy,
   fields: ListRowSearchFields,
   needle: string,
 ): boolean {
-  const n = needle.trim().toLowerCase();
+  const n = normalizeForSearch(needle.trim());
   if (!n) return true;
-  return listRowSearchHaystack(hierarchy, fields).includes(n);
+  return normalizeForSearch(listRowSearchHaystack(hierarchy, fields)).includes(n);
 }
 

--- a/frontend/src/utils/formatCalendarDate.ts
+++ b/frontend/src/utils/formatCalendarDate.ts
@@ -1,0 +1,33 @@
+/**
+ * Fecha de calendario según el locale del navegador (orden y separadores locales).
+ * Día y mes siempre con dos dígitos (`2-digit`).
+ * Acepta ISO completo o prefijo `Y-m-d`; usa componentes locales para evitar desfases por zona horaria.
+ */
+export function formatCalendarDateForBrowser(
+  iso: string | null | undefined,
+  locales: Intl.LocalesArgument =
+    typeof navigator !== 'undefined' && navigator.language ? navigator.language : 'es',
+): string {
+  if (!iso) return '—';
+  const m = String(iso).trim().match(/^(\d{4})-(\d{2})-(\d{2})/);
+  let date: Date;
+  if (m) {
+    const y = Number(m[1]);
+    const month = Number(m[2]);
+    const day = Number(m[3]);
+    date = new Date(y, month - 1, day);
+  } else {
+    date = new Date(iso);
+  }
+  if (Number.isNaN(date.getTime())) return '—';
+  const opts: Intl.DateTimeFormatOptions = {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+  };
+  try {
+    return new Intl.DateTimeFormat(locales, opts).format(date);
+  } catch {
+    return new Intl.DateTimeFormat('es', opts).format(date);
+  }
+}

--- a/frontend/src/utils/normalizeForSearch.ts
+++ b/frontend/src/utils/normalizeForSearch.ts
@@ -1,0 +1,10 @@
+/**
+ * Texto comparable en búsquedas: minúsculas y sin marcas diacríticas
+ * (p. ej. "José" y "jose" coinciden).
+ */
+export function normalizeForSearch(value: string): string {
+  return value
+    .normalize('NFD')
+    .replace(/\p{M}/gu, '')
+    .toLowerCase()
+}


### PR DESCRIPTION
- El filtro de búsqueda de autor de plantillas y nuevo documento ahora no distingue minúsculas y mayúsculas.
- Se añade el filtro de favoritos a plantillas, documentos y nuevo documento.
- En el listado de plantillas que aparece en nuevo documento también se ve la estrella que refleja que esa plantilla es favorita. 
- Se unifica el icono de favoritos en dashboard y dms.
- Se deja en el filtro de plantillas y documentos el filtro fecha con "Fecha de validación" y con el buscador hasta una fecha determinada.
- Se modifica la tabla de plantillas de la vista nuevo documento para que aparezca la fecha de publicación, y el filtro de fecha busca desde una fecha.
- Se modifica el filtro de visibilidad para que sea un buscador reactivo que no distingue mayúsculas y minúsculas en lugar de un select y para que se pueda buscar por global/personal o el contexto académico específico o el nombre del equipo.
- Se modifica el filtro de estado para que únicamente muestre las plantillas/documentos del estado seleccionado. En la vista de nuevo documento se elimina.
- Se modifica el filtrado de elementos por página, para que sea 10 por defecto.

En cuanto a los tests del backend:
- Se corrige el mock de getPublicKey para cumplir el contrato string y evitar 401 masivos; se reemplaza SQL específico de PostgreSQL en metadatos de última versión publicada por una consulta con ventana compatible con SQLite en CI.