### PR TITLE
Feature/fix/num bloque diff

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -103,7 +103,7 @@ VITE_REVERB_PORT=8082
 
 # ─── Puertos host ──────────────────────────────────────────────
 BACKEND_PORT=8001
-FRONTEND_PORT=5474
+FRONTEND_PORT=6074
 
 # ─── Permisos Docker bind mounts (opcional) ────────────────────
 # Si no se definen, up.sh calcula LOCAL_UID/LOCAL_GID automáticamente.

--- a/.env.example
+++ b/.env.example
@@ -103,7 +103,7 @@ VITE_REVERB_PORT=8082
 
 # ─── Puertos host ──────────────────────────────────────────────
 BACKEND_PORT=8001
-FRONTEND_PORT=6074
+FRONTEND_PORT=5274
 
 # ─── Permisos Docker bind mounts (opcional) ────────────────────
 # Si no se definen, up.sh calcula LOCAL_UID/LOCAL_GID automáticamente.

--- a/backend/app/DTOs/Users/ReviewerAcademicAssignmentScope.php
+++ b/backend/app/DTOs/Users/ReviewerAcademicAssignmentScope.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTOs\Users;
+
+/**
+ * Ámbito académico resuelto para filtrar validadores: un candidato es elegible si
+ * tiene asignación en cualquiera de los IDs listados (OR), sin inclusión hacia abajo.
+ */
+final readonly class ReviewerAcademicAssignmentScope
+{
+    /**
+     * @param  list<string>  $moduleIds
+     * @param  list<string>  $studyIds
+     * @param  list<string>  $studyTypeIds
+     * @param  list<string>  $teamIds
+     */
+    public function __construct(
+        public array $moduleIds = [],
+        public array $studyIds = [],
+        public array $studyTypeIds = [],
+        public array $teamIds = [],
+    ) {}
+
+    public function matchesNothing(): bool
+    {
+        return $this->moduleIds === []
+            && $this->studyIds === []
+            && $this->studyTypeIds === []
+            && $this->teamIds === [];
+    }
+}

--- a/backend/app/DTOs/Users/ReviewerCandidateFilterDto.php
+++ b/backend/app/DTOs/Users/ReviewerCandidateFilterDto.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTOs\Users;
+
+use Illuminate\Http\Request;
+
+/**
+ * Contexto académico opcional para acotar candidatos a validador en el directorio.
+ */
+final readonly class ReviewerCandidateFilterDto
+{
+    public function __construct(
+        public ?string $visibilityLevel,
+        public ?string $studyTypeId,
+        public ?string $studyId,
+        public ?string $moduleId,
+        public ?string $teamId,
+    ) {}
+
+    public static function fromRequest(Request $request): self
+    {
+        return new self(
+            visibilityLevel: self::nullableTrimmed($request->query('visibility_level')),
+            studyTypeId: self::nullableTrimmed($request->query('study_type_id')),
+            studyId: self::nullableTrimmed($request->query('study_id')),
+            moduleId: self::nullableTrimmed($request->query('module_id')),
+            teamId: self::nullableTrimmed($request->query('team_id')),
+        );
+    }
+
+    private static function nullableTrimmed(mixed $value): ?string
+    {
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $trimmed = trim($value);
+
+        return $trimmed !== '' ? $trimmed : null;
+    }
+}

