### PR TITLE
Feature/permitir clonacion nueva version

### DIFF
--- a/backend/app/Models/Document.php
+++ b/backend/app/Models/Document.php
@@ -81,10 +81,21 @@ class Document extends Model
                             });
                     })
                     ->orWhere(function (Builder $pub) use ($userId) {
-                        $pub->where('document_head_ev.snapshot_data->document->status', 'published')
-                            ->where(function ($inner) use ($userId) {
-                                self::applyAcademicOverlapOnDocumentsTable($inner, $userId);
-                            });
+                        // Catálogo publicado: visible aunque el head esté en draft/in_review.
+                        // El contexto se evalúa sobre el snapshot publicado (pub_snap), no
+                        // sobre el head en curso, para no ocultar la versión publicada cuando
+                        // alguien está editando una nueva versión.
+                        $pub->whereExists(function ($sub) use ($userId) {
+                            $sub->select(DB::raw(1))
+                                ->from('entity_versions as pub_snap')
+                                ->whereColumn('pub_snap.versionable_id', 'documents.id')
+                                ->where('pub_snap.versionable_type', self::class)
+                                ->where('pub_snap.version_number', '>', 0)
+                                ->where('pub_snap.status', 'published')
+                                ->where(function ($ctx) use ($userId) {
+                                    self::applyAcademicOverlapOnDocumentSnapshotAlias($ctx, $userId, 'pub_snap');
+                                });
+                        });
                     });
             });
         });
@@ -275,6 +286,43 @@ class Document extends Model
                                 'user_course_modules.module_id = '.DocumentHeadSnapshot::jsonDocumentFieldExpression('entity_versions', 'module_id')
                             );
                     });
+            });
+        });
+    }
+
+    /**
+     * Solape académico usando el JSON snapshot de una fila publicada
+     * (alias de entity_versions) en lugar del head actual del documento.
+     */
+    private static function applyAcademicOverlapOnDocumentSnapshotAlias(
+        Builder|QueryBuilder $query,
+        string $userId,
+        string $snapshotAlias
+    ): void {
+        $s = rtrim($snapshotAlias, '.');
+
+        $query->where(function ($w) use ($userId, $s) {
+            $w->whereExists(function ($sub) use ($userId, $s) {
+                $sub->select(DB::raw(1))
+                    ->from('user_study_types')
+                    ->where('user_study_types.user_id', $userId)
+                    ->whereRaw(
+                        'user_study_types.study_type_id = '.DocumentHeadSnapshot::jsonDocumentFieldExpression($s, 'study_type_id')
+                    );
+            })->orWhereExists(function ($sub) use ($userId, $s) {
+                $sub->select(DB::raw(1))
+                    ->from('user_studies')
+                    ->where('user_studies.user_id', $userId)
+                    ->whereRaw(
+                        'user_studies.study_id = '.DocumentHeadSnapshot::jsonDocumentFieldExpression($s, 'study_id')
+                    );
+            })->orWhereExists(function ($sub) use ($userId, $s) {
+                $sub->select(DB::raw(1))
+                    ->from('user_course_modules')
+                    ->where('user_course_modules.user_id', $userId)
+                    ->whereRaw(
+                        'user_course_modules.module_id = '.DocumentHeadSnapshot::jsonDocumentFieldExpression($s, 'module_id')
+                    );
             });
         });
     }

