### PR TITLE
Feature/integrar/fix/validar versionar historico develop

### DIFF
--- a/backend/app/DTOs/Documents/DocumentDto.php
+++ b/backend/app/DTOs/Documents/DocumentDto.php
@@ -44,6 +44,7 @@ final readonly class DocumentDto
         public ?int $latestPublishedVersionNumber,
         public ?string $latestPublishedTitle,
         public ?string $reviewMode,
+        public bool $isAssignedReviewer = false,
     ) {}
 
     public static function fromModel(Document $m): self
@@ -89,6 +90,7 @@ final readonly class DocumentDto
                 : null,
             latestPublishedTitle: $m->getAttribute('latest_published_title'),
             reviewMode: $m->review_mode !== null ? (string) $m->review_mode : null,
+            isAssignedReviewer: (bool) ($m->getAttribute('is_assigned_reviewer') ?? false),
         );
     }
 

--- a/backend/app/Http/Controllers/Api/DocumentController.php
+++ b/backend/app/Http/Controllers/Api/DocumentController.php
@@ -49,6 +49,7 @@ class DocumentController extends Controller
         $this->documentService->attachLatestPublishedVersionMeta($documents);
         $this->documentService->attachTemplateVersionNumbers($documents);
         $this->documentService->attachShareMetadataForViewer($documents, $viewerId);
+        $this->documentService->attachIsAssignedReviewerMeta($documents, $viewerId);
         $this->apiTeamEmbedService->embedOnDocuments(
             $documents,
             $viewerId,
@@ -124,6 +125,7 @@ class DocumentController extends Controller
         $this->assertOptionalProcessContextMatches((string) $document->process_id);
 
         $isCreator = (string) $document->created_by === $viewerId || (string) $document->owner_id === $viewerId;
+        $isAssignedReviewer = false;
 
         if (! $servePublishedSnapshot && ! $isCreator && in_array($document->status, ['draft', 'in_review'], true)) {
             // Any assigned reviewer (pending, approved, or rejected) can see real content while in_review.
@@ -135,6 +137,10 @@ class DocumentController extends Controller
             if (! $isAssignedReviewer) {
                 $servePublishedSnapshot = true;
             }
+        } elseif (! $servePublishedSnapshot && $document->status === 'in_review') {
+            $isAssignedReviewer = $document->reviews()
+                ->where('reviewer_id', $viewerId)
+                ->exists();
         }
 
         if ($servePublishedSnapshot) {
@@ -145,6 +151,7 @@ class DocumentController extends Controller
             $document->setRelation('headVersion', $latestPublished);
             $this->attachCanCloneMeta($document, $request);
             $this->documentService->attachShareMetadataForViewer(collect([$document]), $viewerId);
+            $document->setAttribute('is_assigned_reviewer', $isAssignedReviewer);
             $document->loadMissing(['owner']);
             $this->apiTeamEmbedService->embedOnDocument($document, $viewerId);
             $blocks = $this->documentService->blocksForDisplay($document);
@@ -161,6 +168,7 @@ class DocumentController extends Controller
             'has_review_comments',
             $document->comments()->exists(),
         );
+        $document->setAttribute('is_assigned_reviewer', $isAssignedReviewer);
         $this->attachCanCloneMeta($document, $request);
         $this->documentService->attachShareMetadataForViewer(collect([$document]), $viewerId);
         $document->loadMissing(['owner']);

--- a/backend/app/Http/Controllers/Api/MediaController.php
+++ b/backend/app/Http/Controllers/Api/MediaController.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\StoreMediaRequest;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+
+class MediaController extends Controller
+{
+    /**
+     * POST /api/v1/media
+     *
+     * Recibe una imagen, la almacena en el disco público y retorna su URL.
+     * Usada por BlockNote para incrustar imágenes pegadas en bloques de contenido.
+     */
+    public function store(StoreMediaRequest $request): JsonResponse
+    {
+        $file = $request->file('image');
+        $ext  = $file->getClientOriginalExtension() ?: ($file->guessExtension() ?? 'png');
+        $path = 'images/' . Str::uuid() . '.' . strtolower($ext);
+
+        Storage::disk('public')->put($path, $file->getContent());
+
+        return response()->json([
+            'url' => Storage::disk('public')->url($path),
+        ], 201);
+    }
+}

--- a/backend/app/Http/Requests/StoreMediaRequest.php
+++ b/backend/app/Http/Requests/StoreMediaRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreMediaRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /** @return array<string, mixed> */
+    public function rules(): array
+    {
+        return [
+            'image' => ['required', 'file', 'image', 'mimes:jpeg,jpg,png,gif,webp', 'max:5120'],
+        ];
+    }
+}