--- a/backend/app/Http/Controllers/Api/TemplateStateController.php
+++ b/backend/app/Http/Controllers/Api/TemplateStateController.php
@@ -50,7 +50,7 @@ class TemplateStateController extends Controller
     }
 
     /**
-     * En revisión → borrador (revisor).
+     * En revisión → rechazada (revisor). El creador puede editar y reenviar.
      */
     public function rejectReview(string $template): TemplateResource
     {

--- a/backend/app/Http/Controllers/Api/UserController.php
+++ b/backend/app/Http/Controllers/Api/UserController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
+use App\DTOs\Users\ReviewerCandidateFilterDto;
 use App\Models\JwtUser;
 use App\Services\Contracts\UserDirectoryServiceInterface;
 use Illuminate\Http\JsonResponse;
@@ -56,6 +57,9 @@ class UserController extends Controller
      * `search` es opcional; si se omite devuelve todos los candidatos (hasta per_page).
      *
      * `exclude_user_id`: opcional; no devuelve ese usuario (p. ej. creador de la plantilla, SoD).
+     *
+     * Contexto académico opcional (según visibilidad de la plantilla):
+     * `visibility_level`, `study_type_id`, `study_id`, `module_id`, `team_id`.
      */
     public function reviewerCandidates(Request $request): JsonResponse
     {
@@ -67,8 +71,14 @@ class UserController extends Controller
         $search = trim((string) $request->get('search', ''));
         $perPage = min((int) $request->get('per_page', 20), 50);
         $excludeUserId = $this->optionalExcludeUserId($request);
+        $academicFilter = ReviewerCandidateFilterDto::fromRequest($request);
 
-        $users = $this->userDirectoryService->searchTemplateReviewerCandidates($search, $perPage, $excludeUserId);
+        $users = $this->userDirectoryService->searchTemplateReviewerCandidates(
+            $search,
+            $perPage,
+            $excludeUserId,
+            $academicFilter,
+        );
 
         return response()->json(['data' => $users]);
     }
@@ -83,6 +93,9 @@ class UserController extends Controller
      * `search` es opcional; si se omite devuelve todos los candidatos (hasta per_page).
      *
      * `exclude_user_id`: opcional; no devuelve ese usuario (p. ej. creador de la plantilla, SoD).
+     *
+     * Contexto académico opcional (según visibilidad de la plantilla):
+     * `visibility_level`, `study_type_id`, `study_id`, `module_id`, `team_id`.
      */
     public function documentReviewerCandidates(Request $request): JsonResponse
     {
@@ -94,8 +107,14 @@ class UserController extends Controller
         $search = trim((string) $request->get('search', ''));
         $perPage = min((int) $request->get('per_page', 20), 50);
         $excludeUserId = $this->optionalExcludeUserId($request);
+        $academicFilter = ReviewerCandidateFilterDto::fromRequest($request);
 
-        $users = $this->userDirectoryService->searchDocumentReviewerCandidates($search, $perPage, $excludeUserId);
+        $users = $this->userDirectoryService->searchDocumentReviewerCandidates(
+            $search,
+            $perPage,
+            $excludeUserId,
+            $academicFilter,
+        );
 
         return response()->json(['data' => $users]);
     }

--- a/backend/app/Repositories/Contracts/UserDirectoryRepositoryInterface.php
+++ b/backend/app/Repositories/Contracts/UserDirectoryRepositoryInterface.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Repositories\Contracts;
 
+use App\DTOs\Users\ReviewerAcademicAssignmentScope;
+
 interface UserDirectoryRepositoryInterface
 {
     /**
@@ -18,14 +20,32 @@ interface UserDirectoryRepositoryInterface
      *
      * @return list<array{id: string, name: ?string, email: ?string, role: ?string}>
      */
-    public function searchTemplateReviewerCandidates(string $search, int $limit, ?string $excludeUserId = null): array;
+    public function searchTemplateReviewerCandidates(
+        string $search,
+        int $limit,
+        ?string $excludeUserId = null,
+        ?ReviewerAcademicAssignmentScope $academicScope = null,
+    ): array;
 
     /**
      * Usuarios con permiso `documents.review` (validadores de documento).
      *
      * @return list<array{id: string, name: ?string, email: ?string, role: ?string}>
      */
-    public function searchDocumentReviewerCandidates(string $search, int $limit, ?string $excludeUserId = null): array;
+    public function searchDocumentReviewerCandidates(
+        string $search,
+        int $limit,
+        ?string $excludeUserId = null,
+        ?ReviewerAcademicAssignmentScope $academicScope = null,
+    ): array;
+
+    /**
+     * Devuelve los IDs de la lista que tienen asignación académica dentro del ámbito.
+     *
+     * @param  list<string>  $userIds
+     * @return list<string>
+     */
+    public function filterUserIdsMatchingAcademicScope(array $userIds, ReviewerAcademicAssignmentScope $scope): array;
 
     /**
      * Nombre legible del usuario por su ID, o null si no existe / está vacío.

--- a/backend/app/Repositories/Eloquent/UserDirectoryRepository.php
+++ b/backend/app/Repositories/Eloquent/UserDirectoryRepository.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\Repositories\Eloquent;
 
+use App\DTOs\Users\ReviewerAcademicAssignmentScope;
 use App\Repositories\Contracts\UserDirectoryRepositoryInterface;
+use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Facades\DB;
 
 /**
@@ -54,17 +56,59 @@ class UserDirectoryRepository implements UserDirectoryRepositoryInterface
     /**
      * Usuarios que pueden validar plantillas: tienen {@see self::PERMISSION_TEMPLATE_REVIEW} en `user_resolved_permissions`.
      */
-    public function searchTemplateReviewerCandidates(string $search, int $limit, ?string $excludeUserId = null): array
-    {
-        return $this->searchReviewerCandidatesByPermission(self::PERMISSION_TEMPLATE_REVIEW, $search, $limit, $excludeUserId);
+    public function searchTemplateReviewerCandidates(
+        string $search,
+        int $limit,
+        ?string $excludeUserId = null,
+        ?ReviewerAcademicAssignmentScope $academicScope = null,
+    ): array {
+        return $this->searchReviewerCandidatesByPermission(
+            self::PERMISSION_TEMPLATE_REVIEW,
+            $search,
+            $limit,
+            $excludeUserId,
+            $academicScope,
+        );
     }
 
     /**
      * Usuarios que pueden validar documentos: tienen {@see self::PERMISSION_DOCUMENT_REVIEW} en `user_resolved_permissions`.
      */
-    public function searchDocumentReviewerCandidates(string $search, int $limit, ?string $excludeUserId = null): array
+    public function searchDocumentReviewerCandidates(
+        string $search,
+        int $limit,
+        ?string $excludeUserId = null,
+        ?ReviewerAcademicAssignmentScope $academicScope = null,
+    ): array {
+        return $this->searchReviewerCandidatesByPermission(
+            self::PERMISSION_DOCUMENT_REVIEW,
+            $search,
+            $limit,
+            $excludeUserId,
+            $academicScope,
+        );
+    }
+
+    /**
+     * @param  list<string>  $userIds
+     * @return list<string>
+     */
+    public function filterUserIdsMatchingAcademicScope(array $userIds, ReviewerAcademicAssignmentScope $scope): array
     {
-        return $this->searchReviewerCandidatesByPermission(self::PERMISSION_DOCUMENT_REVIEW, $search, $limit, $excludeUserId);
+        $userIds = array_values(array_unique(array_filter($userIds, static fn (string $id): bool => $id !== '')));
+
+        if ($userIds === [] || $scope->matchesNothing()) {
+            return [];
+        }
+
+        $query = DB::table('users')->whereIn('users.id', $userIds);
+        $this->applyAcademicScopeFilter($query, $scope);
+
+        return $query
+            ->pluck('users.id')
+            ->map(static fn ($id) => (string) $id)
+            ->values()
+            ->all();
     }
 
     /**
@@ -80,6 +124,7 @@ class UserDirectoryRepository implements UserDirectoryRepositoryInterface
         string $search,
         int $limit,
         ?string $excludeUserId = null,
+        ?ReviewerAcademicAssignmentScope $academicScope = null,
     ): array {
         $query = DB::table('users')
             ->join('user_resolved_permissions', 'users.id', '=', 'user_resolved_permissions.user_id')
@@ -87,6 +132,10 @@ class UserDirectoryRepository implements UserDirectoryRepositoryInterface
 
         if ($excludeUserId !== null && $excludeUserId !== '') {
             $query->where('users.id', '!=', $excludeUserId);
+        }
+
+        if ($academicScope !== null) {
+            $this->applyAcademicScopeFilter($query, $academicScope);
         }
 
         if (mb_strlen($search) >= 2) {
@@ -109,6 +158,58 @@ class UserDirectoryRepository implements UserDirectoryRepositoryInterface
             ])
             ->values()
             ->all();
+    }
+
+    private function applyAcademicScopeFilter(Builder $query, ReviewerAcademicAssignmentScope $scope): void
+    {
+        if ($scope->matchesNothing()) {
+            $query->whereRaw('1 = 0');
+
+            return;
+        }
+
+        $query->where(function (Builder $w) use ($scope): void {
+            if ($scope->moduleIds !== []) {
+                $w->orWhereExists(function (Builder $sub) use ($scope): void {
+                    $sub->select(DB::raw(1))
+                        ->from('user_course_modules')
+                        ->whereColumn('user_course_modules.user_id', 'users.id')
+                        ->whereIn('user_course_modules.module_id', $scope->moduleIds);
+                });
+            }
+
+            if ($scope->studyIds !== []) {
+                $w->orWhereExists(function (Builder $sub) use ($scope): void {
+                    $sub->select(DB::raw(1))
+                        ->from('user_studies')
+                        ->whereColumn('user_studies.user_id', 'users.id')
+                        ->whereIn('user_studies.study_id', $scope->studyIds);
+                });
+            }
+
+            if ($scope->studyTypeIds !== []) {
+                $w->orWhereExists(function (Builder $sub) use ($scope): void {
+                    $sub->select(DB::raw(1))
+                        ->from('user_study_types')
+                        ->whereColumn('user_study_types.user_id', 'users.id')
+                        ->whereIn('user_study_types.study_type_id', $scope->studyTypeIds);
+                });
+            }
+
+            if ($scope->teamIds !== []) {
+                $w->orWhereExists(function (Builder $sub) use ($scope): void {
+                    $sub->select(DB::raw(1))
+                        ->from('team_members');
+                    if (DB::connection()->getDriverName() === 'pgsql') {
+                        $sub->whereRaw('team_members.user_id::text = users.id::text')
+                            ->whereIn(DB::raw('team_members.team_id::text'), $scope->teamIds);
+                    } else {
+                        $sub->whereColumn('team_members.user_id', 'users.id')
+                            ->whereIn('team_members.team_id', $scope->teamIds);
+                    }
+                });
+            }
+        });
     }
 
     public function findNameById(string $userId): ?string

--- a/backend/app/Services/Contracts/UserDirectoryServiceInterface.php
+++ b/backend/app/Services/Contracts/UserDirectoryServiceInterface.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Services\Contracts;
 
+use App\DTOs\Users\ReviewerCandidateFilterDto;
+
 interface UserDirectoryServiceInterface
 {
     /**
@@ -18,12 +20,22 @@ interface UserDirectoryServiceInterface
      *
      * @return list<array{id: string, name: ?string, email: ?string, role: ?string}>
      */
-    public function searchTemplateReviewerCandidates(string $search, int $limit, ?string $excludeUserId = null): array;
+    public function searchTemplateReviewerCandidates(
+        string $search,
+        int $limit,
+        ?string $excludeUserId = null,
+        ?ReviewerCandidateFilterDto $academicFilter = null,
+    ): array;
 
     /**
      * Usuarios con permiso `documents.review`.
      *
      * @return list<array{id: string, name: ?string, email: ?string, role: ?string}>
      */
-    public function searchDocumentReviewerCandidates(string $search, int $limit, ?string $excludeUserId = null): array;
+    public function searchDocumentReviewerCandidates(
+        string $search,
+        int $limit,
+        ?string $excludeUserId = null,
+        ?ReviewerCandidateFilterDto $academicFilter = null,
+    ): array;
 }

--- a/backend/app/Services/ReviewerAcademicScopeResolver.php
+++ b/backend/app/Services/ReviewerAcademicScopeResolver.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\DTOs\Users\ReviewerAcademicAssignmentScope;
+use App\DTOs\Users\ReviewerCandidateFilterDto;
+use App\Enums\TemplateVisibilityLevel;
+use App\Repositories\Contracts\AcademicHierarchyRepositoryInterface;
+
+/**
+ * Resuelve el ámbito académico aplicable a candidatos validadores según visibilidad
+ * de plantilla/documento. `global` y `personal` no aplican filtro (null).
+ */
+final class ReviewerAcademicScopeResolver
+{
+    public function __construct(
+        private readonly AcademicHierarchyRepositoryInterface $academicHierarchyRepository,
+    ) {}
+
+  /**
+   * @return ReviewerAcademicAssignmentScope|null null = sin filtro académico
+   */
+    public function resolveFromFilter(ReviewerCandidateFilterDto $filter): ?ReviewerAcademicAssignmentScope
+    {
+        return $this->resolve(
+            $filter->visibilityLevel,
+            $filter->studyTypeId,
+            $filter->studyId,
+            $filter->moduleId,
+            $filter->teamId,
+        );
+    }
+
+    /**
+     * @return ReviewerAcademicAssignmentScope|null null = sin filtro académico
+     */
+    public function resolve(
+        ?string $visibilityLevel,
+        ?string $studyTypeId,
+        ?string $studyId,
+        ?string $moduleId,
+        ?string $teamId,
+    ): ?ReviewerAcademicAssignmentScope {
+        $level = TemplateVisibilityLevel::tryFrom((string) $visibilityLevel);
+
+        if ($level === null || $level === TemplateVisibilityLevel::Global || $level === TemplateVisibilityLevel::Personal) {
+            return null;
+        }
+
+        return match ($level) {
+            TemplateVisibilityLevel::Team => $this->resolveTeamScope($teamId),
+            TemplateVisibilityLevel::StudyType => $this->resolveStudyTypeScope($studyTypeId),
+            TemplateVisibilityLevel::Study => $this->resolveStudyScope($studyId, $studyTypeId),
+            TemplateVisibilityLevel::Module => $this->resolveModuleScope($moduleId),
+            default => null,
+        };
+    }
+
+    private function resolveTeamScope(?string $teamId): ReviewerAcademicAssignmentScope
+    {
+        if ($teamId === null || $teamId === '') {
+            return new ReviewerAcademicAssignmentScope;
+        }
+
+        return new ReviewerAcademicAssignmentScope(teamIds: [$teamId]);
+    }
+
+    private function resolveStudyTypeScope(?string $studyTypeId): ReviewerAcademicAssignmentScope
+    {
+        if ($studyTypeId === null || $studyTypeId === '') {
+            return new ReviewerAcademicAssignmentScope;
+        }
+
+        return new ReviewerAcademicAssignmentScope(studyTypeIds: [$studyTypeId]);
+    }
+
+    private function resolveStudyScope(?string $studyId, ?string $studyTypeId): ReviewerAcademicAssignmentScope
+    {
+        if ($studyId === null || $studyId === '') {
+            return new ReviewerAcademicAssignmentScope;
+        }
+
+        $resolvedStudyTypeId = $studyTypeId;
+        if ($resolvedStudyTypeId === null || $resolvedStudyTypeId === '') {
+            $resolvedStudyTypeId = $this->academicHierarchyRepository->findStudyTypeIdByStudyId($studyId);
+        }
+
+        return new ReviewerAcademicAssignmentScope(
+            studyIds: [$studyId],
+            studyTypeIds: $resolvedStudyTypeId !== null && $resolvedStudyTypeId !== '' ? [$resolvedStudyTypeId] : [],
+        );
+    }
+
+    private function resolveModuleScope(?string $moduleId): ReviewerAcademicAssignmentScope
+    {
+        if ($moduleId === null || $moduleId === '') {
+            return new ReviewerAcademicAssignmentScope;
+        }
+
+        $hierarchy = $this->academicHierarchyRepository->findStudyAndTypeByModuleId($moduleId);
+
+        return new ReviewerAcademicAssignmentScope(
+            moduleIds: [$moduleId],
+            studyIds: $hierarchy !== null ? [$hierarchy['study_id']] : [],
+            studyTypeIds: $hierarchy !== null ? [$hierarchy['study_type_id']] : [],
+        );
+    }
+}

--- a/backend/app/Services/TemplateReviewService.php
+++ b/backend/app/Services/TemplateReviewService.php
@@ -169,7 +169,7 @@ class TemplateReviewService
                 ->where('user_id', $actorId)
                 ->update(['status' => 'rejected']);
 
-            return $this->templatePublishingService->transitionStatus($template, 'draft', $actorId);
+            return $this->templatePublishingService->transitionStatus($template, 'rejected', $actorId);
         });
     }
 

