### PR TITLE
Feature/proteger plantillas personales

### DIFF
--- a/backend/app/Http/Controllers/Api/DocumentPreviewController.php
+++ b/backend/app/Http/Controllers/Api/DocumentPreviewController.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\Controller;
 use App\Models\Document;
 use App\Services\Contracts\DocumentRenderServiceInterface;
 use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Gate;
 
 /**
  * Devuelve el HTML themed del documento. Sirve tanto como vista previa en
@@ -21,7 +22,12 @@ class DocumentPreviewController extends Controller
 
     public function show(string $document): Response
     {
-        $this->authorize('view', Document::query()->findOrFail($document));
+        $model = Document::query()
+            ->withoutGlobalScopes(['user_access'])
+            ->findOrFail($document);
+        if (! Gate::forUser(request()->user())->allows('view', $model)) {
+            abort(404);
+        }
 
         // previewMode = true → el Blade carga paged.js para paginación A4 en
         // el navegador. El export PDF (DocumentPdfService) sigue invocando

--- a/backend/app/Http/Controllers/Api/TemplatePreviewController.php
+++ b/backend/app/Http/Controllers/Api/TemplatePreviewController.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\Controller;
 use App\Models\Template;
 use App\Services\Contracts\TemplateRenderServiceInterface;
 use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Gate;
 
 /**
  * Devuelve el HTML themed de una plantilla. Construye un "preview document"
@@ -28,7 +29,9 @@ class TemplatePreviewController extends Controller
         $model = Template::query()
             ->withoutGlobalScopes(['user_access'])
             ->findOrFail($template);
-        $this->authorize('view', $model);
+        if (! Gate::forUser(request()->user())->allows('view', $model)) {
+            abort(404);
+        }
 
         $html = $this->renderer->renderHtml($template, previewMode: true);
 

--- a/backend/app/Http/Requests/Documents/ShowDocumentRequest.php
+++ b/backend/app/Http/Requests/Documents/ShowDocumentRequest.php
@@ -6,7 +6,6 @@ namespace App\Http\Requests\Documents;
 
 use App\Models\Document;
 use App\Services\Contracts\DocumentServiceInterface;
-use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Foundation\Http\FormRequest;
 
@@ -19,7 +18,7 @@ class ShowDocumentRequest extends FormRequest
 
     protected function failedAuthorization(): void
     {
-        throw new AuthorizationException('Se requiere permiso para ver este documento.');
+        abort(404);
     }
 
     /**

--- a/backend/app/Policies/BlockPolicy.php
+++ b/backend/app/Policies/BlockPolicy.php
@@ -12,8 +12,11 @@ use App\Models\Template;
  * Permisos transversales de bloques (plantilla, documento y snapshots de versión).
  *
  * - `block.index` / `block.show`: compañero global (cualquier mutación plantilla o documento).
- * - `block.create` / `block.update` / `block.delete` en plantilla: compañero de plantilla
- *   + {@see TemplatePolicy::update} sobre el padre.
+ * - `block.create` / `block.update` / `block.delete` en plantilla: slug `block.*` +
+ *   {@see TemplatePolicy::update} sobre el padre (p. ej. creador en borrador personal sin
+ *   `template.create`/`template.update`).
+ * - Listado/detalle en plantilla: slug `block.index`/`block.show` +
+ *   {@see TemplatePolicy::view} sobre el padre (sin compañero global de catálogo).
  * - `block.update` / `block.delete` en documento: compañero de documento +
  *   {@see DocumentPolicy::update} (quien edita el borrador, p. ej. titular o share `edit`).
  */
