### PR TITLE
Feature/fix filtros plantillas documentos

### DIFF
--- a/frontend/src/features/documents/components/DocumentsTable.tsx
+++ b/frontend/src/features/documents/components/DocumentsTable.tsx
@@ -50,7 +50,7 @@ function deliveryDeadlineOnOrBefore(iso: string | null | undefined, capYmd: stri
 
 type Filters = {
   name: string;
-  /** Texto libre sobre contexto académico vinculado (jerarquía + equipo), no la etiqueta de visibilidad. */
+  /** Texto libre del filtro «Visibilidad»: coincide con la columna (nivel + jerarquía + equipo). */
   academicContext: string;
   status: string;
   authorName: string;
@@ -380,11 +380,11 @@ export function DocumentsTable({ processId }: Props = {}) {
                 onChange={handleNameChange}
               />
             </FilterField>
-            <FilterField label="Contexto académico">
+            <FilterField label="Visibilidad">
               <TextInput
                 fieldSize="sm"
                 type="search"
-                placeholder="Global, personal, equipo, nombre de equipo o contexto académico…"
+                placeholder="Global, personal, equipo, nombre de equipo, estudio o módulo…"
                 value={academicContextInput}
                 onChange={handleAcademicContextChange}
               />

--- a/frontend/src/features/templates/components/TemplatesContent.tsx
+++ b/frontend/src/features/templates/components/TemplatesContent.tsx
@@ -377,11 +377,11 @@ export function TemplatesContent() {
         filtersStorageKey="maya:dms:templates-content"
         filtersPanel={
           <>
-            <FilterField label="Contexto académico">
+            <FilterField label="Visibilidad">
               <TextInput
                 fieldSize="sm"
                 type="search"
-                placeholder="Global, personal, equipo, nombre de equipo o contexto académico…"
+                placeholder="Global, personal, equipo, nombre de equipo, estudio o módulo…"
                 value={academicContextInput}
                 onChange={handleAcademicContextChange}
               />

--- a/frontend/src/features/templates/components/TemplatesContent.tsx
+++ b/frontend/src/features/templates/components/TemplatesContent.tsx
@@ -44,7 +44,7 @@ export function TemplatesContent() {
   const navigate = useNavigate();
   const { profile } = useUserProfile();
   const { hierarchy } = useHierarchy();
-  const { hiddenIds, toggleHidden, pageSize, setPageSize } = useTablePreferences({
+  const { hiddenIds, toggleHidden, sortBy, setSortBy, pageSize, setPageSize } = useTablePreferences({
     storageKey: 'maya:dms:templates-content',
   });
   const { templateIds: favoriteTemplateIds } = useFavoritesIds();
@@ -62,7 +62,7 @@ export function TemplatesContent() {
     goToPage,
     deleteTemplate,
     cloneTemplate,
-  } = useTemplates(undefined);
+  } = useTemplates(undefined, sortBy);
 
   const [authorInput, setAuthorInput] = useState(filters.author_name ?? '');
   const authorDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -226,6 +226,7 @@ export function TemplatesContent() {
       {
         id: 'name',
         header: 'Nombre',
+        sortable: true,
         alwaysVisible: true,
         cell: (t) => (
           <span className="flex items-center gap-2 min-w-0">
@@ -288,6 +289,7 @@ export function TemplatesContent() {
       {
         id: 'delivery_deadline',
         header: 'Fecha de validación',
+        sortable: true,
         cell: (t) => (
           <span className="text-xs text-text-secondary dark:text-text-dark-secondary">
             {t.status === 'published' ? '—' : formatCalendarDateForBrowser(t.delivery_deadline)}
@@ -357,6 +359,8 @@ export function TemplatesContent() {
         rowKey={(t) => t.list_row_id ?? t.id}
         hiddenColumnIds={hiddenIds}
         onToggleHiddenColumn={toggleHidden}
+        sortBy={sortBy}
+        onSortChange={setSortBy}
         pageSize={pageSize}
         onPageSizeChange={(size) => {
           setPageSize(size);

--- a/frontend/src/features/templates/components/TemplatesTable.tsx
+++ b/frontend/src/features/templates/components/TemplatesTable.tsx
@@ -362,11 +362,11 @@ export function TemplatesTable({ processId }: Props = {}) {
                 onChange={handleNameChange}
               />
             </FilterField>
-            <FilterField label="Contexto académico">
+            <FilterField label="Visibilidad">
               <TextInput
                 fieldSize="sm"
                 type="search"
-                placeholder="Global, personal, equipo, nombre de equipo o contexto académico…"
+                placeholder="Global, personal, equipo, nombre de equipo, estudio o módulo…"
                 value={academicContextInput}
                 onChange={handleAcademicContextChange}
               />

--- a/frontend/src/features/templates/components/TemplatesTable.tsx
+++ b/frontend/src/features/templates/components/TemplatesTable.tsx
@@ -44,7 +44,7 @@ export function TemplatesTable({ processId }: Props = {}) {
   const { profile } = useUserProfile();
   const { hierarchy } = useHierarchy();
 
-  const { hiddenIds, toggleHidden, pageSize, setPageSize } = useTablePreferences({
+  const { hiddenIds, toggleHidden, sortBy, setSortBy, pageSize, setPageSize } = useTablePreferences({
     storageKey: 'maya:dms:templates-table',
   });
   const { templateIds: favoriteTemplateIds } = useFavoritesIds();
@@ -57,7 +57,7 @@ export function TemplatesTable({ processId }: Props = {}) {
     clearActionError,
     applyFilters,
     goToPage,
-  } = useTemplates(processId);
+  } = useTemplates(processId, sortBy);
 
   const [nameInput, setNameInput] = useState('');
   const [nameFilter, setNameFilter] = useState('');
@@ -242,6 +242,7 @@ export function TemplatesTable({ processId }: Props = {}) {
       {
         id: 'name',
         header: 'Nombre',
+        sortable: true,
         alwaysVisible: true,
         cell: (t) => (
           <span className="flex items-center gap-2 min-w-0">
@@ -305,6 +306,7 @@ export function TemplatesTable({ processId }: Props = {}) {
       {
         id: 'delivery_deadline',
         header: 'Fecha de validación',
+        sortable: true,
         cell: (t) => (
           <span className="text-xs text-text-secondary dark:text-text-dark-secondary">
             {t.status === 'published' ? '—' : formatCalendarDateForBrowser(t.delivery_deadline)}
@@ -338,6 +340,8 @@ export function TemplatesTable({ processId }: Props = {}) {
         rowKey={(t) => t.list_row_id ?? t.id}
         hiddenColumnIds={hiddenIds}
         onToggleHiddenColumn={toggleHidden}
+        sortBy={sortBy}
+        onSortChange={setSortBy}
         pageSize={pageSize}
         onPageSizeChange={(size) => {
           setPageSize(size);

--- a/frontend/src/features/templates/hooks/useTemplates.ts
+++ b/frontend/src/features/templates/hooks/useTemplates.ts
@@ -33,14 +33,20 @@ function formatActionError(err: unknown): string {
 
 const DEFAULT_PER_PAGE = 10;
 
+/** Columnas de tabla que admiten ordenación local (no incluye «estado»). */
+const SORTABLE_TEMPLATE_COLUMN_IDS = new Set(['name', 'delivery_deadline']);
+
+export type TemplatesTableSort = { columnId: string; direction: 'asc' | 'desc' } | null;
+
 /**
  * Listado y mutaciones de plantillas normativas.
  * La API devuelve el catálogo completo (filtrado); la paginación es en cliente.
  *
  * @param processId Si se aporta, se aplica como filtro `process_id` permanente
  *   (no se expone en el panel de filtros — viene del contexto de la URL).
+ * @param sortBy Orden local solo para columnas en {@see SORTABLE_TEMPLATE_COLUMN_IDS}.
  */
-export function useTemplates(processId?: string) {
+export function useTemplates(processId?: string, sortBy?: TemplatesTableSort) {
   const [fullList, setFullList] = useState<Template[]>([]);
   /** Sin `per_page` por defecto: las pantallas usan `filters.per_page ?? pageSize` (preferencias de tabla). */
   const [filters, setFilters] = useState<TemplateListFilters>({});
@@ -72,14 +78,42 @@ export function useTemplates(processId?: string) {
   const page = filters.page ?? 1;
   const perPage = filters.per_page ?? DEFAULT_PER_PAGE;
 
+  const sortedList = useMemo(() => {
+    if (!sortBy || !SORTABLE_TEMPLATE_COLUMN_IDS.has(sortBy.columnId)) {
+      return fullList;
+    }
+    const { columnId, direction } = sortBy;
+    const dir = direction === 'asc' ? 1 : -1;
+
+    return [...fullList].sort((a, b) => {
+      if (columnId === 'name') {
+        return (a.name ?? '').localeCompare(b.name ?? '', 'es') * dir;
+      }
+      if (columnId === 'delivery_deadline') {
+        const valA = a.status === 'published' ? '9999-12-31' : (a.delivery_deadline ?? '').slice(0, 10);
+        const valB = b.status === 'published' ? '9999-12-31' : (b.delivery_deadline ?? '').slice(0, 10);
+        if (valA < valB) {
+          return -1 * dir;
+        }
+        if (valA > valB) {
+          return 1 * dir;
+        }
+
+        return 0;
+      }
+
+      return 0;
+    });
+  }, [fullList, sortBy]);
+
   const templates = useMemo(
-    () => sliceTemplatesPage(fullList, page, perPage),
-    [fullList, page, perPage],
+    () => sliceTemplatesPage(sortedList, page, perPage),
+    [sortedList, page, perPage],
   );
 
   const meta = useMemo(
-    () => buildTemplatesListMeta(fullList.length, page, perPage),
-    [fullList.length, page, perPage],
+    () => buildTemplatesListMeta(sortedList.length, page, perPage),
+    [sortedList.length, page, perPage],
   );
 
   const load = useCallback(async () => {
@@ -186,8 +220,8 @@ export function useTemplates(processId?: string) {
 
   return {
     templates,
-    /** Catálogo completo en el orden devuelto por la API; la paginación/filtros extra son en cliente. */
-    catalogSorted: fullList,
+    /** Catálogo completo: orden API y, si aplica, orden local por nombre o fecha de validación. */
+    catalogSorted: sortedList,
     meta,
     filters,
     loading,

--- a/frontend/src/pages/NuevaProgramacionSelectorPage.tsx
+++ b/frontend/src/pages/NuevaProgramacionSelectorPage.tsx
@@ -27,6 +27,9 @@ import {
   type ColumnDef,
 } from '@maya/shared-ui-react';
 
+/** Orden local solo en columnas con `sortable: true` (nombre y fecha de publicación). */
+const SORTABLE_SELECTOR_COLUMN_IDS = new Set(['name', 'latest_published_at']);
+
 export function NuevaProgramacionSelectorPage() {
   const navigate = useNavigate();
   const location = useLocation();
@@ -36,7 +39,7 @@ export function NuevaProgramacionSelectorPage() {
   const selectedProcessId = locationState?.processId;
   const [process, setProcess] = useState<Process | null>(null);
 
-  const { hiddenIds, toggleHidden, pageSize, setPageSize } = useTablePreferences({
+  const { hiddenIds, toggleHidden, sortBy, setSortBy, pageSize, setPageSize } = useTablePreferences({
     storageKey: 'maya:dms:nueva-programacion-selector',
   });
   const { templateIds: favoriteTemplateIds } = useFavoritesIds();
@@ -148,21 +151,49 @@ export function NuevaProgramacionSelectorPage() {
     );
   }, [afterFavorites, academicContextFilter, hierarchy]);
 
+  const sortedList = useMemo(() => {
+    if (!sortBy || !SORTABLE_SELECTOR_COLUMN_IDS.has(sortBy.columnId)) {
+      return afterAcademicContext;
+    }
+    const { columnId, direction } = sortBy;
+    const dir = direction === 'asc' ? 1 : -1;
+
+    return [...afterAcademicContext].sort((a, b) => {
+      if (columnId === 'name') {
+        return (a.name ?? '').localeCompare(b.name ?? '', 'es') * dir;
+      }
+      if (columnId === 'latest_published_at') {
+        const valA = a.latest_published_at ?? '';
+        const valB = b.latest_published_at ?? '';
+        if (valA < valB) {
+          return -1 * dir;
+        }
+        if (valA > valB) {
+          return 1 * dir;
+        }
+
+        return 0;
+      }
+
+      return 0;
+    });
+  }, [afterAcademicContext, sortBy]);
+
   useEffect(() => {
-    const last = Math.max(1, Math.ceil(afterAcademicContext.length / Math.max(1, listPerPage)));
+    const last = Math.max(1, Math.ceil(sortedList.length / Math.max(1, listPerPage)));
     if (listPage > last) {
       setFilters((f) => ({ ...f, page: last }));
     }
-  }, [afterAcademicContext.length, listPage, listPerPage]);
+  }, [sortedList.length, listPage, listPerPage]);
 
   const templates = useMemo(
-    () => sliceTemplatesPage(afterAcademicContext, listPage, listPerPage),
-    [afterAcademicContext, listPage, listPerPage],
+    () => sliceTemplatesPage(sortedList, listPage, listPerPage),
+    [sortedList, listPage, listPerPage],
   );
 
   const meta = useMemo(
-    () => buildTemplatesListMeta(afterAcademicContext.length, listPage, listPerPage),
-    [afterAcademicContext.length, listPage, listPerPage],
+    () => buildTemplatesListMeta(sortedList.length, listPage, listPerPage),
+    [sortedList.length, listPage, listPerPage],
   );
 
   const columns: ColumnDef<Template>[] = useMemo(
@@ -170,6 +201,7 @@ export function NuevaProgramacionSelectorPage() {
       {
         id: 'name',
         header: 'Nombre',
+        sortable: true,
         alwaysVisible: true,
         cell: (t) => (
           <span className="flex items-center gap-2 min-w-0">
@@ -212,6 +244,7 @@ export function NuevaProgramacionSelectorPage() {
       {
         id: 'latest_published_at',
         header: 'Fecha de publicación',
+        sortable: true,
         cell: (t) => (
           <span className="text-xs text-text-secondary dark:text-text-dark-secondary">
             {formatCalendarDateForBrowser(t.latest_published_at)}
@@ -314,6 +347,8 @@ export function NuevaProgramacionSelectorPage() {
         rowKey={(t) => t.list_row_id ?? t.id}
         hiddenColumnIds={hiddenIds}
         onToggleHiddenColumn={toggleHidden}
+        sortBy={sortBy}
+        onSortChange={setSortBy}
         pageSize={pageSize}
         onPageSizeChange={setPageSize}
         emptyMessage="No hay plantillas utilizables para crear documentos con los filtros actuales."

--- a/frontend/src/pages/NuevaProgramacionSelectorPage.tsx
+++ b/frontend/src/pages/NuevaProgramacionSelectorPage.tsx
@@ -14,6 +14,7 @@ import type { Process } from '../types/processes';
 import { formatCalendarDateForBrowser } from '../utils/formatCalendarDate';
 import { useHierarchy } from '../features/hierarchy';
 import { formatListRowVisibilityCaption, listRowSearchMatches } from '../utils/academicContextSearch';
+import { normalizeForSearch } from '../utils/normalizeForSearch';
 import {
   DataTable,
   DatePicker,
@@ -52,6 +53,9 @@ export function NuevaProgramacionSelectorPage() {
   const [allTemplates, setAllTemplates] = useState<Template[]>([]);
   const [loading, setLoading] = useState(true);
   const [listError, setListError] = useState<string | null>(null);
+  const [nameInput, setNameInput] = useState('');
+  const [nameFilter, setNameFilter] = useState('');
+  const nameDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [authorInput, setAuthorInput] = useState('');
   const authorDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [academicContextInput, setAcademicContextInput] = useState('');
@@ -133,9 +137,19 @@ export function NuevaProgramacionSelectorPage() {
     return mappedTemplates.filter((t) => favoriteTemplateIds.has(t.id));
   }, [mappedTemplates, favoritesFilter, favoriteTemplateIds]);
 
+  const afterName = useMemo(() => {
+    if (!nameFilter.trim()) {
+      return afterFavorites;
+    }
+    const needle = normalizeForSearch(nameFilter.trim());
+    return afterFavorites.filter((t) => normalizeForSearch(t.name ?? '').includes(needle));
+  }, [afterFavorites, nameFilter]);
+
   const afterAcademicContext = useMemo(() => {
-    if (!academicContextFilter.trim()) return afterFavorites;
-    return afterFavorites.filter((t) =>
+    if (!academicContextFilter.trim()) {
+      return afterName;
+    }
+    return afterName.filter((t) =>
       listRowSearchMatches(
         hierarchy,
         {
@@ -149,7 +163,7 @@ export function NuevaProgramacionSelectorPage() {
         academicContextFilter,
       ),
     );
-  }, [afterFavorites, academicContextFilter, hierarchy]);
+  }, [afterName, academicContextFilter, hierarchy]);
 
   const sortedList = useMemo(() => {
     if (!sortBy || !SORTABLE_SELECTOR_COLUMN_IDS.has(sortBy.columnId)) {
@@ -277,6 +291,18 @@ export function NuevaProgramacionSelectorPage() {
     setFilters((f) => ({ ...f, page: Math.max(1, page) }));
   };
 
+  const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setNameInput(value);
+    if (nameDebounceRef.current) {
+      clearTimeout(nameDebounceRef.current);
+    }
+    nameDebounceRef.current = setTimeout(() => {
+      setNameFilter(value);
+      setFilters((f) => ({ ...f, page: 1 }));
+    }, 400);
+  };
+
   const handleAuthorChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
     setAuthorInput(value);
@@ -297,8 +323,17 @@ export function NuevaProgramacionSelectorPage() {
   };
 
   const clearFilters = () => {
-    if (authorDebounceRef.current) clearTimeout(authorDebounceRef.current);
-    if (academicContextDebounceRef.current) clearTimeout(academicContextDebounceRef.current);
+    if (nameDebounceRef.current) {
+      clearTimeout(nameDebounceRef.current);
+    }
+    if (authorDebounceRef.current) {
+      clearTimeout(authorDebounceRef.current);
+    }
+    if (academicContextDebounceRef.current) {
+      clearTimeout(academicContextDebounceRef.current);
+    }
+    setNameInput('');
+    setNameFilter('');
     setAuthorInput('');
     setAcademicContextInput('');
     setAcademicContextFilter('');
@@ -315,7 +350,9 @@ export function NuevaProgramacionSelectorPage() {
 
   const filtersActiveCount =
     (favoritesFilter ? 1 : 0) +
-    [academicContextFilter, filters.author_name, filters.published_on].filter((v) => v && String(v).trim() !== '').length;
+    [nameFilter, academicContextFilter, filters.author_name, filters.published_on].filter(
+      (v) => v && String(v).trim() !== '',
+    ).length;
 
   return (
     <div className="min-h-full overflow-y-auto p-6 space-y-4">
@@ -375,11 +412,19 @@ export function NuevaProgramacionSelectorPage() {
         }}
         filtersPanel={
           <>
-            <FilterField label="Contexto académico">
+            <FilterField label="Nombre">
+              <TextInput
+                fieldSize="sm"
+                placeholder="Buscar por nombre..."
+                value={nameInput}
+                onChange={handleNameChange}
+              />
+            </FilterField>
+            <FilterField label="Visibilidad">
               <TextInput
                 fieldSize="sm"
                 type="search"
-                placeholder="Global, personal, equipo, nombre de equipo o contexto académico…"
+                placeholder="Global, personal, equipo, nombre de equipo, estudio o módulo…"
                 value={academicContextInput}
                 onChange={handleAcademicContextChange}
               />


### PR DESCRIPTION
- Plantillas: se ha recuperado la ordenación local por nombre y fecha de validación, alineada con el comportamiento de documentos. La columna Estado no es ordenable (sin flecha de ordenación).
- Selector de nuevo documento: misma idea de ordenación donde aplica (nombre y fecha de publicación) y coherencia con el listado de plantillas.
- Filtros (plantillas, documentos, nuevo documento): la etiqueta del filtro que unificaba búsqueda por nivel y contexto vuelve a mostrarse como «Visibilidad», en línea con la columna de la tabla. El comportamiento de búsqueda no cambia.
- Nuevo documento: se ha añadido el filtro por nombre como primer campo del panel, con el mismo criterio que en plantillas (normalización para búsqueda, debounce), para alinear la estética y la experiencia con el resto de pantallas.