--- a/backend/app/Services/TemplateReviewerAssignmentService.php
+++ b/backend/app/Services/TemplateReviewerAssignmentService.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace App\Services;
 
 use App\DTOs\Templates\SyncUsersDto;
+use App\Models\Template;
 use App\Repositories\Contracts\ResolvedPermissionReaderInterface;
 use App\Repositories\Contracts\TemplateRepositoryInterface;
+use App\Repositories\Contracts\UserDirectoryRepositoryInterface;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\ValidationException;
 
@@ -15,6 +17,8 @@ class TemplateReviewerAssignmentService
     public function __construct(
         private readonly TemplateRepositoryInterface $templateRepository,
         private readonly ResolvedPermissionReaderInterface $resolvedPermissions,
+        private readonly ReviewerAcademicScopeResolver $academicScopeResolver,
+        private readonly UserDirectoryRepositoryInterface $userDirectoryRepository,
     ) {}
 
     /**
@@ -49,6 +53,7 @@ class TemplateReviewerAssignmentService
             }
 
             $this->assertUsersHavePermission($uniqueUserIds, 'template.review', 'user_ids');
+            $this->assertUsersMatchTemplateAcademicScope($template, $uniqueUserIds, 'user_ids');
 
             // TemplateReviewer usa SoftDeletes; forceDelete elimina filas físicamente
             // para no violar la restricción única (template_id, user_id) al reinsertar.
@@ -80,6 +85,7 @@ class TemplateReviewerAssignmentService
             }
 
             $this->assertUsersHavePermission($uniqueUserIds, 'document.review', 'user_ids');
+            $this->assertUsersMatchTemplateAcademicScope($template, $uniqueUserIds, 'user_ids');
 
             // TemplateDocumentReviewer no usa SoftDeletes: delete() es borrado físico.
             // A diferencia de TemplateReviewer (que sí usa SoftDeletes y requiere forceDelete),
@@ -116,6 +122,40 @@ class TemplateReviewerAssignmentService
         throw ValidationException::withMessages([
             $field => [
                 'Todos los usuarios asignados deben tener el permiso '.$requiredPermission.'.',
+            ],
+        ]);
+    }
+
+    /**
+     * @param  list<string>  $userIds
+     */
+    private function assertUsersMatchTemplateAcademicScope(Template $template, array $userIds, string $field): void
+    {
+        if ($userIds === []) {
+            return;
+        }
+
+        $scope = $this->academicScopeResolver->resolve(
+            is_string($template->visibility_level) ? $template->visibility_level : null,
+            is_string($template->study_type_id) ? $template->study_type_id : null,
+            is_string($template->study_id) ? $template->study_id : null,
+            is_string($template->module_id) ? $template->module_id : null,
+            is_string($template->team_id) ? $template->team_id : null,
+        );
+
+        if ($scope === null) {
+            return;
+        }
+
+        $matching = $this->userDirectoryRepository->filterUserIdsMatchingAcademicScope($userIds, $scope);
+
+        if (count($matching) === count($userIds)) {
+            return;
+        }
+
+        throw ValidationException::withMessages([
+            $field => [
+                'Los validadores asignados deben pertenecer al contexto académico de la plantilla.',
             ],
         ]);
     }

--- a/backend/app/Services/UserDirectoryService.php
+++ b/backend/app/Services/UserDirectoryService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services;
 
+use App\DTOs\Users\ReviewerCandidateFilterDto;
 use App\Repositories\Contracts\UserDirectoryRepositoryInterface;
 use App\Services\Contracts\UserDirectoryServiceInterface;
 