@@ -40,7 +43,7 @@ class BlockPolicy
      */
     public function listForTemplate(JwtUser $user, Template $template): bool
     {
-        if (! $this->viewAny($user)) {
+        if (! $user->hasPermission('block.index')) {
             return false;
         }
 
@@ -52,7 +55,7 @@ class BlockPolicy
      */
     public function showForTemplate(JwtUser $user, Template $template): bool
     {
-        if (! $this->view($user)) {
+        if (! $user->hasPermission('block.show')) {
             return false;
         }
 
@@ -76,7 +79,7 @@ class BlockPolicy
      */
     public function createForTemplate(JwtUser $user, Template $template): bool
     {
-        if (! $user->hasPermission('block.create') || ! $this->hasTemplateCompanionSlug($user)) {
+        if (! $user->hasPermission('block.create')) {
             return false;
         }
 
@@ -88,7 +91,7 @@ class BlockPolicy
      */
     public function updateForTemplate(JwtUser $user, Template $template): bool
     {
-        if (! $user->hasPermission('block.update') || ! $this->hasTemplateCompanionSlug($user)) {
+        if (! $user->hasPermission('block.update')) {
             return false;
         }
 
@@ -100,7 +103,7 @@ class BlockPolicy
      */
     public function deleteForTemplate(JwtUser $user, Template $template): bool
     {
-        if (! $user->hasPermission('block.delete') || ! $this->hasTemplateCompanionSlug($user)) {
+        if (! $user->hasPermission('block.delete')) {
             return false;
         }
 

--- a/backend/app/Policies/DocumentPolicy.php
+++ b/backend/app/Policies/DocumentPolicy.php
@@ -79,16 +79,13 @@ class DocumentPolicy
             return false;
         }
 
+        // Catálogo visible (scope user_access): compartidos en contexto académico; excluye
+        // documentos personales ajenos (visibilidad heredada de plantilla personal).
         if (Document::query()->whereKey($documentId)->exists()) {
             return true;
         }
 
-        return EntityVersion::query()
-            ->where('versionable_type', Document::class)
-            ->where('versionable_id', (string) $documentId)
-            ->where('version_number', '>', 0)
-            ->where('status', 'published')
-            ->exists();
+        return false;
     }
 
     /**

--- a/backend/app/Policies/TemplatePolicy.php
+++ b/backend/app/Policies/TemplatePolicy.php
@@ -119,18 +119,9 @@ class TemplatePolicy
             return false;
         }
 
+        // Catálogo visible (scope user_access): incluye compartidas con snapshot publicado aunque el
+        // cabezal esté en borrador; excluye plantillas personales ajenas.
         if (Template::query()->whereKey($templateId)->exists()) {
-            return true;
-        }
-
-        // Non-creator can view even when the head is in draft/in_review/rejected, as long as a published
-        // snapshot exists. The controller will serve that published snapshot instead of draft data.
-        if (EntityVersion::query()
-            ->where('versionable_type', Template::class)
-            ->where('versionable_id', (string) $templateId)
-            ->where('version_number', '>', 0)
-            ->where('status', 'published')
-            ->exists()) {
             return true;
         }
 

--- a/backend/tests/Feature/Api/BlockMutationPermissionsApiTest.php
+++ b/backend/tests/Feature/Api/BlockMutationPermissionsApiTest.php
@@ -77,6 +77,17 @@ it('denies template block store without block.create', function () {
     ])->assertForbidden();
 });
 
+it('allows template block store for owner with block.create only on personal draft', function () {
+    grantBlockMutationPermissions('block.create');
+
+    $ctx = seedPersonalTemplateWithBlock(test()->userId);
+
+    $this->postJson("/api/v1/templates/{$ctx['templateId']}/blocks", [
+        'title' => 'Nuevo',
+        'block_state' => 'editable',
+    ])->assertCreated();
+});
+
 it('allows template block store for owner with block.create and template.update', function () {
     grantBlockMutationPermissions('block.create', 'template.update');
 

--- a/backend/tests/Feature/DocumentsTemplateVersionApiTest.php
+++ b/backend/tests/Feature/DocumentsTemplateVersionApiTest.php
@@ -1273,6 +1273,61 @@ class DocumentsTemplateVersionApiTest extends TestCase
         $create->assertJsonPath('data.module_id', null);
     }
 
+    public function test_peer_cannot_view_others_personal_published_document_via_show_or_preview(): void
+    {
+        $creatorId = (string) Str::uuid();
+        $peerId = (string) Str::uuid();
+        $this->grantPermissionsForUser($creatorId);
+        $this->grantPermissionsForUser($peerId);
+        $headersCreator = $this->authHeaders($creatorId);
+        $headersPeer = $this->authHeaders($peerId);
+
+        $tid = (string) Str::uuid();
+        $b1 = (string) Str::uuid();
+        Template::query()->forceCreate([
+            'id' => $tid,
+            'process_id' => '00000000-0000-0000-0000-000000000001',
+            'name' => 'Plantilla personal doc',
+            'description' => null,
+            'visibility_level' => TemplateVisibilityLevel::Personal->value,
+            'delivery_deadline' => now()->addDay()->toDateString(),
+            'study_type_id' => null,
+            'study_id' => null,
+            'module_id' => null,
+            'team_id' => null,
+            'created_by' => $creatorId,
+            'status' => 'draft',
+            'review_stages' => 0,
+            'review_mode' => 'sequential',
+        ]);
+        TemplateBlock::query()->forceCreate([
+            'id' => $b1,
+            'template_id' => $tid,
+            'title' => 'Bloque',
+            'default_content' => ['x' => 1],
+            'block_state' => 'editable',
+            'sort_order' => 0,
+        ]);
+
+        $this->postJson("/api/v1/templates/{$tid}/publish", [], $headersCreator)->assertOk();
+
+        $createDoc = $this->postJson('/api/v1/documents', [
+            'template_id' => $tid,
+            'title' => 'doc personal ajeno',
+            'delivery_deadline' => now()->addDay()->toDateString(),
+            'process_id' => '00000000-0000-0000-0000-000000000001',
+        ], $headersCreator)->assertCreated();
+
+        $docId = (string) $createDoc->json('data.id');
+
+        $this->postJson("/api/v1/documents/{$docId}/publish", [], $headersCreator)
+            ->assertOk()
+            ->assertJsonPath('data.status', 'published');
+
+        $this->getJson("/api/v1/documents/{$docId}", $headersPeer)->assertNotFound();
+        $this->get("/api/v1/documents/{$docId}/preview", $headersPeer)->assertNotFound();
+    }
+
     public function test_store_document_from_personal_template_rejects_academic_context_override(): void
     {
         $creatorId = (string) Str::uuid();

--- a/backend/tests/Feature/TemplatesApiTest.php
+++ b/backend/tests/Feature/TemplatesApiTest.php
@@ -1300,6 +1300,48 @@ class TemplatesApiTest extends TestCase
         $this->getJson("/api/v1/templates/{$tid}", $headersB)->assertNotFound();
     }
 
+    public function test_peer_cannot_view_others_personal_published_template_via_show_or_preview(): void
+    {
+        $creatorId = (string) Str::uuid();
+        $peerId = (string) Str::uuid();
+        $headersCreator = $this->authHeaders($creatorId, []);
+        $this->assignUserPermissions($creatorId, ['template.show', 'template.create']);
+        $headersPeer = $this->authHeaders($peerId, ['teacher']);
+
+        $tid = (string) Str::uuid();
+        $bid = (string) Str::uuid();
+        Template::query()->forceCreate([
+            'id' => $tid,
+            'process_id' => '00000000-0000-0000-0000-000000000001',
+            'name' => 'Personal publicada ajena',
+            'description' => null,
+            'visibility_level' => TemplateVisibilityLevel::Personal->value,
+            'delivery_deadline' => null,
+            'study_type_id' => null,
+            'study_id' => null,
+            'module_id' => null,
+            'team_id' => null,
+            'created_by' => $creatorId,
+            'status' => 'draft',
+            'review_stages' => 0,
+            'review_mode' => 'sequential',
+        ]);
+
+        TemplateBlock::query()->forceCreate([
+            'id' => $bid,
+            'template_id' => $tid,
+            'title' => 'Bloque',
+            'default_content' => ['x' => 1],
+            'block_state' => 'editable',
+            'sort_order' => 0,
+        ]);
+
+        $this->postJson("/api/v1/templates/{$tid}/publish", [], $headersCreator)->assertOk();
+
+        $this->getJson("/api/v1/templates/{$tid}", $headersPeer)->assertNotFound();
+        $this->get("/api/v1/templates/{$tid}/preview", $headersPeer)->assertNotFound();
+    }
+
     public function test_creator_can_view_own_template_without_templates_read_permission(): void
     {
         $creatorId = (string) Str::uuid();

--- a/backend/tests/Unit/Policies/BlockPolicyTest.php
+++ b/backend/tests/Unit/Policies/BlockPolicyTest.php
@@ -63,8 +63,8 @@ class BlockPolicyTest extends TestCase
 
     public function test_list_for_template_requires_view_on_parent(): void
     {
-        $ownerId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
-        $user = $this->makeJwtUser(['block.index', 'template.update']);
+        $ownerId = '11111111-1111-1111-1111-111111111111';
+        $user = $this->makeJwtUser(['block.index'], $ownerId);
         auth()->setUser($user);
         $template = $this->makeTemplate($ownerId);
 
@@ -73,6 +73,16 @@ class BlockPolicyTest extends TestCase
         $stranger = $this->makeJwtUser(['block.index', 'template.update']);
         auth()->setUser($stranger);
         $this->assertFalse($this->policy->listForTemplate($stranger, $template));
+    }
+
+    public function test_list_for_template_allowed_for_owner_without_template_catalog_slugs(): void
+    {
+        $ownerId = '11111111-1111-1111-1111-111111111111';
+        $user = $this->makeJwtUser(['block.index'], $ownerId);
+        auth()->setUser($user);
+        $template = $this->makeTemplate($ownerId);
+
+        $this->assertTrue($this->policy->listForTemplate($user, $template));
     }
 
     public function test_list_for_document_requires_view_on_parent(): void
@@ -85,20 +95,21 @@ class BlockPolicyTest extends TestCase
         $this->assertTrue($this->policy->listForDocument($user, $document));
     }
 
-    public function test_create_for_template_requires_block_create_and_template_companion(): void
+    public function test_create_for_template_requires_block_create_and_parent_update(): void
     {
-        $ownerId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+        $ownerId = '11111111-1111-1111-1111-111111111111';
         $template = $this->makeTemplate($ownerId);
+
+        $owner = $this->makeJwtUser(['block.create'], $ownerId);
+        auth()->setUser($owner);
+        $this->assertTrue($this->policy->createForTemplate($owner, $template));
 
         $user = $this->makeJwtUser(['block.create', 'template.update']);
         auth()->setUser($user);
-        $this->assertTrue($this->policy->createForTemplate($user, $template));
+        $this->assertFalse($this->policy->createForTemplate($user, $template));
 
-        $noSlug = $this->makeJwtUser(['template.update']);
+        $noSlug = $this->makeJwtUser(['template.update'], $ownerId);
         $this->assertFalse($this->policy->createForTemplate($noSlug, $template));
-
-        $docOnly = $this->makeJwtUser(['block.create', 'document.update']);
-        $this->assertFalse($this->policy->createForTemplate($docOnly, $template));
     }
 
     public function test_update_for_document_requires_document_companion(): void
@@ -132,10 +143,10 @@ class BlockPolicyTest extends TestCase
     /**
      * @param  list<string>  $permissions
      */
-    private function makeJwtUser(array $permissions): JwtUser
+    private function makeJwtUser(array $permissions, ?string $id = null): JwtUser
     {
         return new JwtUser([
-            'id' => '11111111-1111-1111-1111-111111111111',
+            'id' => $id ?? '11111111-1111-1111-1111-111111111111',
             'email' => null,
             'name' => null,
             'department' => null,

--- a/backend/tests/Unit/Policies/DocumentPolicyTest.php
+++ b/backend/tests/Unit/Policies/DocumentPolicyTest.php
@@ -11,6 +11,7 @@ use App\Models\JwtUser;
 use App\Models\Template;
 use App\Policies\DocumentPolicy;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use Tests\TestCase;
 
@@ -75,6 +76,42 @@ class DocumentPolicyTest extends TestCase
         );
 
         $this->assertFalse($this->policy->view($user, $doc));
+    }
+
+    public function test_view_denied_for_foreign_personal_document_with_published_snapshot(): void
+    {
+        $creatorId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+        $ownerId = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+        $peerId = '22222222-2222-2222-2222-222222222222';
+        auth()->setUser($this->makeJwtUser($peerId, ['document.show']));
+        $doc = $this->makeDocument(
+            createdBy: $creatorId,
+            ownerId: $ownerId,
+            status: 'published',
+            visibilityLevel: TemplateVisibilityLevel::Personal->value,
+        );
+
+        DB::table('entity_versions')->insert([
+            'id' => (string) Str::uuid(),
+            'versionable_type' => Document::class,
+            'versionable_id' => $doc->id,
+            'version_number' => 1,
+            'base_version_id' => null,
+            'change_set' => null,
+            'status' => 'published',
+            'created_by' => $creatorId,
+            'published_by' => $ownerId,
+            'published_at' => now(),
+            'changelog' => 'v1',
+            'snapshot_data' => json_encode(['document' => ['id' => $doc->id]], JSON_THROW_ON_ERROR),
+            'is_snapshot_immutable' => 1,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $peer = $this->makeJwtUser($peerId, ['document.show']);
+
+        $this->assertFalse($this->policy->view($peer, $doc));
     }
 
     public function test_review_denied_without_documents_review_permission(): void

--- a/backend/tests/Unit/Policies/TemplatePolicyTest.php
+++ b/backend/tests/Unit/Policies/TemplatePolicyTest.php
@@ -130,6 +130,40 @@ class TemplatePolicyTest extends TestCase
         $this->assertFalse($this->policy->view($user, $template));
     }
 
+    public function test_view_denied_for_foreign_personal_template_with_published_snapshot(): void
+    {
+        $creatorId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+        $peerId = 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+        auth()->setUser($this->makeJwtUser($peerId, ['template.show']));
+        $template = $this->makeTemplate(
+            createdBy: $creatorId,
+            status: 'published',
+            visibilityLevel: TemplateVisibilityLevel::Personal->value,
+        );
+
+        \Illuminate\Support\Facades\DB::table('entity_versions')->insert([
+            'id' => (string) \Illuminate\Support\Str::uuid(),
+            'versionable_type' => Template::class,
+            'versionable_id' => $template->id,
+            'version_number' => 1,
+            'base_version_id' => null,
+            'change_set' => null,
+            'status' => 'published',
+            'created_by' => $creatorId,
+            'published_by' => $creatorId,
+            'published_at' => now(),
+            'changelog' => 'v1',
+            'snapshot_data' => json_encode(['template' => ['id' => $template->id]], JSON_THROW_ON_ERROR),
+            'is_snapshot_immutable' => 1,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $peer = $this->makeJwtUser($peerId, ['template.show']);
+
+        $this->assertFalse($this->policy->view($peer, $template));
+    }
+
     public function test_creator_without_templates_review_permission_cannot_review_template(): void
     {
         $creatorId = '11111111-1111-1111-1111-111111111111';

--- a/frontend/src/features/templates/components/TemplateEditor.tsx
+++ b/frontend/src/features/templates/components/TemplateEditor.tsx
@@ -171,7 +171,10 @@ export function TemplateEditor({ template }: Props) {
   const navigate = useNavigate();
   const { t } = useTranslation('documents');
   const { blocks, loading, createBlock, updateBlock, reorderBlocks } =
-    useTemplateBlocks(template.id);
+    useTemplateBlocks(template.id, {
+      created_by: template.created_by,
+      status: template.status,
+    });
   const { isDark } = useDarkMode();
   const sensors = useSensors(useSensor(PointerSensor));
 

--- a/frontend/src/features/templates/components/TemplateReviewView.tsx
+++ b/frontend/src/features/templates/components/TemplateReviewView.tsx
@@ -312,7 +312,10 @@ export function TemplateReviewView({ template }: Props) {
   const location = useLocation();
   const backTo = (location.state as { backTo?: string } | null)?.backTo ?? '/dashboard';
   const { profile, hasPermission } = useUserProfile();
-  const { blocks } = useTemplateBlocks(template.id);
+  const { blocks } = useTemplateBlocks(template.id, {
+    created_by: template.created_by,
+    status: template.status,
+  });
   const queryClient = useQueryClient();
 
   const [activeView, setActiveView] = useState<ActiveView | null>(null);

--- a/frontend/src/features/templates/components/WizardStep2Blocks.tsx
+++ b/frontend/src/features/templates/components/WizardStep2Blocks.tsx
@@ -168,7 +168,10 @@ export const WizardStep2Blocks = React.forwardRef<WizardStep2BlocksHandle, Wizar
     updateBlock,
     deleteBlock,
     reorderBlocks
-  } = useTemplateBlocks(template.id);
+  } = useTemplateBlocks(template.id, {
+    created_by: template.created_by,
+    status: template.status,
+  });
 
   const { isDark: globalIsDark } = useDarkMode();
   const effectiveIsDark = isDark || globalIsDark;

--- a/frontend/src/features/templates/components/WizardStep4Summary.tsx
+++ b/frontend/src/features/templates/components/WizardStep4Summary.tsx
@@ -50,7 +50,10 @@ export function WizardStep4Summary({
   onBlocksLoadingChange,
   onBlocksChange,
 }: Props) {
-  const { blocks, loading } = useTemplateBlocks(template.id);
+  const { blocks, loading } = useTemplateBlocks(template.id, {
+    created_by: template.created_by,
+    status: template.status,
+  });
 
   useEffect(() => {
     onBlocksLoadingChange?.(loading);

--- a/frontend/src/features/templates/hooks/useTemplateBlocks.ts
+++ b/frontend/src/features/templates/hooks/useTemplateBlocks.ts
@@ -11,8 +11,9 @@ import { useUserProfile } from '../../user-profile';
 import {
   canCreateTemplateBlock,
   canDeleteTemplateBlock,
-  canListBlocks,
+  canListTemplateBlocks,
   canUpdateTemplateBlock,
+  type TemplateBlockPermissionContext,
 } from '../../../permissions';
 import type {
   CreateBlockPayload,
@@ -29,12 +30,15 @@ function formatError(err: unknown): string {
   return err instanceof Error ? err.message : 'Error desconocido';
 }
 
-export function useTemplateBlocks(templateId: string) {
-  const { hasPermission } = useUserProfile();
-  const mayListBlocks = canListBlocks(hasPermission);
-  const mayCreateBlock = canCreateTemplateBlock(hasPermission);
-  const mayUpdateBlock = canUpdateTemplateBlock(hasPermission);
-  const mayDeleteBlock = canDeleteTemplateBlock(hasPermission);
+export function useTemplateBlocks(
+  templateId: string,
+  templateContext?: TemplateBlockPermissionContext,
+) {
+  const { hasPermission, profile } = useUserProfile();
+  const mayListBlocks = canListTemplateBlocks(hasPermission, profile?.id, templateContext);
+  const mayCreateBlock = canCreateTemplateBlock(hasPermission, profile?.id, templateContext);
+  const mayUpdateBlock = canUpdateTemplateBlock(hasPermission, profile?.id, templateContext);
+  const mayDeleteBlock = canDeleteTemplateBlock(hasPermission, profile?.id, templateContext);
   const [blocks, setBlocks] = useState<TemplateBlock[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);

--- a/frontend/src/pages/TemplatePreviewPage.tsx
+++ b/frontend/src/pages/TemplatePreviewPage.tsx
@@ -24,7 +24,7 @@ import { Button, ConfirmDialog, statusBadgeClass } from '@ceedcv-maya/shared-ui-
 import { FavoriteButton } from '../components/FavoriteButton';
 import { VersionHistoryPanel } from '../components/VersionHistoryPanel';
 import { useUserProfile } from '../features/user-profile';
-import { canListBlocks, canDeleteBlockComment, DMS_PERMISSIONS } from '../permissions';
+import { canListTemplateBlocks, canDeleteBlockComment, DMS_PERMISSIONS } from '../permissions';
 import { isDiscardWorkingVersionAllowed } from '../utils/versionableEntityActions';
 import { useHierarchy } from '../features/hierarchy';
 import { BlockCommentsCard, ViewCardHeader } from '../features/templates/components/BlockCommentsCard';
@@ -108,7 +108,6 @@ export function TemplatePreviewPage() {
   };
 
   const { profile, hasPermission } = useUserProfile();
-  const mayListBlocks = canListBlocks(hasPermission);
 
   const [template, setTemplate] = useState<Template | null>(null);
   const [blocks, setBlocks] = useState<TemplateBlock[]>([]);
@@ -189,7 +188,8 @@ export function TemplatePreviewPage() {
           if (cancelled) return;
           const t = tRes.data;
           setTemplate(t);
-          if (mayListBlocks) {
+          const canListBlocks = canListTemplateBlocks(hasPermission, profile?.id, t);
+          if (canListBlocks) {
             const bRes = await fetchBlocks(id);
             if (!cancelled) {
               setBlocks(bRes.data.slice().sort((a, b) => (a.sort_order ?? 0) - (b.sort_order ?? 0)));
@@ -215,10 +215,7 @@ export function TemplatePreviewPage() {
     };
     void load();
     return () => { cancelled = true; };
-  // profile?.id was previously used in the loading condition but is no longer needed here;
-  // the backend handles authorization. Keeping it out of deps avoids a double-load flash.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [id, templateVersionId, mayListBlocks]);
+  }, [id, templateVersionId, hasPermission, profile?.id]);
 
   const handleSendMessage = async (parentId: string | null, body: string) => {
     if (!activeView?.blockId || !id) return;

--- a/frontend/src/permissions.ts
+++ b/frontend/src/permissions.ts
@@ -93,6 +93,12 @@ export function canDeleteTheme(
   return hasPermission(DMS_PERMISSIONS.themeDelete);
 }
 
+/** Contexto de plantilla padre para permisos de bloques (alineado con TemplatePolicy). */
+export type TemplateBlockPermissionContext = {
+  created_by?: string;
+  status?: string;
+};
+
 /** `block.index` / `block.show` requieren además mutación de plantilla o documento (catálogo). */
 export function canAccessBlockCatalog(hasPermission: (slug: string) => boolean): boolean {
   const hasMutation =
@@ -108,11 +114,53 @@ export function canListBlocks(hasPermission: (slug: string) => boolean): boolean
   return hasPermission(DMS_PERMISSIONS.blockIndex) && canAccessBlockCatalog(hasPermission);
 }
 
+/**
+ * Listar bloques de una plantilla concreta: `block.index` + vista sobre el padre.
+ * El creador de la plantilla no necesita slugs de catálogo de plantilla.
+ */
+export function canListTemplateBlocks(
+  hasPermission: (slug: string) => boolean,
+  profileId: string | undefined,
+  template?: TemplateBlockPermissionContext,
+): boolean {
+  if (!hasPermission(DMS_PERMISSIONS.blockIndex)) {
+    return false;
+  }
+
+  if (!template) {
+    return canAccessBlockCatalog(hasPermission);
+  }
+
+  if (profileId && template.created_by && profileId === template.created_by) {
+    return true;
+  }
+
+  return (
+    canAccessBlockCatalog(hasPermission) ||
+    hasPermission(DMS_PERMISSIONS.templateShow) ||
+    hasPermission(DMS_PERMISSIONS.documentCreate)
+  );
+}
+
 export function canShowBlockDetail(hasPermission: (slug: string) => boolean): boolean {
   return hasPermission(DMS_PERMISSIONS.blockShow) && canAccessBlockCatalog(hasPermission);
 }
 
-export function canMutateTemplateBlocks(hasPermission: (slug: string) => boolean): boolean {
+export function canMutateTemplateBlocks(
+  hasPermission: (slug: string) => boolean,
+  profileId?: string,
+  template?: TemplateBlockPermissionContext,
+): boolean {
+  if (
+    profileId &&
+    template?.created_by &&
+    profileId === template.created_by &&
+    template.status &&
+    (template.status === 'draft' || template.status === 'rejected')
+  ) {
+    return true;
+  }
+
   return (
     hasPermission(DMS_PERMISSIONS.templateCreate) || hasPermission(DMS_PERMISSIONS.templateUpdate)
   );
@@ -124,16 +172,37 @@ export function canMutateDocumentBlocks(hasPermission: (slug: string) => boolean
   );
 }
 
-export function canCreateTemplateBlock(hasPermission: (slug: string) => boolean): boolean {
-  return hasPermission(DMS_PERMISSIONS.blockCreate) && canMutateTemplateBlocks(hasPermission);
+export function canCreateTemplateBlock(
+  hasPermission: (slug: string) => boolean,
+  profileId?: string,
+  template?: TemplateBlockPermissionContext,
+): boolean {
+  return (
+    hasPermission(DMS_PERMISSIONS.blockCreate) &&
+    canMutateTemplateBlocks(hasPermission, profileId, template)
+  );
 }
 
-export function canUpdateTemplateBlock(hasPermission: (slug: string) => boolean): boolean {
-  return hasPermission(DMS_PERMISSIONS.blockUpdate) && canMutateTemplateBlocks(hasPermission);
+export function canUpdateTemplateBlock(
+  hasPermission: (slug: string) => boolean,
+  profileId?: string,
+  template?: TemplateBlockPermissionContext,
+): boolean {
+  return (
+    hasPermission(DMS_PERMISSIONS.blockUpdate) &&
+    canMutateTemplateBlocks(hasPermission, profileId, template)
+  );
 }
 
-export function canDeleteTemplateBlock(hasPermission: (slug: string) => boolean): boolean {
-  return hasPermission(DMS_PERMISSIONS.blockDelete) && canMutateTemplateBlocks(hasPermission);
+export function canDeleteTemplateBlock(
+  hasPermission: (slug: string) => boolean,
+  profileId?: string,
+  template?: TemplateBlockPermissionContext,
+): boolean {
+  return (
+    hasPermission(DMS_PERMISSIONS.blockDelete) &&
+    canMutateTemplateBlocks(hasPermission, profileId, template)
+  );
 }
 
 export function canUpdateDocumentBlock(hasPermission: (slug: string) => boolean): boolean {


### PR DESCRIPTION
Esta rama cierra un fallo de seguridad por el cual un usuario podía ver plantillas y documentos personales ajenos (incluso publicados) accediendo directamente a la URL de show o preview. Además corrige una inconsistencia de permisos que impedía al creador añadir bloques en su plantilla personal en borrador.