--- a/backend/app/Policies/DocumentPolicy.php
+++ b/backend/app/Policies/DocumentPolicy.php
@@ -231,7 +231,23 @@ class DocumentPolicy
      */
     public function clone(JwtUser $user, Document $document): bool
     {
-        if ($document->status !== 'published' || ! $this->view($user, $document)) {
+        if (! $this->view($user, $document)) {
+            return false;
+        }
+
+        $documentId = (string) $document->getKey();
+        if ($documentId === '') {
+            return false;
+        }
+
+        $hasPublishedSnapshot = EntityVersion::query()
+            ->where('versionable_type', Document::class)
+            ->where('versionable_id', $documentId)
+            ->where('version_number', '>', 0)
+            ->where('status', 'published')
+            ->exists();
+
+        if (! $hasPublishedSnapshot) {
             return false;
         }
 

--- a/backend/app/Policies/TemplatePolicy.php
+++ b/backend/app/Policies/TemplatePolicy.php
@@ -257,7 +257,23 @@ class TemplatePolicy
      */
     public function clone(JwtUser $user, Template $template): bool
     {
-        if ($template->status !== 'published' || ! $this->view($user, $template)) {
+        if (! $this->view($user, $template)) {
+            return false;
+        }
+
+        $templateId = (string) $template->getKey();
+        if ($templateId === '') {
+            return false;
+        }
+
+        $hasPublishedSnapshot = EntityVersion::query()
+            ->where('versionable_type', Template::class)
+            ->where('versionable_id', $templateId)
+            ->where('version_number', '>', 0)
+            ->where('status', 'published')
+            ->exists();
+
+        if (! $hasPublishedSnapshot) {
             return false;
         }
 

--- a/backend/app/Services/DocumentService.php
+++ b/backend/app/Services/DocumentService.php
@@ -677,7 +677,12 @@ class DocumentService implements DocumentServiceInterface
             ]);
         }
 
-        return $this->documentStateService->transition($documentId, 'draft', $actorId);
+        return $this->documentStateService->transition($documentId, 'draft', $actorId, [
+            // Igual que en plantillas: quien abre la nueva versión pasa a ser el
+            // editor titular del ciclo en curso, evitando dobles editores en borrador.
+            'owner_id' => $actorId,
+            'created_by' => $actorId,
+        ]);
     }
 
     /**

--- a/backend/database/seeders/EntityVersionsSeeder.php
+++ b/backend/database/seeders/EntityVersionsSeeder.php
@@ -19,36 +19,34 @@ class EntityVersionsSeeder extends Seeder
         }
 
         $rows = $this->mockRows();
-        if ($rows === []) {
-            return;
-        }
+        if ($rows !== []) {
+            $now = Carbon::now();
 
-        $now = Carbon::now();
+            $normalizedRows = [];
+            foreach ($rows as $row) {
+                $type = (string) ($row['versionable_type'] ?? '');
+                $id = (string) ($row['versionable_id'] ?? '');
+                if ($type === '' || $id === '') {
+                    continue;
+                }
 
-        $normalizedRows = [];
-        foreach ($rows as $row) {
-            $type = (string) ($row['versionable_type'] ?? '');
-            $id = (string) ($row['versionable_id'] ?? '');
-            if ($type === '' || $id === '') {
-                continue;
+                if (! $this->versionableExists($type, $id)) {
+                    continue;
+                }
+
+                $row['change_set'] = $this->asJsonString($row['change_set'] ?? null);
+                $row['snapshot_data'] = $this->asJsonString($row['snapshot_data'] ?? null);
+                $row['is_snapshot_immutable'] = (bool) ($row['is_snapshot_immutable'] ?? false);
+                $row['status'] ??= 'draft';
+                $row['created_at'] ??= $now;
+                $row['updated_at'] ??= $now;
+
+                $normalizedRows[] = $row;
             }
 
-            if (! $this->versionableExists($type, $id)) {
-                continue;
+            if ($normalizedRows !== []) {
+                DB::table('entity_versions')->insertOrIgnore($normalizedRows);
             }
-
-            $row['change_set'] = $this->asJsonString($row['change_set'] ?? null);
-            $row['snapshot_data'] = $this->asJsonString($row['snapshot_data'] ?? null);
-            $row['is_snapshot_immutable'] = (bool) ($row['is_snapshot_immutable'] ?? false);
-            $row['status'] ??= 'draft';
-            $row['created_at'] ??= $now;
-            $row['updated_at'] ??= $now;
-
-            $normalizedRows[] = $row;
-        }
-
-        if ($normalizedRows !== []) {
-            DB::table('entity_versions')->insertOrIgnore($normalizedRows);
         }
 
         $this->backfillMissingDocumentPublishedSnapshots();

--- a/frontend/src/pages/DocumentPreviewPage.tsx
+++ b/frontend/src/pages/DocumentPreviewPage.tsx
@@ -310,7 +310,6 @@ export function DocumentPreviewPage({ mode = 'preview' }: Props = {}) {
     (isOwner || hasPermission(DMS_PERMISSIONS.documentVersion));
   const canClone =
     !isValidateMode &&
-    !isHistoricalSnapshot &&
     detail?.can_clone === true;
   const canDiscardWorkingVersion =
     !isValidateMode &&

--- a/frontend/src/pages/TemplatePreviewPage.tsx
+++ b/frontend/src/pages/TemplatePreviewPage.tsx
@@ -299,8 +299,8 @@ export function TemplatePreviewPage() {
     template != null &&
     !template.latest_published_version_id &&
     (isOwner || hasPermission(DMS_PERMISSIONS.templateDelete));
-  /** Coincide con `TemplatePolicy::clone` y `data.can_clone` de la API. */
-  const canClone = !viewingPublishedSnapshot && template?.can_clone === true;
+  /** Coincide con `TemplatePolicy::clone` y `data.can_clone` de la API, también en vista de snapshot publicado. */
+  const canClone = template?.can_clone === true;
   const canSubmit =
     !viewingPublishedSnapshot && isOwner && isDraft && hasReviewers && !template.has_review_comments;
   /** Alineado con `TemplatePolicy::startRevision`: creador o `template.version` en publicada. */


### PR DESCRIPTION
Corrige el comportamiento de documentos (y refuerza el de plantillas) cuando existe una nueva versión en borrador o en validación: la versión publicada sigue visible en el listado según contexto académico, el creador de la nueva revisión ve ambas versiones, el resto de usuarios solo la publicada, y la clonación usa la última versión publicada en entity_versions aunque el head esté en draft o in_review.

Se han modificado los seeders pero no se debe refrescar la migración sin hacer un reset porque da problemas la tabla de teams que depende de infra.