@@ -14,6 +15,7 @@ class UserDirectoryService implements UserDirectoryServiceInterface
 {
     public function __construct(
         private readonly UserDirectoryRepositoryInterface $repository,
+        private readonly ReviewerAcademicScopeResolver $academicScopeResolver,
     ) {}
 
     /**
@@ -24,13 +26,29 @@ class UserDirectoryService implements UserDirectoryServiceInterface
         return $this->repository->searchUsers($search, $limit, $excludeUserId);
     }
 
-    public function searchTemplateReviewerCandidates(string $search, int $limit, ?string $excludeUserId = null): array
-    {
-        return $this->repository->searchTemplateReviewerCandidates($search, $limit, $excludeUserId);
+    public function searchTemplateReviewerCandidates(
+        string $search,
+        int $limit,
+        ?string $excludeUserId = null,
+        ?ReviewerCandidateFilterDto $academicFilter = null,
+    ): array {
+        $scope = $academicFilter !== null
+            ? $this->academicScopeResolver->resolveFromFilter($academicFilter)
+            : null;
+
+        return $this->repository->searchTemplateReviewerCandidates($search, $limit, $excludeUserId, $scope);
     }
 
-    public function searchDocumentReviewerCandidates(string $search, int $limit, ?string $excludeUserId = null): array
-    {
-        return $this->repository->searchDocumentReviewerCandidates($search, $limit, $excludeUserId);
+    public function searchDocumentReviewerCandidates(
+        string $search,
+        int $limit,
+        ?string $excludeUserId = null,
+        ?ReviewerCandidateFilterDto $academicFilter = null,
+    ): array {
+        $scope = $academicFilter !== null
+            ? $this->academicScopeResolver->resolveFromFilter($academicFilter)
+            : null;
+
+        return $this->repository->searchDocumentReviewerCandidates($search, $limit, $excludeUserId, $scope);
     }
 }

--- a/backend/database/data/programaciones_didacticas_pack.php
+++ b/backend/database/data/programaciones_didacticas_pack.php
@@ -27,6 +27,8 @@ declare(strict_types=1);
  *
  * @return array{
  *   templates: list<array<string, mixed>>,
+ *   template_reviewers: list<array<string, mixed>>,
+ *   template_document_reviewers: list<array<string, mixed>>,
  *   template_blocks: list<array<string, mixed>>,
  *   template_versions: list<array<string, mixed>>,
  *   entity_versions: list<array<string, mixed>>,
@@ -626,8 +628,57 @@ return (static function (): array {
 
     $document_blocks = require __DIR__ . '/programaciones_didacticas_doc_blocks.php';
 
+    // ============================================================
+    // TEMPLATE REVIEWERS — Dirección (Keycloak / maya_infra: ed568442…)
+    // ============================================================
+
+    $template_reviewers = [
+        [
+            'id' => 'ff000000-0000-4000-8000-000000000000',
+            'template_id' => $T0,
+            'user_id' => $uDir,
+            'stage' => 1,
+            'status' => 'pending',
+        ],
+        [
+            'id' => 'ff000001-0000-4000-8000-000000000000',
+            'template_id' => $T1,
+            'user_id' => $uDir,
+            'stage' => 1,
+            'status' => 'pending',
+        ],
+        [
+            'id' => 'ff000002-0000-4000-8000-000000000000',
+            'template_id' => $T2,
+            'user_id' => $uDir,
+            'stage' => 1,
+            'status' => 'pending',
+        ],
+    ];
+
+    // ============================================================
+    // TEMPLATE DOCUMENT REVIEWERS — Dirección (Keycloak / maya_infra: ed568442…)
+    // ============================================================
+
+    $template_document_reviewers = [
+        [
+            'template_id' => $T0,
+            'user_id' => $uDir,
+        ],
+        [
+            'template_id' => $T1,
+            'user_id' => $uDir,
+        ],
+        [
+            'template_id' => $T2,
+            'user_id' => $uDir,
+        ],
+    ];
+
     return [
         'templates' => $templates,
+        'template_reviewers' => $template_reviewers,
+        'template_document_reviewers' => $template_document_reviewers,
         'template_blocks' => $blocks,
         'template_versions' => $template_versions,
         'documents' => $documents,

--- a/backend/database/data/templates_mock.php
+++ b/backend/database/data/templates_mock.php
@@ -19,4 +19,6 @@ $pack = require __DIR__ . '/programaciones_didacticas_pack.php';
 
 return [
     'templates' => $pack['templates'],
+    'template_reviewers' => $pack['template_reviewers'],
+    'template_document_reviewers' => $pack['template_document_reviewers'],
 ];

--- a/backend/tests/Feature/UsersSearchApiTest.php
+++ b/backend/tests/Feature/UsersSearchApiTest.php
@@ -194,4 +194,149 @@ class UsersSearchApiTest extends TestCase
         $this->assertNotContains($reviewerA, $ids);
         $this->assertContains($reviewerB, $ids);
     }
+
+    public function test_template_reviewer_candidates_filters_by_study_scope_without_downward_inclusion(): void
+    {
+        $callerId = (string) Str::uuid();
+        $studyTypeId = (string) Str::uuid();
+        $studyId = (string) Str::uuid();
+        $moduleId = (string) Str::uuid();
+        $studyReviewerId = (string) Str::uuid();
+        $moduleOnlyReviewerId = (string) Str::uuid();
+        $otherStudyReviewerId = (string) Str::uuid();
+
+        DB::table('study_types')->insert([
+            'id' => $studyTypeId,
+            'name' => 'Grado test',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+        DB::table('studies')->insert([
+            'id' => $studyId,
+            'study_type_id' => $studyTypeId,
+            'name' => 'Medicina test',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+        DB::table('course_modules')->insert([
+            'id' => $moduleId,
+            'study_id' => $studyId,
+            'name' => 'Anatomía test',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        foreach ([$studyReviewerId, $moduleOnlyReviewerId, $otherStudyReviewerId] as $rid) {
+            DB::table('users')->insert([
+                'id' => $rid,
+                'name' => 'Reviewer '.$rid,
+                'email' => 'scope-'.$rid.'@maya.test',
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+            DB::table('user_resolved_permissions')->insertOrIgnore([
+                'user_id' => $rid,
+                'permission_slug' => 'template.review',
+            ]);
+        }
+
+        DB::table('user_studies')->insert([
+            'id' => (string) Str::uuid(),
+            'user_id' => $studyReviewerId,
+            'study_id' => $studyId,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+        DB::table('user_course_modules')->insert([
+            'id' => (string) Str::uuid(),
+            'user_id' => $moduleOnlyReviewerId,
+            'module_id' => $moduleId,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+        DB::table('user_studies')->insert([
+            'id' => (string) Str::uuid(),
+            'user_id' => $otherStudyReviewerId,
+            'study_id' => (string) Str::uuid(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $url = '/api/v1/users/reviewer-candidates?visibility_level=study&study_id='.urlencode($studyId);
+        $response = $this->getJson($url, $this->authHeaders($callerId, ['template.show']));
+
+        $response->assertOk();
+        $ids = array_column($response->json('data'), 'id');
+        $this->assertContains($studyReviewerId, $ids);
+        $this->assertNotContains($moduleOnlyReviewerId, $ids);
+        $this->assertNotContains($otherStudyReviewerId, $ids);
+    }
+
+    public function test_template_reviewer_candidates_module_scope_includes_parent_study_assignment(): void
+    {
+        $callerId = (string) Str::uuid();
+        $studyTypeId = (string) Str::uuid();
+        $studyId = (string) Str::uuid();
+        $moduleId = (string) Str::uuid();
+        $studyReviewerId = (string) Str::uuid();
+        $moduleReviewerId = (string) Str::uuid();
+
+        DB::table('study_types')->insert([
+            'id' => $studyTypeId,
+            'name' => 'Grado module scope',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+        DB::table('studies')->insert([
+            'id' => $studyId,
+            'study_type_id' => $studyTypeId,
+            'name' => 'Estudio module scope',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+        DB::table('course_modules')->insert([
+            'id' => $moduleId,
+            'study_id' => $studyId,
+            'name' => 'Módulo module scope',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        foreach ([$studyReviewerId, $moduleReviewerId] as $rid) {
+            DB::table('users')->insert([
+                'id' => $rid,
+                'name' => 'Module scope '.$rid,
+                'email' => 'mod-'.$rid.'@maya.test',
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+            DB::table('user_resolved_permissions')->insertOrIgnore([
+                'user_id' => $rid,
+                'permission_slug' => 'template.review',
+            ]);
+        }
+
+        DB::table('user_studies')->insert([
+            'id' => (string) Str::uuid(),
+            'user_id' => $studyReviewerId,
+            'study_id' => $studyId,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+        DB::table('user_course_modules')->insert([
+            'id' => (string) Str::uuid(),
+            'user_id' => $moduleReviewerId,
+            'module_id' => $moduleId,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $url = '/api/v1/users/reviewer-candidates?visibility_level=module&module_id='.urlencode($moduleId);
+        $response = $this->getJson($url, $this->authHeaders($callerId, ['template.show']));
+
+        $response->assertOk();
+        $ids = array_column($response->json('data'), 'id');
+        $this->assertContains($studyReviewerId, $ids);
+        $this->assertContains($moduleReviewerId, $ids);
+    }
 }

--- a/backend/tests/Unit/Services/ReviewerAcademicScopeResolverTest.php
+++ b/backend/tests/Unit/Services/ReviewerAcademicScopeResolverTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services;
+
+use App\DTOs\Users\ReviewerAcademicAssignmentScope;
+use App\Repositories\Contracts\AcademicHierarchyRepositoryInterface;
+use App\Services\ReviewerAcademicScopeResolver;
+use Mockery;
+use Tests\TestCase;
+
+final class ReviewerAcademicScopeResolverTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    public function test_global_and_personal_return_null_scope(): void
+    {
+        $resolver = new ReviewerAcademicScopeResolver(Mockery::mock(AcademicHierarchyRepositoryInterface::class));
+
+        $this->assertNull($resolver->resolve('global', null, null, null, null));
+        $this->assertNull($resolver->resolve('personal', 'st-1', 's-1', 'm-1', null));
+    }
+
+    public function test_study_type_scope_only_includes_study_type_assignment(): void
+    {
+        $resolver = new ReviewerAcademicScopeResolver(Mockery::mock(AcademicHierarchyRepositoryInterface::class));
+
+        $scope = $resolver->resolve('study_type', 'st-1', null, null, null);
+
+        $this->assertInstanceOf(ReviewerAcademicAssignmentScope::class, $scope);
+        $this->assertSame(['st-1'], $scope->studyTypeIds);
+        $this->assertSame([], $scope->studyIds);
+        $this->assertSame([], $scope->moduleIds);
+    }
+
+    public function test_study_scope_includes_study_and_parent_study_type(): void
+    {
+        $hierarchy = Mockery::mock(AcademicHierarchyRepositoryInterface::class);
+        $hierarchy->shouldReceive('findStudyTypeIdByStudyId')->once()->with('s-1')->andReturn('st-1');
+
+        $resolver = new ReviewerAcademicScopeResolver($hierarchy);
+        $scope = $resolver->resolve('study', null, 's-1', null, null);
+
+        $this->assertSame(['s-1'], $scope->studyIds);
+        $this->assertSame(['st-1'], $scope->studyTypeIds);
+        $this->assertSame([], $scope->moduleIds);
+    }
+
+    public function test_module_scope_includes_module_study_and_study_type(): void
+    {
+        $hierarchy = Mockery::mock(AcademicHierarchyRepositoryInterface::class);
+        $hierarchy->shouldReceive('findStudyAndTypeByModuleId')->once()->with('m-1')->andReturn([
+            'study_id' => 's-1',
+            'study_type_id' => 'st-1',
+        ]);
+
+        $resolver = new ReviewerAcademicScopeResolver($hierarchy);
+        $scope = $resolver->resolve('module', null, null, 'm-1', null);
+
+        $this->assertSame(['m-1'], $scope->moduleIds);
+        $this->assertSame(['s-1'], $scope->studyIds);
+        $this->assertSame(['st-1'], $scope->studyTypeIds);
+    }
+
+    public function test_team_scope_only_includes_team_membership(): void
+    {
+        $resolver = new ReviewerAcademicScopeResolver(Mockery::mock(AcademicHierarchyRepositoryInterface::class));
+
+        $scope = $resolver->resolve('team', null, null, null, 'team-1');
+
+        $this->assertSame(['team-1'], $scope->teamIds);
+        $this->assertSame([], $scope->studyIds);
+    }
+}

--- a/backend/tests/Unit/Services/TemplateReviewerAssignmentServiceTest.php
+++ b/backend/tests/Unit/Services/TemplateReviewerAssignmentServiceTest.php
@@ -8,6 +8,8 @@ use App\DTOs\Templates\SyncUsersDto;
 use App\Models\Template;
 use App\Repositories\Contracts\TemplateRepositoryInterface;
 use App\Repositories\Contracts\ResolvedPermissionReaderInterface;
+use App\Repositories\Contracts\UserDirectoryRepositoryInterface;
+use App\Services\ReviewerAcademicScopeResolver;
 use App\Services\TemplateReviewerAssignmentService;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\ValidationException;
@@ -46,6 +48,11 @@ final class TemplateReviewerAssignmentServiceTest extends TestCase
         $template->shouldReceive('getAttribute')->with('review_mode')->andReturn($reviewMode);
         $template->shouldReceive('getAttribute')->with('review_stages')->andReturn($reviewStages);
         $template->shouldReceive('getAttribute')->with('id')->andReturn('tmpl-uuid');
+        $template->shouldReceive('getAttribute')->with('visibility_level')->andReturn('personal');
+        $template->shouldReceive('getAttribute')->with('study_type_id')->andReturn(null);
+        $template->shouldReceive('getAttribute')->with('study_id')->andReturn(null);
+        $template->shouldReceive('getAttribute')->with('module_id')->andReturn(null);
+        $template->shouldReceive('getAttribute')->with('team_id')->andReturn(null);
 
         return $template;
     }
@@ -53,8 +60,21 @@ final class TemplateReviewerAssignmentServiceTest extends TestCase
     private function makeService(
         TemplateRepositoryInterface $templateRepo,
         ResolvedPermissionReaderInterface $permRepo,
+        ?ReviewerAcademicScopeResolver $scopeResolver = null,
+        ?UserDirectoryRepositoryInterface $userDirectoryRepository = null,
     ): TemplateReviewerAssignmentService {
-        return new TemplateReviewerAssignmentService($templateRepo, $permRepo);
+        $scopeResolver ??= Mockery::mock(ReviewerAcademicScopeResolver::class);
+        $scopeResolver->shouldReceive('resolve')->andReturnNull()->byDefault();
+
+        $userDirectoryRepository ??= Mockery::mock(UserDirectoryRepositoryInterface::class);
+        $userDirectoryRepository->shouldReceive('filterUserIdsMatchingAcademicScope')->andReturn([])->byDefault();
+
+        return new TemplateReviewerAssignmentService(
+            $templateRepo,
+            $permRepo,
+            $scopeResolver,
+            $userDirectoryRepository,
+        );
     }
 
     /**

--- a/frontend/src/api/templates.ts
+++ b/frontend/src/api/templates.ts
@@ -80,7 +80,13 @@ function buildListQuery(filters: TemplateListFilters): string {
 
 /** GET /api/v1/templates */
 export async function fetchTemplates(filters: TemplateListFilters = {}): Promise<TemplatesListResponse> {
-  return apiGetJson<TemplatesListResponse>(`templates${buildListQuery(filters)}`);
+  const body = await apiGetJson<TemplatesListResponse | Template[]>(
+    `templates${buildListQuery(filters)}`,
+  );
+  if (Array.isArray(body)) {
+    return { data: body };
+  }
+  return { data: Array.isArray(body?.data) ? body.data : [] };
 }
 
 /** GET /api/v1/templates/{id} */

--- a/frontend/src/api/users.ts
+++ b/frontend/src/api/users.ts
@@ -4,6 +4,15 @@ import { apiFetchJson, apiGetJson } from './http';
 
 export type { MeProfile, User, UserTeam } from '../types/users';
 
+/** Contexto académico para acotar candidatos a validador según visibilidad de plantilla. */
+export type ReviewerCandidateAcademicContext = {
+  visibility_level?: string;
+  study_type_id?: string;
+  study_id?: string;
+  module_id?: string;
+  team_id?: string;
+};
+
 const profileApi = createProfileApi<MeProfile>({ apiFetchJson, apiGetJson });
 
 /** GET /api/v1/users?search={query}&per_page=20 */
@@ -19,6 +28,7 @@ export async function searchUsers(query: string, excludeUserId?: string): Promis
 export async function searchTemplateReviewerCandidates(
   query = '',
   excludeUserId?: string,
+  academicContext?: ReviewerCandidateAcademicContext,
 ): Promise<UsersSearchResponse> {
   const q = new URLSearchParams({ per_page: '50' });
   const trimmed = query.trim();
@@ -28,6 +38,7 @@ export async function searchTemplateReviewerCandidates(
   if (excludeUserId) {
     q.set('exclude_user_id', excludeUserId);
   }
+  appendReviewerAcademicContext(q, academicContext);
   return apiGetJson<UsersSearchResponse>(`users/reviewer-candidates?${q.toString()}`);
 }
 
@@ -35,6 +46,7 @@ export async function searchTemplateReviewerCandidates(
 export async function searchDocumentReviewerCandidates(
   query = '',
   excludeUserId?: string,
+  academicContext?: ReviewerCandidateAcademicContext,
 ): Promise<UsersSearchResponse> {
   const q = new URLSearchParams({ per_page: '50' });
   const trimmed = query.trim();
@@ -44,7 +56,30 @@ export async function searchDocumentReviewerCandidates(
   if (excludeUserId) {
     q.set('exclude_user_id', excludeUserId);
   }
+  appendReviewerAcademicContext(q, academicContext);
   return apiGetJson<UsersSearchResponse>(`users/document-reviewer-candidates?${q.toString()}`);
+}
+
+function appendReviewerAcademicContext(
+  params: URLSearchParams,
+  academicContext?: ReviewerCandidateAcademicContext,
+): void {
+  if (!academicContext?.visibility_level) {
+    return;
+  }
+  params.set('visibility_level', academicContext.visibility_level);
+  if (academicContext.study_type_id) {
+    params.set('study_type_id', academicContext.study_type_id);
+  }
+  if (academicContext.study_id) {
+    params.set('study_id', academicContext.study_id);
+  }
+  if (academicContext.module_id) {
+    params.set('module_id', academicContext.module_id);
+  }
+  if (academicContext.team_id) {
+    params.set('team_id', academicContext.team_id);
+  }
 }
 
 /** GET /api/v1/users/owner-candidates?search={query}&per_page=20 */

--- a/frontend/src/features/documents/components/DocumentDiffPanel.tsx
+++ b/frontend/src/features/documents/components/DocumentDiffPanel.tsx
@@ -130,14 +130,21 @@ function blockStateLabel(
 
 // ── Component ─────────────────────────────────────────────────────────────────
 
-type Props = { blocks: DocumentDisplayBlock[]; onClose: () => void };
+type Props = {
+  /** Bloques a mostrar en el diff (p. ej. solo el bloque seleccionado). */
+  blocks: DocumentDisplayBlock[];
+  /** Lista completa del documento para numerar bloques; si no se pasa, se usa `blocks`. */
+  allBlocks?: DocumentDisplayBlock[];
+  onClose: () => void;
+};
 
-export function DocumentDiffPanel({ blocks, onClose }: Props) {
+export function DocumentDiffPanel({ blocks, allBlocks, onClose }: Props) {
   const { t } = useTranslation('documents');
   const [ascending, setAscending] = useState(true);
   const [focusedIdx, setFocusedIdx] = useState(0);
   const blockRefs = useRef<(HTMLDivElement | null)[]>([]);
 
+  const numberingBlocks = allBlocks ?? blocks;
   const changedBlocks = useMemo(() => computeChangedBlocks(blocks), [blocks]);
 
   const diffLines = useMemo(
@@ -162,10 +169,11 @@ export function DocumentDiffPanel({ blocks, onClose }: Props) {
         .map((block, idx) => ({
           block,
           lines: diffLines[idx] ?? [],
-          blockNumber: blocks.findIndex(b => b.template_block_id === block.template_block_id) + 1,
+          blockNumber:
+            numberingBlocks.findIndex(b => b.template_block_id === block.template_block_id) + 1,
         }))
         .filter(({ lines }) => lines.length > 0),
-    [changedBlocks, diffLines, blocks],
+    [changedBlocks, diffLines, numberingBlocks],
   );
 
   const pairs = useMemo(

--- a/frontend/src/features/documents/components/DocumentWizard.tsx
+++ b/frontend/src/features/documents/components/DocumentWizard.tsx
@@ -653,10 +653,15 @@ export function DocumentWizard({ documentId, templateId, mode = 'edit' }: Props)
       setTemplateReviewerPoolIds([]);
       setReviewerListKind('none');
       try {
-        const [templateResp, usersResp] = await Promise.all([
-          fetchTemplate(detail.template_id),
-          searchDocumentReviewerCandidates(),
-        ]);
+        const templateResp = await fetchTemplate(detail.template_id);
+        if (cancelled) return;
+        const usersResp = await searchDocumentReviewerCandidates('', undefined, {
+          visibility_level: templateResp.data.visibility_level,
+          study_type_id: templateResp.data.study_type_id ?? undefined,
+          study_id: templateResp.data.study_id ?? undefined,
+          module_id: templateResp.data.module_id ?? undefined,
+          team_id: templateResp.data.team_id ?? undefined,
+        });
         if (cancelled) return;
         setDocumentReviewMode(templateResp.data.review_mode ?? 'parallel');
 

--- a/frontend/src/features/documents/components/DocumentWizard.tsx
+++ b/frontend/src/features/documents/components/DocumentWizard.tsx
@@ -178,7 +178,7 @@ export function DocumentWizard({ documentId, templateId, mode = 'edit' }: Props)
   const [documentReviewers, setDocumentReviewers] = useState<ReviewerView[]>([]);
   /** IDs de `template_document_reviewers` (vacío si la plantilla no define pool de documento). */
   const [, setDocumentReviewerPoolIds] = useState<string[]>([]);
-  /** IDs de `template_reviewers` (revisores normativos; el backend los usa si no hay pool de documento). */
+  /** IDs de `template_reviewers` (solo informativos en UI si no hay pool de documento). */
   const [, setTemplateReviewerPoolIds] = useState<string[]>([]);
   const [reviewerListKind, setReviewerListKind] = useState<'document' | 'template_fallback' | 'none'>('none');
   const [documentReviewMode, setDocumentReviewMode] = useState<ReviewModeView>('parallel');
@@ -519,6 +519,8 @@ export function DocumentWizard({ documentId, templateId, mode = 'edit' }: Props)
   const allStudies = hierarchy.flatMap((t) => t.studies);
   const selectedTemplateVisibility = template?.visibility_level ?? detail?.visibility_level ?? null;
   const visibilityRule: VisibilityRuleMode = selectedTemplateVisibility ?? 'unknown';
+  /** Solo hay revisión de documento si la plantilla define validadores de documento (no revisores de plantilla). */
+  const willSubmitDocumentToReview = reviewerListKind === 'document';
   const templateStudyTypeId = template?.study_type_id ?? null;
   const templateStudyId = template?.study_id ?? null;
   const templateModuleId = template?.module_id ?? null;
@@ -1177,7 +1179,7 @@ export function DocumentWizard({ documentId, templateId, mode = 'edit' }: Props)
             disabled={!isDraft}
             onClick={() => setSummaryConfirmAction('submit')}
           >
-            Enviar a validar
+            {willSubmitDocumentToReview ? 'Enviar a validar' : 'Publicar'}
           </Button>
         </>
       )}
@@ -1758,8 +1760,8 @@ export function DocumentWizard({ documentId, templateId, mode = 'edit' }: Props)
                 <div className="space-y-1">
                   {reviewerListKind === 'template_fallback' && (
                     <p className="text-xs text-text-muted dark:text-text-dark-muted leading-snug">
-                      La plantilla no define validadores de documento; al enviar se usarán los revisores
-                      normativos de la plantilla (misma prioridad que en el servidor).
+                      La plantilla no define validadores de documento. Los revisores de plantilla listados abajo
+                      no aplican a la revisión del documento; al publicar no pasará por validación.
                     </p>
                   )}
                   <ul className="mt-1 space-y-1 text-xs">
@@ -1989,19 +1991,23 @@ export function DocumentWizard({ documentId, templateId, mode = 'edit' }: Props)
       />
       <ConfirmDialog
         open={summaryConfirmAction !== null}
-        title={summaryConfirmAction === 'submit' ? 'Confirmar envío a validar' : 'Confirmar guardado'}
+        title={
+          summaryConfirmAction === 'submit'
+            ? willSubmitDocumentToReview
+              ? 'Confirmar envío a validar'
+              : 'Confirmar publicación'
+            : 'Confirmar guardado'
+        }
         description={
           summaryConfirmAction === 'submit'
             ? (
                 <div className="space-y-2">
                   <p>
-                    {reviewerListKind === 'document'
+                    {willSubmitDocumentToReview
                       ? 'Se enviará una notificación a los validadores del documento configurados en la plantilla.'
-                      : reviewerListKind === 'template_fallback'
-                        ? 'La plantilla no tiene validadores de documento; se notificará según los revisores normativos de la plantilla listados abajo.'
-                        : 'No hay revisores configurados en la plantilla para este envío.'}
+                      : 'No hay validadores de documento en la plantilla. El documento se publicará directamente sin pasar por revisión.'}
                   </p>
-                  {documentReviewers.length > 0 ? (
+                  {willSubmitDocumentToReview && documentReviewers.length > 0 ? (
                     <>
                       <p>
                         Tipo de revisión:{' '}
@@ -2021,15 +2027,19 @@ export function DocumentWizard({ documentId, templateId, mode = 'edit' }: Props)
                         </ul>
                       )}
                     </>
-                  ) : (
-                    <p>No hay personas en la lista de revisión para mostrar.</p>
-                  )}
+                  ) : null}
                   <p>Después no se podrá seguir editando como borrador.</p>
                 </div>
               )
             : '¿Quieres guardar y salir sin enviar? El documento permanecerá en estado borrador.'
         }
-        confirmLabel={summaryConfirmAction === 'submit' ? 'Sí, enviar a validar' : 'Sí, guardar y salir'}
+        confirmLabel={
+          summaryConfirmAction === 'submit'
+            ? willSubmitDocumentToReview
+              ? 'Sí, enviar a validar'
+              : 'Sí, publicar'
+            : 'Sí, guardar y salir'
+        }
         cancelLabel="Cancelar"
         variant={summaryConfirmAction === 'submit' ? 'primary' : 'teal'}
         loading={summaryConfirmAction === 'submit' && submittingForReview}
@@ -2039,7 +2049,7 @@ export function DocumentWizard({ documentId, templateId, mode = 'edit' }: Props)
       <ConfirmDialog
         open={showNoValidatorsDocModal}
         title="Sin validadores configurados"
-        description="La plantilla no tiene validadores asignados. Al enviar este documento, se publicará automáticamente sin revisión. Para añadir validadores, edita la plantilla."
+        description="La plantilla no tiene validadores de documento. El documento se publicará directamente sin revisión. Para añadir validadores, edita la plantilla."
         confirmLabel="Continuar de todas formas"
         cancelLabel="Cancelar"
         onConfirm={() => {

--- a/frontend/src/features/hierarchy/selectors/academicContextSelector.ts
+++ b/frontend/src/features/hierarchy/selectors/academicContextSelector.ts
@@ -48,8 +48,13 @@ export interface AcademicContextLoad {
  * - Habilita reutilización futura desde otros consumidores (admin views).
  */
 export function buildAcademicContext(payload: AcademicContextPayload): AcademicContextLoad {
+  const studyTypes = payload.study_types ?? [];
+  const studies = payload.studies ?? [];
+  const modules = payload.modules ?? [];
+  const teamsPayload = payload.teams ?? [];
+
   const modulesByStudy = new Map<string, AcademicContextModule[]>();
-  for (const mod of payload.modules) {
+  for (const mod of modules) {
     const bucket = modulesByStudy.get(mod.study_id);
     if (bucket) {
       bucket.push(mod);
@@ -59,7 +64,7 @@ export function buildAcademicContext(payload: AcademicContextPayload): AcademicC
   }
 
   const studiesByType = new Map<string, AcademicContextStudy[]>();
-  for (const study of payload.studies) {
+  for (const study of studies) {
     const bucket = studiesByType.get(study.study_type_id);
     if (bucket) {
       bucket.push(study);
@@ -68,7 +73,7 @@ export function buildAcademicContext(payload: AcademicContextPayload): AcademicC
     }
   }
 
-  const hierarchy: AcademicHierarchy = payload.study_types.map((type) => ({
+  const hierarchy: AcademicHierarchy = studyTypes.map((type) => ({
     id: type.id,
     name: type.name,
     studies: (studiesByType.get(type.id) ?? []).map((study) => ({
@@ -83,7 +88,7 @@ export function buildAcademicContext(payload: AcademicContextPayload): AcademicC
     })),
   }));
 
-  const teams: UserTeam[] = payload.teams.map((team) => ({
+  const teams: UserTeam[] = teamsPayload.map((team) => ({
     id: team.id,
     name: team.name,
     description: null,

--- a/frontend/src/features/templates/components/TemplateReviewView.tsx
+++ b/frontend/src/features/templates/components/TemplateReviewView.tsx
@@ -12,7 +12,7 @@ import { SequentialValidatorBadge } from '../../documents/components/SequentialV
 import { Button, ConfirmDialog } from '@maya/shared-ui-react';
 import { approveTemplateReview, rejectTemplateReview } from '../../../api/templates';
 import { canCreateBlockComment, canDeleteBlockComment, DMS_PERMISSIONS } from '../../../permissions';
-import { apiFetchJson } from '../../../api/http';
+import { apiFetchJson, ApiHttpError } from '../../../api/http';
 import { useUserProfile } from '../../user-profile';
 import { useProcessesQuery } from '../../../hooks/useProcesses';
 import {
@@ -317,8 +317,7 @@ export function TemplateReviewView({ template }: Props) {
   const [activeView, setActiveView] = useState<ActiveView | null>(null);
   const [diffBlockId, setDiffBlockId] = useState<string | null>(null);
   const [actionLoading, setActionLoading] = useState(false);
-  // Error state tracked for telemetry but not surfaced in this view yet.
-  const [, setError] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
   const [, setCommentLoading] = useState(false);
 
@@ -428,9 +427,10 @@ export function TemplateReviewView({ template }: Props) {
     setError(null);
     try {
       await approveTemplateReview(template.id);
+      await queryClient.invalidateQueries({ queryKey: ['templates'] });
       navigate(backTo);
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Error al aprobar la plantilla');
+      setError(e instanceof ApiHttpError ? e.message : e instanceof Error ? e.message : 'Error al aprobar la plantilla');
     } finally {
       setActionLoading(false);
     }
@@ -450,9 +450,10 @@ export function TemplateReviewView({ template }: Props) {
     setError(null);
     try {
       await rejectTemplateReview(template.id);
+      await queryClient.invalidateQueries({ queryKey: ['templates'] });
       navigate(backTo);
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Error al rechazar la plantilla');
+      setError(e instanceof ApiHttpError ? e.message : e instanceof Error ? e.message : 'Error al rechazar la plantilla');
     } finally {
       setActionLoading(false);
     }
@@ -566,6 +567,14 @@ export function TemplateReviewView({ template }: Props) {
             : undefined
       }
     >
+      {error && (
+        <div
+          role="alert"
+          className="mb-6 rounded-lg border border-danger/30 bg-danger/10 px-4 py-3 text-sm text-danger-dark dark:text-danger"
+        >
+          {error}
+        </div>
+      )}
       {/* Blocks list (article content) */}
       <div className="space-y-12">
         {blocks.length === 0 ? (

--- a/frontend/src/features/templates/components/TemplateWizard.tsx
+++ b/frontend/src/features/templates/components/TemplateWizard.tsx
@@ -685,6 +685,10 @@ export function TemplateWizard({ template: templateProp, initialTemplate, proces
           {step === 'users' && (
             <WizardStep3Users
               visibilityLevel={step1Methods.watch('visibility')}
+              studyTypeId={step1Methods.watch('studyTypeId') || undefined}
+              studyId={step1Methods.watch('studyId') || undefined}
+              moduleId={step1Methods.watch('moduleId') || undefined}
+              teamId={step1Methods.watch('teamId') || undefined}
               validators={validators}
               onValidatorsChange={(v) => { setValidators(v); setUsersDirty(true); }}
               validationType={validationType}

--- a/frontend/src/features/templates/components/TemplatesContent.tsx
+++ b/frontend/src/features/templates/components/TemplatesContent.tsx
@@ -231,11 +231,11 @@ export function TemplatesContent() {
         header: 'Nombre',
         sortable: true,
         alwaysVisible: true,
-        cell: (t) => (
+        cell: (template) => (
           <span className="flex items-center gap-2 min-w-0">
-            {favoriteTemplateIds.has(t.id) && <FavoriteInlineMark />}
-            <span className="truncate font-medium">{t.name}</span>
-            {t.has_review_comments && (t.status === 'draft' || t.status === 'rejected') && profile && t.created_by === profile.id && (
+            {favoriteTemplateIds.has(template.id) && <FavoriteInlineMark />}
+            <span className="truncate font-medium">{template.name}</span>
+            {template.has_review_comments && (template.status === 'draft' || template.status === 'rejected') && profile && template.created_by === profile.id && (
               <span
                 className="shrink-0 inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded text-xs font-bold bg-danger/10 text-danger-dark dark:text-danger border border-danger/20"
                 title={t('templates:pendingReviewTitle')}
@@ -249,18 +249,18 @@ export function TemplatesContent() {
       {
         id: 'visibility_level',
         header: 'Visibilidad',
-        cell: (t) => {
+        cell: (template) => {
           const caption = formatListRowVisibilityCaption(hierarchy, {
-            visibility_level: t.visibility_level,
-            study_type_id: t.study_type_id,
-            study_id: t.study_id,
-            module_id: t.module_id,
-            team_id: t.team_id,
-            team: t.team,
+            visibility_level: template.visibility_level,
+            study_type_id: template.study_type_id,
+            study_id: template.study_id,
+            module_id: template.module_id,
+            team_id: template.team_id,
+            team: template.team,
           });
           return (
             <span
-              className={`inline-flex max-w-full min-w-0 text-xs font-medium px-2 py-0.5 rounded-full ${visibilityBadgeClass(t.visibility_level)}`}
+              className={`inline-flex max-w-full min-w-0 text-xs font-medium px-2 py-0.5 rounded-full ${visibilityBadgeClass(template.visibility_level)}`}
               title={caption}
             >
               <span className="truncate">{caption}</span>
@@ -271,17 +271,17 @@ export function TemplatesContent() {
       {
         id: 'author_name',
         header: 'Autor',
-        cell: (t) => (
+        cell: (template) => (
           <span className="text-xs text-text-secondary dark:text-text-dark-secondary">
-            {t.author_name ?? '—'}
+            {template.author_name ?? '—'}
           </span>
         ),
       },
       {
         id: 'status',
         header: 'Estado',
-        cell: (t) => {
-          const status = t.status as TemplateStatus;
+        cell: (template) => {
+          const status = template.status as TemplateStatus;
           return (
             <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${statusBadgeClass(status)}`}>
               {STATUS_LABEL[status] ?? status}
@@ -293,14 +293,14 @@ export function TemplatesContent() {
         id: 'delivery_deadline',
         header: 'Fecha de validación',
         sortable: true,
-        cell: (t) => (
+        cell: (template) => (
           <span className="text-xs text-text-secondary dark:text-text-dark-secondary">
-            {t.status === 'published' ? '—' : formatCalendarDateForBrowser(t.delivery_deadline)}
+            {template.status === 'published' ? '—' : formatCalendarDateForBrowser(template.delivery_deadline)}
           </span>
         ),
       },
     ],
-    [profile, favoriteTemplateIds, hierarchy],
+    [profile, favoriteTemplateIds, hierarchy, t],
   );
 
   return (

--- a/frontend/src/features/templates/components/TemplatesTable.tsx
+++ b/frontend/src/features/templates/components/TemplatesTable.tsx
@@ -35,6 +35,13 @@ const STATUS_LABEL: Record<TemplateStatus, string> = {
   rejected: 'Rechazada',
 };
 
+function templateStatusLabel(status: string | null | undefined): string {
+  if (!status) {
+    return '—';
+  }
+  return STATUS_LABEL[status as TemplateStatus] ?? status;
+}
+
 // Estado y visibilidad: clases en `@maya/shared-ui-react/badges`.
 
 type Props = {
@@ -238,10 +245,12 @@ export function TemplatesTable({ processId }: Props = {}) {
     if (profile?.id && t.created_by === profile.id) {
       return true;
     }
-    return (
-      t.status === 'in_review'
-      && t.reviewers?.some((r) => r.user_id === profile?.id) === true
-    );
+    const isAssignedReviewer =
+      t.reviewers?.some((r) => r.user_id === profile?.id) === true;
+    if (isAssignedReviewer && (t.status === 'in_review' || t.status === 'rejected')) {
+      return true;
+    }
+    return false;
   };
 
   const handleRowClick = (t: Template) => {
@@ -257,11 +266,18 @@ export function TemplatesTable({ processId }: Props = {}) {
       return;
     }
     const isAssignedReviewer =
-      t.status === 'in_review' && t.reviewers?.some((r) => r.user_id === profile?.id);
-    const openReviewView = isAssignedReviewer && canReview;
-    navigate(openReviewView ? `/templates/${t.id}/review` : `/templates/${t.id}`, {
-      state: { backTo, processId },
-    });
+      t.reviewers?.some((r) => r.user_id === profile?.id) === true;
+    const openReviewView = t.status === 'in_review' && isAssignedReviewer && canReview;
+    if (openReviewView) {
+      navigate(`/templates/${t.id}/review`, { state: { backTo, processId } });
+      return;
+    }
+    const isOwner = profile?.id != null && t.created_by === profile.id;
+    if (isOwner && t.status === 'draft') {
+      navigate(`/templates/${t.id}/edit`, { state: { backTo, processId } });
+      return;
+    }
+    navigate(`/templates/${t.id}`, { state: { backTo, processId } });
   };
 
   const columns: ColumnDef<Template>[] = useMemo(
@@ -322,10 +338,10 @@ export function TemplatesTable({ processId }: Props = {}) {
         id: 'status',
         header: 'Estado',
         cell: (t) => {
-          const status = t.status as TemplateStatus;
+          const status = t.status ?? '';
           return (
             <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${statusBadgeClass(status)}`}>
-              {STATUS_LABEL[status] ?? status}
+              {templateStatusLabel(status)}
             </span>
           );
         },

--- a/frontend/src/features/templates/components/TemplatesTable.tsx
+++ b/frontend/src/features/templates/components/TemplatesTable.tsx
@@ -287,11 +287,11 @@ export function TemplatesTable({ processId }: Props = {}) {
         header: 'Nombre',
         sortable: true,
         alwaysVisible: true,
-        cell: (t) => (
+        cell: (template) => (
           <span className="flex items-center gap-2 min-w-0">
-            {favoriteTemplateIds.has(t.id) && <FavoriteInlineMark />}
-            <span className="truncate font-medium">{t.name}</span>
-            {t.has_review_comments && (t.status === 'draft' || t.status === 'rejected') && profile && t.created_by === profile.id && (
+            {favoriteTemplateIds.has(template.id) && <FavoriteInlineMark />}
+            <span className="truncate font-medium">{template.name}</span>
+            {template.has_review_comments && (template.status === 'draft' || template.status === 'rejected') && profile && template.created_by === profile.id && (
               <span
                 className="shrink-0 inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded text-xs font-bold bg-danger/10 text-danger-dark dark:text-danger border border-danger/20"
                 title={t('templates:pendingReviewTitle')}
@@ -305,15 +305,15 @@ export function TemplatesTable({ processId }: Props = {}) {
       {
         id: 'visibility_level',
         header: 'Visibilidad',
-        cell: (t) => {
-          const level = t.visibility_level as TemplateVisibilityLevel;
+        cell: (template) => {
+          const level = template.visibility_level as TemplateVisibilityLevel;
           const caption = formatListRowVisibilityCaption(hierarchy, {
             visibility_level: level,
-            study_type_id: t.study_type_id,
-            study_id: t.study_id,
-            module_id: t.module_id,
-            team_id: t.team_id,
-            team: t.team,
+            study_type_id: template.study_type_id,
+            study_id: template.study_id,
+            module_id: template.module_id,
+            team_id: template.team_id,
+            team: template.team,
           });
           return (
             <span
@@ -328,17 +328,17 @@ export function TemplatesTable({ processId }: Props = {}) {
       {
         id: 'author_name',
         header: 'Autor',
-        cell: (t) => (
+        cell: (template) => (
           <span className="text-xs text-text-secondary dark:text-text-dark-secondary">
-            {t.author_name ?? '—'}
+            {template.author_name ?? '—'}
           </span>
         ),
       },
       {
         id: 'status',
         header: 'Estado',
-        cell: (t) => {
-          const status = t.status ?? '';
+        cell: (template) => {
+          const status = template.status ?? '';
           return (
             <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${statusBadgeClass(status)}`}>
               {templateStatusLabel(status)}
@@ -350,14 +350,14 @@ export function TemplatesTable({ processId }: Props = {}) {
         id: 'delivery_deadline',
         header: 'Fecha de validación',
         sortable: true,
-        cell: (t) => (
+        cell: (template) => (
           <span className="text-xs text-text-secondary dark:text-text-dark-secondary">
-            {t.status === 'published' ? '—' : formatCalendarDateForBrowser(t.delivery_deadline)}
+            {template.status === 'published' ? '—' : formatCalendarDateForBrowser(template.delivery_deadline)}
           </span>
         ),
       },
     ],
-    [profile, favoriteTemplateIds, hierarchy],
+    [profile, favoriteTemplateIds, hierarchy, t],
   );
 
   if (!canIndex) {

--- a/frontend/src/features/templates/components/TemplatesTableBoundary.tsx
+++ b/frontend/src/features/templates/components/TemplatesTableBoundary.tsx
@@ -1,0 +1,32 @@
+import { Component, type ReactNode } from 'react';
+
+type Props = { children: ReactNode };
+type State = { message: string | null };
+
+/**
+ * Captura errores de render del listado de plantillas y muestra el mensaje real
+ * (el ErrorBoundary genérico de shared-ui solo muestra texto fijo).
+ */
+export class TemplatesTableBoundary extends Component<Props, State> {
+  state: State = { message: null };
+
+  static getDerivedStateFromError(error: unknown): State {
+    const message =
+      error instanceof Error ? error.message : 'Error desconocido al renderizar plantillas.';
+    return { message };
+  }
+
+  render() {
+    if (this.state.message) {
+      return (
+        <div
+          role="alert"
+          className="rounded-lg border border-danger/30 bg-danger/10 px-4 py-3 text-sm text-danger-dark dark:text-danger"
+        >
+          Error al cargar plantillas: {this.state.message}
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/frontend/src/features/templates/components/WizardStep2Blocks.tsx
+++ b/frontend/src/features/templates/components/WizardStep2Blocks.tsx
@@ -726,11 +726,6 @@ export const WizardStep2Blocks = React.forwardRef<WizardStep2BlocksHandle, Wizar
                             Los bloques tipo bloqueado deben tener contenido predeterminado (obligatorio).
                           </p>
                         )}
-                        {formUiState === 'locked' && !formContent && (
-                          <p className="bg-warning/10 text-warning-dark rounded px-3 py-1.5 dark:bg-warning-dark/30 dark:text-warning-light">
-                            Los bloques bloqueados deben tener contenido predeterminado (obligatorio).
-                          </p>
-                        )}
                         {formUiState === 'editable' && !formContent && (
                           <p className="bg-info/10 text-info-dark rounded px-3 py-1.5 dark:bg-info-dark/30 dark:text-info-light">
                             Se recomienda añadir contenido predeterminado para los bloques editables.

--- a/frontend/src/features/templates/components/WizardStep3Users.tsx
+++ b/frontend/src/features/templates/components/WizardStep3Users.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   DndContext,
@@ -16,7 +16,7 @@ import {
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import type { User } from '../../../types/users';
-import { searchDocumentReviewerCandidates, searchTemplateReviewerCandidates } from '../../../api/users';
+import { searchDocumentReviewerCandidates, searchTemplateReviewerCandidates, type ReviewerCandidateAcademicContext } from '../../../api/users';
 import { useUserProfile } from '../../../features/user-profile';
 import { DMS_PERMISSIONS } from '../../../permissions';
 import { Button, TextInput } from '@maya/shared-ui-react';
@@ -358,6 +358,10 @@ function UserAddPanel({
 
 type Props = {
   visibilityLevel?: string;
+  studyTypeId?: string;
+  studyId?: string;
+  moduleId?: string;
+  teamId?: string;
   validators: ValidatorEntry[];
   onValidatorsChange: (validators: ValidatorEntry[]) => void;
   validationType: 'libre' | 'ordenada';
@@ -370,6 +374,10 @@ type Props = {
 
 export function WizardStep3Users({
   visibilityLevel = 'personal',
+  studyTypeId,
+  studyId,
+  moduleId,
+  teamId,
   validators,
   onValidatorsChange,
   validationType,
@@ -398,6 +406,19 @@ export function WizardStep3Users({
   const [searchingDocument, setSearchingDocument] = useState(false);
   const [searchErrorDocument, setSearchErrorDocument] = useState<string | null>(null);
 
+  const reviewerAcademicContext = useMemo((): ReviewerCandidateAcademicContext | undefined => {
+    if (!visibilityLevel) {
+      return undefined;
+    }
+    return {
+      visibility_level: visibilityLevel,
+      study_type_id: studyTypeId || undefined,
+      study_id: studyId || undefined,
+      module_id: moduleId || undefined,
+      team_id: teamId || undefined,
+    };
+  }, [visibilityLevel, studyTypeId, studyId, moduleId, teamId]);
+
   useEffect(() => {
     if (!canSearchUsers) {
       setSearchResultsTemplate([]);
@@ -411,13 +432,13 @@ export function WizardStep3Users({
     const timer = setTimeout(() => {
       setSearchingTemplate(true);
       setSearchErrorTemplate(null);
-      searchTemplateReviewerCandidates(q)
+      searchTemplateReviewerCandidates(q, undefined, reviewerAcademicContext)
         .then((res) => setSearchResultsTemplate(res.data))
         .catch(() => setSearchErrorTemplate('No se pudo completar la búsqueda. Inténtalo de nuevo.'))
         .finally(() => setSearchingTemplate(false));
     }, 300);
     return () => clearTimeout(timer);
-  }, [searchQueryTemplate, canSearchUsers]);
+  }, [searchQueryTemplate, canSearchUsers, reviewerAcademicContext]);
 
   useEffect(() => {
     if (!canSearchUsers) {
@@ -432,13 +453,13 @@ export function WizardStep3Users({
     const timer = setTimeout(() => {
       setSearchingDocument(true);
       setSearchErrorDocument(null);
-      searchDocumentReviewerCandidates(q)
+      searchDocumentReviewerCandidates(q, undefined, reviewerAcademicContext)
         .then((res) => setSearchResultsDocument(res.data))
         .catch(() => setSearchErrorDocument('No se pudo completar la búsqueda. Inténtalo de nuevo.'))
         .finally(() => setSearchingDocument(false));
     }, 300);
     return () => clearTimeout(timer);
-  }, [searchQueryDocument, canSearchUsers]);
+  }, [searchQueryDocument, canSearchUsers, reviewerAcademicContext]);
 
   const handleAddToTemplate = (user: User) => {
     if (!validators.some((v) => v.userId === user.id)) {

--- a/frontend/src/features/templates/components/__tests__/WizardStep3Users.test.tsx
+++ b/frontend/src/features/templates/components/__tests__/WizardStep3Users.test.tsx
@@ -158,7 +158,9 @@ describe('WizardStep3Users', () => {
     fireEvent.change(searchInputs[0], { target: { value: 'User 2' } });
 
     await waitFor(() => {
-      expect(searchTemplateReviewerCandidates).toHaveBeenCalledWith('User 2');
+      expect(searchTemplateReviewerCandidates).toHaveBeenCalledWith('User 2', undefined, expect.objectContaining({
+        visibility_level: 'personal',
+      }));
       expect(screen.getAllByText('User 2').length).toBeGreaterThan(0);
     });
 
@@ -181,8 +183,12 @@ describe('WizardStep3Users', () => {
     fireEvent.change(searchInputs[1], { target: { value: 'ab' } });
 
     await waitFor(() => {
-      expect(searchTemplateReviewerCandidates).toHaveBeenCalledWith('ab');
-      expect(searchDocumentReviewerCandidates).toHaveBeenCalledWith('ab');
+      expect(searchTemplateReviewerCandidates).toHaveBeenCalledWith('ab', undefined, expect.objectContaining({
+        visibility_level: 'personal',
+      }));
+      expect(searchDocumentReviewerCandidates).toHaveBeenCalledWith('ab', undefined, expect.objectContaining({
+        visibility_level: 'personal',
+      }));
     });
   });
 });

--- a/frontend/src/features/templates/constants.ts
+++ b/frontend/src/features/templates/constants.ts
@@ -13,6 +13,7 @@ export const STATUS_OPTIONS = [
   { value: '', label: 'Todos' },
   { value: 'draft', label: 'Borrador' },
   { value: 'in_review', label: 'En revisión' },
+  { value: 'rejected', label: 'Rechazada' },
   { value: 'published', label: 'Publicada' },
   { value: 'archived', label: 'Archivada' },
 ] as const;

--- a/frontend/src/features/templates/hooks/useTemplates.ts
+++ b/frontend/src/features/templates/hooks/useTemplates.ts
@@ -83,13 +83,14 @@ export function useTemplates(processId?: string, sortBy?: TemplatesTableSort) {
   const perPage = filters.per_page ?? DEFAULT_PER_PAGE;
 
   const sortedList = useMemo(() => {
+    const list = Array.isArray(fullList) ? fullList : [];
     if (!sortBy || !SORTABLE_TEMPLATE_COLUMN_IDS.has(sortBy.columnId)) {
-      return fullList;
+      return list;
     }
     const { columnId, direction } = sortBy;
     const dir = direction === 'asc' ? 1 : -1;
 
-    return [...fullList].sort((a, b) => {
+    return [...list].sort((a, b) => {
       if (columnId === 'name') {
         return (a.name ?? '').localeCompare(b.name ?? '', 'es') * dir;
       }
@@ -132,7 +133,7 @@ export function useTemplates(processId?: string, sortBy?: TemplatesTableSort) {
       setListError(null);
       setLoading(true);
       const res = await fetchTemplates(filtersForApi);
-      setFullList(res.data);
+      setFullList(Array.isArray(res.data) ? res.data : []);
     } catch (e) {
       setListError(formatActionError(e));
       setFullList([]);

--- a/frontend/src/pages/DocumentPreviewPage.tsx
+++ b/frontend/src/pages/DocumentPreviewPage.tsx
@@ -979,7 +979,13 @@ export function DocumentPreviewPage({ mode = 'preview' }: Props = {}) {
                     />
                   )
                 : diffBlockId !== null
-                  ? <DocumentDiffPanel blocks={diffPanelBlocks} onClose={() => setDiffBlockId(null)} />
+                  ? (
+                      <DocumentDiffPanel
+                        blocks={diffPanelBlocks}
+                        allBlocks={detail?.blocks}
+                        onClose={() => setDiffBlockId(null)}
+                      />
+                    )
                   : undefined
           }
         >
@@ -1196,7 +1202,13 @@ export function DocumentPreviewPage({ mode = 'preview' }: Props = {}) {
         headerRef={pageHeaderRef}
         sidebar={
           diffBlockId !== null && !selectedReviewView
-            ? <DocumentDiffPanel blocks={diffPanelBlocks} onClose={() => setDiffBlockId(null)} />
+            ? (
+                <DocumentDiffPanel
+                  blocks={diffPanelBlocks}
+                  allBlocks={detail?.blocks}
+                  onClose={() => setDiffBlockId(null)}
+                />
+              )
             : selectedReviewView && (() => {
           const block = detail?.blocks?.find(b => (b.document_block_id || b.template_block_id) === selectedReviewView.blockId);
           if (!block) return null;

--- a/frontend/src/pages/ProcesosPage.tsx
+++ b/frontend/src/pages/ProcesosPage.tsx
@@ -4,6 +4,7 @@ import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 import { Alert, Button, ErrorBoundary, PageTitle } from '@maya/shared-ui-react';
 import { TemplatesTable } from '../features/templates/components/TemplatesTable';
+import { TemplatesTableBoundary } from '../features/templates/components/TemplatesTableBoundary';
 import { DocumentsTable } from '../features/documents/components/DocumentsTable';
 import { useUserProfile } from '../features/user-profile';
 import { useProcessesQuery } from '../hooks/useProcesses';
@@ -131,7 +132,9 @@ export function ProcesosPage() {
 
       <ErrorBoundary key={`${activeTab}:${processId ?? 'all'}`}>
         {activeTab === 'templates' ? (
-          <TemplatesTable processId={canShow ? processId : undefined} />
+          <TemplatesTableBoundary>
+            <TemplatesTable processId={canShow ? processId : undefined} />
+          </TemplatesTableBoundary>
         ) : (
           <DocumentsTable processId={canShow ? processId : undefined} />
         )}

--- a/frontend/src/utils/academicContextSearch.ts
+++ b/frontend/src/utils/academicContextSearch.ts
@@ -32,7 +32,7 @@ function resolveStudyTypeName(hierarchy: AcademicHierarchy, studyTypeId: string 
 function resolveStudyName(hierarchy: AcademicHierarchy, studyId: string | null | undefined): string | null {
   if (!studyId) return null;
   for (const st of hierarchy) {
-    const s = st.studies.find((x) => String(x.id) === String(studyId));
+    const s = (st.studies ?? []).find((x) => String(x.id) === String(studyId));
     if (s?.name?.trim()) return s.name.trim();
   }
   return null;
@@ -41,8 +41,8 @@ function resolveStudyName(hierarchy: AcademicHierarchy, studyId: string | null |
 function resolveModuleName(hierarchy: AcademicHierarchy, moduleId: string | null | undefined): string | null {
   if (!moduleId) return null;
   for (const st of hierarchy) {
-    for (const s of st.studies) {
-      const m = s.course_modules.find((x) => String(x.id) === String(moduleId));
+    for (const s of st.studies ?? []) {
+      const m = (s.course_modules ?? []).find((x) => String(x.id) === String(moduleId));
       if (m?.name?.trim()) return m.name.trim();
     }
   }
@@ -102,7 +102,7 @@ export function academicContextSearchHaystack(
   const sid = fields.study_id;
   if (sid) {
     for (const st of hierarchy) {
-      const s = st.studies.find((x) => String(x.id) === String(sid));
+      const s = (st.studies ?? []).find((x) => String(x.id) === String(sid));
       if (s?.name) {
         parts.push(s.name);
         break;
@@ -113,8 +113,8 @@ export function academicContextSearchHaystack(
   const mid = fields.module_id;
   if (mid) {
     outer: for (const st of hierarchy) {
-      for (const s of st.studies) {
-        const m = s.course_modules.find((x) => String(x.id) === String(mid));
+      for (const s of st.studies ?? []) {
+        const m = (s.course_modules ?? []).find((x) => String(x.id) === String(mid));
         if (m?.name) {
           parts.push(m.name);
           break outer;


### PR DESCRIPTION
- Numeración del diff: al abrir «Ver cambios» de un bloque, el panel lateral mostraba siempre «Bloque 1» aunque en la plantilla fuera el 2, 3, etc. Los comentarios y la vista de bloques sí numeraban bien.

- Banner duplicado: en el paso Bloques del wizard, pestaña Contenido, los bloques tipo bloqueado sin contenido predeterminado mostraban dos avisos amarillo idénticos.

Esta rama ha partido de feature/validadores-contexto-academico por lo que si se mergea aquella a multi_issues primero deberia hacerse un merge origin/fix/multi_issues para no duplicar los commits; Y si se hace este merge primero, no sería necesario mergear la otra rama porque todos los cambios hechos allí, están aquí también.