### PR TITLE
fix(dms): align delete/discard actions and draft navigation for templ…

### DIFF
--- a/backend/app/Http/Controllers/Api/DocumentController.php
+++ b/backend/app/Http/Controllers/Api/DocumentController.php
@@ -147,6 +147,7 @@ class DocumentController extends Controller
             }
             $resolved->setRelation('headVersion', $latestPublished);
             $this->attachCanCloneMeta($resolved, $request);
+            $this->documentService->attachLatestPublishedVersionMeta(collect([$resolved]));
             $this->documentService->attachShareMetadataForViewer(collect([$resolved]), $viewerId);
             $resolved->setAttribute('is_assigned_reviewer', $isAssignedReviewer);
             $resolved->loadMissing(['owner']);
@@ -167,6 +168,7 @@ class DocumentController extends Controller
         );
         $resolved->setAttribute('is_assigned_reviewer', $isAssignedReviewer);
         $this->attachCanCloneMeta($resolved, $request);
+        $this->documentService->attachLatestPublishedVersionMeta(collect([$resolved]));
         $this->documentService->attachShareMetadataForViewer(collect([$resolved]), $viewerId);
         $resolved->loadMissing(['owner']);
         $this->apiTeamEmbedService->embedOnDocument(

--- a/frontend/src/features/templates/components/TemplateCard.tsx
+++ b/frontend/src/features/templates/components/TemplateCard.tsx
@@ -6,6 +6,7 @@ import { useUserProfile } from '../../../features/user-profile';
 import { DMS_PERMISSIONS } from '../../../permissions';
 import { useHierarchy } from '../../../features/hierarchy';
 import { formatListRowVisibilityCaption } from '../../../utils/academicContextSearch';
+import { shouldOpenTemplateEditorFromList } from '../templateListNavigation';
 
 const STATUS_LABEL: Record<TemplateStatus, string> = {
   draft: 'Borrador',
@@ -36,7 +37,9 @@ export function TemplateCard({ template: t, onDelete, onClone }: Props) {
   const [dialog, setDialog] = useState<'delete' | 'clone' | null>(null);
   const [dialogLoading, setDialogLoading] = useState(false);
   const canClone = t.can_clone === true;
-  const canEdit = (t.status === 'draft' || t.status === 'rejected') && profile?.id === t.created_by;
+  const isOwner = profile?.id === t.created_by;
+  const canEdit = isOwner && (t.status === 'draft' || t.status === 'rejected');
+  const openEditorFromList = shouldOpenTemplateEditorFromList(t, isOwner);
   const isAuthorized =
     profile?.id === t.created_by || hasPermission(DMS_PERMISSIONS.templateDelete);
   const hasDiscardableDraft = !!(t.working_version_id && (t.status === 'draft' || t.status === 'in_review'));
@@ -102,8 +105,10 @@ export function TemplateCard({ template: t, onDelete, onClone }: Props) {
             ? () => navigate(`/templates/${t.id}/review`)
             : isRejected
               ? () => navigate(`/templates/${t.id}`)  // rejected → preview with readonly comments first
-              : canEdit
+              : openEditorFromList
                 ? () => navigate(`/templates/${t.id}/edit`)
+              : canEdit
+                ? () => navigate(`/templates/${t.id}`)
                 : undefined
           : undefined
       }

--- a/frontend/src/features/templates/components/TemplatesTable.tsx
+++ b/frontend/src/features/templates/components/TemplatesTable.tsx
@@ -25,6 +25,7 @@ import { useFavoritesIds } from '../../../hooks/useFavoritesIds';
 import { FavoriteInlineMark } from '../../../components/FavoriteInlineMark';
 import { formatCalendarDateForBrowser } from '../../../utils/formatCalendarDate';
 import { normalizeForSearch } from '../../../utils/normalizeForSearch';
+import { shouldOpenTemplateEditorFromList } from '../templateListNavigation';
 
 function templateStatusLabel(
   status: string | null | undefined,
@@ -292,7 +293,7 @@ export function TemplatesTable({ processId }: Props = {}) {
       return;
     }
     const isOwner = profile?.id != null && t.created_by === profile.id;
-    if (isOwner && t.status === 'draft') {
+    if (shouldOpenTemplateEditorFromList(t, isOwner)) {
       navigate(`/templates/${t.id}/edit`, { state: { backTo, processId } });
       return;
     }

--- a/frontend/src/features/templates/templateListNavigation.ts
+++ b/frontend/src/features/templates/templateListNavigation.ts
@@ -1,0 +1,12 @@
+import type { Template } from '../../types/templates';
+
+/**
+ * Borrador inicial (sin publicación previa): abrir editor.
+ * Borrador o revisión sobre una versión ya publicada: preview (descartar, enviar a validar, etc.).
+ */
+export function shouldOpenTemplateEditorFromList(
+  template: Pick<Template, 'status' | 'latest_published_version_id'>,
+  isOwner: boolean,
+): boolean {
+  return isOwner && template.status === 'draft' && !template.latest_published_version_id;
+}

--- a/frontend/src/pages/DocumentPreviewPage.tsx
+++ b/frontend/src/pages/DocumentPreviewPage.tsx
@@ -28,6 +28,7 @@ import { FavoriteButton } from '../components/FavoriteButton';
 import { VersionHistoryPanel } from '../components/VersionHistoryPanel';
 import { useUserProfile } from '../features/user-profile';
 import { canCreateBlockComment, canDeleteBlockComment, DMS_PERMISSIONS } from '../permissions';
+import { canDeleteUnpublishedEntity, isDiscardWorkingVersionAllowed } from '../utils/versionableEntityActions';
 import { PaperPreviewLayout } from '../features/documents/components/PaperPreviewLayout';
 import { PagedThemedPreview } from '../features/documents/components/PagedThemedPreview';
 import { useDocumentPdfExport } from '../features/documents/hooks/useDocumentPdfExport';
@@ -292,15 +293,17 @@ export function DocumentPreviewPage({ mode = 'preview' }: Props = {}) {
       detail.share_permission === 'edit' ||
       hasPermission(DMS_PERMISSIONS.documentUpdate));
   const canMutatePublished = canUpdate;
-  /** Paridad con `DocumentPolicy::delete`: titular/creador o `document.delete` (API valida contexto). */
-  const canDelete =
-    !!detail &&
-    isDraft &&
-    !detail.latest_published_version_id &&
-    (isOwner || hasPermission(DMS_PERMISSIONS.documentDelete));
-  const canEditDraft = isDraft && canUpdate;
   const canReviewDocument = hasPermission(DMS_PERMISSIONS.documentReview);
   const isHistoricalSnapshot = versionSnapshot !== null;
+  /** Paridad con plantillas: eliminar solo si nunca hubo versión publicada. */
+  const canDelete =
+    !!detail &&
+    !isHistoricalSnapshot &&
+    canDeleteUnpublishedEntity(
+      detail.latest_published_version_id,
+      isOwner || hasPermission(DMS_PERMISSIONS.documentDelete),
+    );
+  const canEditDraft = isDraft && canUpdate;
   const showVersionHistory =
     isOwner || hasPermission(DMS_PERMISSIONS.documentHistoryView);
   const canStartNewVersion =
@@ -315,10 +318,13 @@ export function DocumentPreviewPage({ mode = 'preview' }: Props = {}) {
   const canDiscardWorkingVersion =
     !isValidateMode &&
     !isHistoricalSnapshot &&
-    (detail?.status === 'draft' || detail?.status === 'in_review' || detail?.status === 'rejected') &&
     canMutatePublished &&
-    !!detail?.latest_published_version_id &&
-    !!detail?.working_version_id;
+    isDiscardWorkingVersionAllowed(
+      detail?.latest_published_version_id,
+      detail?.working_version_id,
+      detail?.status,
+      ['draft', 'in_review', 'rejected'],
+    );
 
   useEffect(() => {
     if (!isValidateMode) {

--- a/frontend/src/pages/TemplatePreviewPage.tsx
+++ b/frontend/src/pages/TemplatePreviewPage.tsx
@@ -25,6 +25,7 @@ import { FavoriteButton } from '../components/FavoriteButton';
 import { VersionHistoryPanel } from '../components/VersionHistoryPanel';
 import { useUserProfile } from '../features/user-profile';
 import { canListBlocks, canDeleteBlockComment, DMS_PERMISSIONS } from '../permissions';
+import { canDeleteUnpublishedEntity, isDiscardWorkingVersionAllowed } from '../utils/versionableEntityActions';
 import { useHierarchy } from '../features/hierarchy';
 import { BlockCommentsCard, ViewCardHeader } from '../features/templates/components/BlockCommentsCard';
 import type { BlockComment } from '../features/templates/components/BlockCommentsCard';
@@ -293,12 +294,14 @@ export function TemplatePreviewPage() {
     && (isOwner || hasPermission(DMS_PERMISSIONS.templateHistoryView));
 
   const canEdit = isOwner && isDraft && !viewingPublishedSnapshot;
-  /** Solo se permite eliminar plantillas que nunca han sido publicadas. */
+  /** Eliminar solo si nunca hubo versión publicada (alta o clon sin publicar). */
   const canDelete =
     !viewingPublishedSnapshot &&
     template != null &&
-    !template.latest_published_version_id &&
-    (isOwner || hasPermission(DMS_PERMISSIONS.templateDelete));
+    canDeleteUnpublishedEntity(
+      template.latest_published_version_id,
+      isOwner || hasPermission(DMS_PERMISSIONS.templateDelete),
+    );
   /** Coincide con `TemplatePolicy::clone` y `data.can_clone` de la API. */
   const canClone = !viewingPublishedSnapshot && template?.can_clone === true;
   const canSubmit =
@@ -314,9 +317,12 @@ export function TemplatePreviewPage() {
     !viewingPublishedSnapshot &&
     template != null &&
     isOwner &&
-    (template.status === 'draft' || template.status === 'in_review') &&
-    !!template.latest_published_version_id &&
-    !!template.working_version_id;
+    isDiscardWorkingVersionAllowed(
+      template.latest_published_version_id,
+      template.working_version_id,
+      template.status,
+      ['draft', 'in_review'],
+    );
 
   const processesQuery = useProcessesQuery(undefined, {
     enabled: !!template?.process_id,

--- a/frontend/src/utils/versionableEntityActions.ts
+++ b/frontend/src/utils/versionableEntityActions.ts
@@ -1,0 +1,28 @@
+/**
+ * Reglas compartidas plantilla/documento:
+ * - Eliminar: entidad nueva (nunca publicada; alta o clon sin publicar).
+ * - Descartar versión: working draft sobre una versión ya publicada.
+ */
+
+export function canDeleteUnpublishedEntity(
+  latestPublishedVersionId: string | null | undefined,
+  isAuthorized: boolean,
+): boolean {
+  return isAuthorized && !latestPublishedVersionId;
+}
+
+export function isDiscardWorkingVersionAllowed(
+  latestPublishedVersionId: string | null | undefined,
+  workingVersionId: string | null | undefined,
+  status: string | null | undefined,
+  allowedStatuses: readonly string[],
+): boolean {
+  if (!latestPublishedVersionId || !workingVersionId) {
+    return false;
+  }
+  if (!status || !allowedStatuses.includes(status)) {
+    return false;
+  }
+
+  return true;
+}


### PR DESCRIPTION
En documentos, el show adjunta latest_published_version_id para distinguir eliminar (nunca publicado) de descartar versión. Se unifica la lógica en plantillas y documentos y el listado de plantillas abre preview (no editor) cuando el borrador es una nueva versión sobre una publicada.