--- a/backend/app/Http/Resources/DocumentResource.php
+++ b/backend/app/Http/Resources/DocumentResource.php
@@ -49,6 +49,7 @@ class DocumentResource extends JsonResource
             'latest_published_version_number' => $dto->latestPublishedVersionNumber,
             'latest_published_title' => $dto->latestPublishedTitle,
             'review_mode' => $dto->reviewMode,
+            'is_assigned_reviewer' => $dto->isAssignedReviewer,
         ];
     }
 }

--- a/backend/app/Services/Contracts/DocumentServiceInterface.php
+++ b/backend/app/Services/Contracts/DocumentServiceInterface.php
@@ -260,4 +260,9 @@ interface DocumentServiceInterface
      * @param  Collection<int, Document>  $documents
      */
     public function attachTemplateVersionNumbers(Collection $documents): void;
+
+    /**
+     * @param  Collection<int, Document>  $documents
+     */
+    public function attachIsAssignedReviewerMeta(Collection $documents, string $viewerId): void;
 }

--- a/backend/app/Services/DocumentService.php
+++ b/backend/app/Services/DocumentService.php
@@ -1328,6 +1328,31 @@ class DocumentService implements DocumentServiceInterface
         }
     }
 
+    public function attachIsAssignedReviewerMeta(Collection $documents, string $viewerId): void
+    {
+        if ($documents->isEmpty()) {
+            return;
+        }
+
+        $ids = $documents->pluck('id')->filter(fn ($id) => is_string($id) && $id !== '')->values()->all();
+        if ($ids === []) {
+            return;
+        }
+
+        $assignedDocIds = array_flip(
+            DocumentReview::query()
+                ->whereIn('document_id', $ids)
+                ->where('reviewer_id', $viewerId)
+                ->pluck('document_id')
+                ->map(fn ($id) => (string) $id)
+                ->all(),
+        );
+
+        foreach ($documents as $document) {
+            $document->setAttribute('is_assigned_reviewer', array_key_exists((string) $document->id, $assignedDocIds));
+        }
+    }
+
     private function extractPublishedTitleFromSnapshot(mixed $snapshot): ?string
     {
         if (is_string($snapshot) && $snapshot !== '') {

--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -29,4 +29,7 @@ chown -R www-data:www-data storage 2>/dev/null || true
 echo "[entrypoint] Running package:discover..."
 php artisan package:discover --ansi 2>/dev/null || true
 
+# Ensure public storage symlink exists for media file serving
+php artisan storage:link --force 2>/dev/null || true
+
 exec "$@"

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\Api\CommentController;
 use App\Http\Controllers\Api\DashboardController;
 use App\Http\Controllers\Api\DocumentBlockController;
 use App\Http\Controllers\Api\DocumentController;
+use App\Http\Controllers\Api\MediaController;
 use App\Http\Controllers\Api\DocumentOptionsController;
 use App\Http\Controllers\Api\DocumentShareController;
 use App\Http\Controllers\Api\DocumentStateController;
@@ -46,6 +47,9 @@ Route::prefix('v1')->group(function () {
         MeRoutes::register();
         Route::get('/hierarchy', [AcademicHierarchyController::class, 'index']);
         Route::get('/processes', [ProcessController::class, 'index']);
+
+        // Media — subida de imágenes para bloques BlockNote
+        Route::post('media', [MediaController::class, 'store']);
 
         // Plantillas
         // Combinación de validación UUID (develop) y actualización masiva de bloques (feature).

--- a/frontend/src/api/media.ts
+++ b/frontend/src/api/media.ts
@@ -1,0 +1,23 @@
+import { buildApiUrl, getBearerToken } from './http';
+
+export async function uploadMedia(file: File): Promise<string> {
+  const token = await getBearerToken();
+  const form = new FormData();
+  form.append('image', file);
+
+  const headers: Record<string, string> = { Accept: 'application/json' };
+  if (token) headers.Authorization = `Bearer ${token}`;
+
+  const response = await fetch(buildApiUrl('media'), {
+    method: 'POST',
+    headers,
+    body: form,
+  });
+
+  if (!response.ok) {
+    throw new Error(`Upload failed: HTTP ${response.status}`);
+  }
+
+  const data = (await response.json()) as { url: string };
+  return data.url;
+}

--- a/frontend/src/components/DocumentsContent.tsx
+++ b/frontend/src/components/DocumentsContent.tsx
@@ -103,7 +103,7 @@ export function DocumentsContent() {
         !!d.latest_published_version_id;
       const isAssignedReviewer =
         d.status === 'in_review' &&
-        hasPermission('documents.review');
+        d.is_assigned_reviewer === true;
       const canSeeLive =
         (profile?.id != null && (profile.id === d.created_by || profile.id === d.owner_id)) ||
         d.share_permission === 'edit' ||
@@ -368,9 +368,7 @@ export function DocumentsContent() {
               }
               const isReviewerForDoc =
                 d.status === 'in_review' &&
-                hasPermission('documents.review') &&
-                profile?.id !== d.created_by &&
-                profile?.id !== d.owner_id;
+                d.is_assigned_reviewer === true;
               if (isReviewerForDoc) {
                 navigate(`/documents/${d.id}/validate`);
                 return;
@@ -643,9 +641,7 @@ export function DocumentsContent() {
                     }
                     const isReviewerForDoc =
                       d.status === 'in_review' &&
-                      hasPermission('documents.review') &&
-                      profile?.id !== d.created_by &&
-                      profile?.id !== d.owner_id;
+                      d.is_assigned_reviewer === true;
                     if (isReviewerForDoc) {
                       navigate(`/documents/${d.id}/validate`);
                       return;

--- a/frontend/src/features/documents/components/DocumentWizard.tsx
+++ b/frontend/src/features/documents/components/DocumentWizard.tsx
@@ -57,6 +57,7 @@ import {
 import { WizardShell, type WizardStepDef } from '../../../components/wizard/WizardShell';
 import { BlockListItem } from '../../blocks-ui/BlockListItem';
 import { getCommentsForBlock } from '../../../utils/blockComments';
+import { uploadMedia } from '../../../api/media';
 
 const BlockNoteEditorPanel = lazy(() =>
   import('../../templates/components/BlockNoteEditorPanel').then(
@@ -1541,6 +1542,7 @@ export function DocumentWizard({ documentId, templateId, mode = 'edit' }: Props)
                                 isDark={isDark}
                                 onChange={(content) => { setLocalContent(content); triggerSave(); }}
                                 onFullscreenChange={handleEditorFullscreenChange}
+                                uploadFile={uploadMedia}
                               />
                             </Suspense>
                           </div>

--- a/frontend/src/features/documents/components/DocumentWizard.tsx
+++ b/frontend/src/features/documents/components/DocumentWizard.tsx
@@ -951,8 +951,8 @@ export function DocumentWizard({ documentId, templateId, mode = 'edit' }: Props)
     try {
       const updated = await approveDocumentReview(documentId, actionableReviewId, null);
       setValidateConfirm(null);
-      navigate('/dashboard', {
-        state: { documentValidationBanner: validationSuccessBannerMessage(updated, 'approve') },
+      navigate(processBackTo, {
+        state: { documentValidationBanner: validationSuccessBannerMessage(updated, 'approve'), tab: 'documents' },
       });
     } catch (e) {
       setValidationModalError(e instanceof ApiHttpError ? e.message : 'No se pudo aprobar la revisión.');
@@ -976,8 +976,8 @@ export function DocumentWizard({ documentId, templateId, mode = 'edit' }: Props)
     try {
       const updated = await rejectDocumentReview(documentId, actionableReviewId, null);
       setValidateConfirm(null);
-      navigate('/dashboard', {
-        state: { documentValidationBanner: validationSuccessBannerMessage(updated, 'reject') },
+      navigate(processBackTo, {
+        state: { documentValidationBanner: validationSuccessBannerMessage(updated, 'reject'), tab: 'documents' },
       });
     } catch (e) {
       setValidationModalError(e instanceof ApiHttpError ? e.message : 'No se pudo rechazar la revisión.');

--- a/frontend/src/features/documents/components/DocumentsTable.tsx
+++ b/frontend/src/features/documents/components/DocumentsTable.tsx
@@ -232,7 +232,7 @@ export function DocumentsTable({ processId }: Props = {}) {
         !!d.latest_published_version_id;
       const isAssignedReviewer =
         d.status === 'in_review' &&
-        hasPermission('documents.review');
+        d.is_assigned_reviewer === true;
       const canSeeLive =
         (profile?.id != null && (profile.id === d.created_by || profile.id === d.owner_id)) ||
         d.share_permission === 'edit' ||
@@ -376,9 +376,7 @@ export function DocumentsTable({ processId }: Props = {}) {
           }
           const isReviewerForDoc =
             doc.status === 'in_review' &&
-            hasPermission('documents.review') &&
-            profile?.id !== doc.created_by &&
-            profile?.id !== doc.owner_id;
+            doc.is_assigned_reviewer === true;
           if (isReviewerForDoc) {
             navigate(`/documents/${doc.id}/validate`, {
               state: { backTo: processId ? `/procesos/${processId}` : '/dashboard', processId },

--- a/frontend/src/features/templates/components/BlockContentHtml.tsx
+++ b/frontend/src/features/templates/components/BlockContentHtml.tsx
@@ -86,9 +86,11 @@ export function BlockContentHtml({ content }: { content: unknown[] }) {
       repaired.length === 0 ||
       repaired.every(
         (b: any) =>
-          !Array.isArray(b.content) ||
-          b.content.length === 0 ||
-          b.content.every((c: any) => typeof c.text !== 'string' || !c.text.trim()),
+          b.type !== 'image' && (
+            !Array.isArray(b.content) ||
+            b.content.length === 0 ||
+            b.content.every((c: any) => typeof c.text !== 'string' || !c.text.trim())
+          ),
       );
     if (isEmpty) return '';
     try {

--- a/frontend/src/features/templates/components/BlockNoteEditorPanel.tsx
+++ b/frontend/src/features/templates/components/BlockNoteEditorPanel.tsx
@@ -204,10 +204,12 @@ export function BlockNoteEditorPanel({ initialContent, editable, isDark, onChang
           // the pasted content lands in-place instead of after an empty line.
           const currentBlock = currentBlocks[blockIdx];
           const isEmpty =
-            currentBlock.content.length === 0 ||
-            (currentBlock.content.length === 1 &&
-              currentBlock.content[0].type === 'text' &&
-              !currentBlock.content[0].text);
+            currentBlock.type !== 'image' && (
+              currentBlock.content.length === 0 ||
+              (currentBlock.content.length === 1 &&
+                currentBlock.content[0].type === 'text' &&
+                !currentBlock.content[0].text)
+            );
 
           if (isEmpty) {
             editor.removeBlocks([blockId]);

--- a/frontend/src/features/templates/components/BlockNoteEditorPanel.tsx
+++ b/frontend/src/features/templates/components/BlockNoteEditorPanel.tsx
@@ -13,6 +13,7 @@ interface Props {
   isDark: boolean;
   onChange?: (content: unknown) => void;
   onFullscreenChange?: (isFullscreen: boolean) => void;
+  uploadFile?: (file: File) => Promise<string>;
 }
 
 // BlockNote 0.49 changed blockGroup/blockContainer renderHTML to return {dom,contentDOM}
@@ -100,7 +101,7 @@ function cleanHtmlForPaste(html: string): string {
     .replace(/\s+/g, ' ');
 }
 
-export function BlockNoteEditorPanel({ initialContent, editable, isDark, onChange, onFullscreenChange }: Props) {
+export function BlockNoteEditorPanel({ initialContent, editable, isDark, onChange, onFullscreenChange, uploadFile }: Props) {
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [isFullscreen, setIsFullscreen] = useState(false);
@@ -133,10 +134,12 @@ export function BlockNoteEditorPanel({ initialContent, editable, isDark, onChang
   // guard StrictMode's mount→cleanup→remount leaves two handlers → paste fires twice.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const editorRef = useRef<any>(null);
+  const uploadFileRef = useRef(uploadFile);
   if (!editorRef.current) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     editorRef.current = (BlockNoteEditor as any).create({
       initialContent: safeContent ? repairBlockNoteBlocks(safeContent) : undefined,
+      uploadFile: uploadFileRef.current,
     });
     patchBlockNoteStructuralNodeViews((editorRef.current as any)._tiptapEditor);
   }

--- a/frontend/src/features/templates/components/TemplateEditor.tsx
+++ b/frontend/src/features/templates/components/TemplateEditor.tsx
@@ -32,6 +32,7 @@ import {
   BLOCK_UI_STATE_CONFIG,
   blockToUiState,
 } from '../blockUiState';
+import { uploadMedia } from '../../../api/media';
 const BlockNoteEditorPanel = lazy(() =>
   import('./BlockNoteEditorPanel').then((m) => ({ default: m.BlockNoteEditorPanel })),
 );
@@ -452,6 +453,7 @@ export function TemplateEditor({ template }: Props) {
                 }}
                 editable={true} // Siempre editable en la plantilla
                 isDark={isDark}
+                uploadFile={uploadMedia}
               />
             </Suspense>
           </div>

--- a/frontend/src/features/templates/components/WizardStep2Blocks.tsx
+++ b/frontend/src/features/templates/components/WizardStep2Blocks.tsx
@@ -275,12 +275,16 @@ export const WizardStep2Blocks = React.forwardRef<WizardStep2BlocksHandle, Wizar
     try { parsedDesc = formDesc ? JSON.parse(formDesc) : null; } catch { parsedDesc = null; }
     // Normalize whitespace-only BlockNote content to null so it is stored as empty
     // and the UI shows "Este bloque no tiene contenido." instead of blank text nodes.
+    // Non-text blocks (image, etc.) carry content in `props`, not `content[]`, so they
+    // must never be treated as blank even when their `content` array is empty.
     if (Array.isArray(parsedContent) && parsedContent.length > 0) {
-      type BlockNoteNode = { content?: Array<{ text?: unknown }> };
+      type BlockNoteNode = { type?: string; content?: Array<{ text?: unknown }> };
       const isBlank = (parsedContent as BlockNoteNode[]).every((b) =>
-        !Array.isArray(b.content) ||
-        b.content.length === 0 ||
-        b.content.every((c) => typeof c.text !== 'string' || !c.text.trim()),
+        b.type !== 'image' && (
+          !Array.isArray(b.content) ||
+          b.content.length === 0 ||
+          b.content.every((c) => typeof c.text !== 'string' || !c.text.trim())
+        ),
       );
       if (isBlank) parsedContent = null;
     }

--- a/frontend/src/features/templates/components/WizardStep2Blocks.tsx
+++ b/frontend/src/features/templates/components/WizardStep2Blocks.tsx
@@ -26,6 +26,7 @@ import { useTemplateCommentsQuery } from '../hooks/useTemplateComments';
 import { type BlockUiState, BLOCK_UI_STATE_CONFIG, blockToUiState } from '../blockUiState';
 import { useAutoSave } from '../../../hooks/useAutoSave';
 import { apiFetchJson } from '../../../api/http';
+import { uploadMedia } from '../../../api/media';
 import { BlockCommentsCard, type BlockComment } from './BlockCommentsCard';
 import { getCommentsForBlock } from '../../../utils/blockComments';
 
@@ -697,6 +698,7 @@ export const WizardStep2Blocks = React.forwardRef<WizardStep2BlocksHandle, Wizar
                               editable={true}
                               isDark={effectiveIsDark}
                               onFullscreenChange={handleEditorFullscreenChange}
+                              uploadFile={uploadMedia}
                             />
                           </Suspense>
                         </div>
@@ -725,6 +727,7 @@ export const WizardStep2Blocks = React.forwardRef<WizardStep2BlocksHandle, Wizar
                             editable={true}
                             isDark={effectiveIsDark}
                             onFullscreenChange={handleEditorFullscreenChange}
+                            uploadFile={uploadMedia}
                           />
                         </Suspense>
                       </div>

--- a/frontend/src/pages/DocumentPreviewPage.tsx
+++ b/frontend/src/pages/DocumentPreviewPage.tsx
@@ -547,8 +547,8 @@ export function DocumentPreviewPage({ mode = 'preview' }: Props = {}) {
     try {
       const updated = await approveDocumentReview(documentId, actionableReviewId, null);
       setValidateConfirm(null);
-      navigate('/dashboard', {
-        state: { documentValidationBanner: validationSuccessBannerMessage(updated, 'approve') },
+      navigate(backTo, {
+        state: { documentValidationBanner: validationSuccessBannerMessage(updated, 'approve'), tab: 'documents' },
       });
     } catch (e) {
       setValidationModalError(e instanceof Error ? e.message : 'No se pudo aprobar la revisión.');
@@ -569,8 +569,8 @@ export function DocumentPreviewPage({ mode = 'preview' }: Props = {}) {
     try {
       const updated = await rejectDocumentReview(documentId, actionableReviewId, null);
       setValidateConfirm(null);
-      navigate('/dashboard', {
-        state: { documentValidationBanner: validationSuccessBannerMessage(updated, 'reject') },
+      navigate(backTo, {
+        state: { documentValidationBanner: validationSuccessBannerMessage(updated, 'reject'), tab: 'documents' },
       });
     } catch (e) {
       setValidationModalError(e instanceof Error ? e.message : 'No se pudo rechazar la revisión.');
@@ -1108,7 +1108,7 @@ export function DocumentPreviewPage({ mode = 'preview' }: Props = {}) {
 
           const isCreator = profile?.id && detail?.created_by === profile.id;
           const isOwner = profile?.id && detail?.owner_id === profile.id;
-          const commentMode = (isCreator || isOwner) ? 'creator-edit' : isDocumentReviewer ? 'validator' : 'creator-readonly';
+          const commentMode = (isDocumentReviewer && detail?.status === 'in_review') ? 'validator' : (isCreator || isOwner) ? 'creator-edit' : 'creator-readonly';
 
           if (selectedReviewView.mode === 'comments') {
             return (

--- a/frontend/src/pages/DocumentPreviewPage.tsx
+++ b/frontend/src/pages/DocumentPreviewPage.tsx
@@ -600,11 +600,11 @@ export function DocumentPreviewPage({ mode = 'preview' }: Props = {}) {
           <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${statusBadgeClass(detail.status)}`}>
             {STATUS_LABEL[detail.status] ?? detail.status}
           </span>
-          
+          {detail.status !== 'draft' && (
           <span className="text-xs font-mono bg-ui-body dark:bg-ui-dark-bg border border-ui-border dark:border-ui-dark-border px-2 py-0.5 rounded-full text-text-secondary dark:text-text-dark-secondary">
-            v{detail.status === "draft" ? detail.current_version + 1 : detail.current_version}
+            v{detail.current_version}
           </span>
-          
+          )}
         </>
       )}
       {!isValidateMode && !isHistoricalSnapshot && detail.status === 'in_review' && allReviews.length > 0 && (

--- a/frontend/src/pages/ProcesosPage.tsx
+++ b/frontend/src/pages/ProcesosPage.tsx
@@ -1,5 +1,6 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import { useQueryClient } from '@tanstack/react-query';
 import { Button, ErrorBoundary, PageTitle } from '@maya/shared-ui-react';
 import { TemplatesTable } from '../features/templates/components/TemplatesTable';
 import { DocumentsTable } from '../features/documents/components/DocumentsTable';
@@ -18,9 +19,20 @@ const TAB_CLASS = (active: boolean) =>
 export function ProcesosPage() {
   const navigate = useNavigate();
   const location = useLocation();
+  const queryClient = useQueryClient();
   const { processId } = useParams<{ processId?: string }>();
-  const locationState = location.state as { tab?: Tab } | null;
+  const locationState = location.state as { tab?: Tab; documentValidationBanner?: string } | null;
   const [activeTab, setActiveTab] = useState<Tab>(locationState?.tab ?? 'templates');
+  const [validationBanner, setValidationBanner] = useState<string | null>(null);
+
+  useEffect(() => {
+    const banner = locationState?.documentValidationBanner;
+    if (!banner) return;
+    setValidationBanner(banner);
+    if (locationState?.tab) setActiveTab(locationState.tab);
+    void queryClient.invalidateQueries({ queryKey: ['documents'] });
+    navigate(location.pathname, { replace: true, state: {} });
+  }, [location.state, location.pathname, navigate, queryClient]);
 
   // Resuelve el proceso activo (para mostrar nombre en el header).
   const processesQuery = useProcessesQuery(undefined, { enabled: !!processId });
@@ -67,6 +79,26 @@ export function ProcesosPage() {
           </div>
         }
       />
+
+      {validationBanner && (
+        <div
+          className="mb-4 flex items-center justify-between gap-3 rounded-lg border border-success/30 bg-success/10 px-4 py-3 dark:bg-success/15 dark:border-success/40"
+          role="status"
+        >
+          <p className="text-sm font-medium text-success-dark dark:text-success">
+            {validationBanner}
+          </p>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="shrink-0 text-success-dark dark:text-success"
+            onClick={() => setValidationBanner(null)}
+          >
+            Cerrar
+          </Button>
+        </div>
+      )}
 
       <ErrorBoundary key={`${activeTab}:${processId ?? 'all'}`}>
         {activeTab === 'templates' ? (

--- a/frontend/src/pages/TemplatePreviewPage.tsx
+++ b/frontend/src/pages/TemplatePreviewPage.tsx
@@ -395,9 +395,11 @@ export function TemplatePreviewPage() {
           <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${statusBadgeClass(template.status)}`}>
             {STATUS_LABEL[template.status] ?? template.status}
           </span>
-          <span className="text-xs font-mono bg-ui-body dark:bg-ui-dark-bg border border-ui-border dark:border-ui-dark-border px-2 py-0.5 rounded-full text-text-secondary dark:text-text-dark-secondary">
-            v{template.status === "draft" ? template.version + 1 : template.version}
-          </span>
+          {template.status !== 'draft' && (
+            <span className="text-xs font-mono bg-ui-body dark:bg-ui-dark-bg border border-ui-border dark:border-ui-dark-border px-2 py-0.5 rounded-full text-text-secondary dark:text-text-dark-secondary">
+              v{template.version}
+            </span>
+          )}
           {template.status === 'in_review' && (template.reviewers?.length ?? 0) > 0 && (
             <SequentialValidatorBadge
               reviewMode={template.review_mode}

--- a/frontend/src/types/documents.ts
+++ b/frontend/src/types/documents.ts
@@ -48,6 +48,8 @@ export type Document = {
   can_clone?: boolean;
   /** Modo de revisión resuelto desde el snapshot anclado; coincide con lo que aplica el backend al aprobar/rechazar. */
   review_mode?: 'sequential' | 'parallel';
+  /** El usuario autenticado está asignado como revisor de este documento. */
+  is_assigned_reviewer?: boolean;
   working_version_id?: string | null;
   review_history?: DocumentReviewCycleSnapshot[] | null;
   latest_published_version_id?: string | null;


### PR DESCRIPTION
# Testing — `feature/INTEGRAR/FIX/Validar-versionar-historico-develop`

## Setup

```bash
git checkout feature/INTEGRAR/FIX/Validar-versionar-historico-develop
git pull
./up.sh
```

Tras arrancar, reiniciar el backend una vez para que cree el symlink de storage:

```bash
docker restart $(docker ps --filter "name=dms-backend" -q)
```

---

# 1. Imágenes en bloques de contenido

**Dónde:**  
Editor de plantillas → Wizard paso 2 → tab "Contenido" de cualquier bloque editable.  

**También:**  
Editor de documento → paso "Bloques" → seleccionar un bloque.

## Casos a probar

| Acción | Resultado esperado |
|---|---|
| Copiar un screenshot (`Ctrl+C` en área de pantalla) y pegar en el editor | La imagen se sube, aparece en el bloque y persiste tras guardar y recargar |
| Pegar imagen sola (sin texto) | Guarda correctamente — no queda vacío |
| Pegar imagen y añadir texto debajo | Todo persiste |
| Seleccionar un bloque con imagen y pegar texto | El texto se inserta después de la imagen, no la borra |
| Vista previa del bloque (pestaña resumen / preview) | La imagen se renderiza en la preview HTML |

> Formatos soportados: `jpeg`, `png`, `gif`, `webp`  
> Límite: **5 MB**

---

# 2. Botón "Validar" en documentos

**Contexto:** Flujo de revisión de documentos.

| Caso | Resultado esperado |
|---|---|
| Usuario asignado como revisor de un documento | Botón "Validar" visible aunque no tenga permiso `document.validate` global |
| Usuario NO asignado como revisor | Botón no visible |

---

# 3. Navegación post validación

**Dónde:** Pantalla de revisión de documento → aprobar o rechazar.

| Acción | Resultado esperado |
|---|---|
| Aprobar un documento | Redirige a la página del proceso, no queda en pantalla muerta |
| Rechazar un documento | Ídem |

---

# Verificación rápida del endpoint de imágenes

```bash
curl -s https://dms-api.maya.test/api/v1/health/ready
# debe devolver 200
```