### PR TITLE
fix(templates): sequential reject gate and pending stage query in rep…

### DIFF
--- a/backend/app/Repositories/Contracts/TemplateRepositoryInterface.php
+++ b/backend/app/Repositories/Contracts/TemplateRepositoryInterface.php
@@ -126,6 +126,11 @@ interface TemplateRepositoryInterface
     public function listPendingReviewInboxForUser(string $userId): Collection;
 
     /**
+     * Etapa mínima entre revisores de plantilla con status pending, o null si no hay pendientes.
+     */
+    public function minPendingReviewStageForTemplate(string $templateId): ?int;
+
+    /**
      * Ejecuta una operación dentro de transacción.
      */
     public function transaction(callable $callback): mixed;

--- a/backend/app/Repositories/Eloquent/TemplateRepository.php
+++ b/backend/app/Repositories/Eloquent/TemplateRepository.php
@@ -8,6 +8,7 @@ use App\DTOs\Templates\FilterTemplatesDto;
 use App\DTOs\Templates\TemplateFilterDto;
 use App\Models\Template;
 use App\Models\TemplateBlock;
+use App\Models\TemplateReviewer;
 use App\Policies\TemplatePolicy;
 use App\Repositories\Contracts\TemplateRepositoryInterface;
 use App\Support\SearchAccentFold;
@@ -656,6 +657,16 @@ class TemplateRepository implements TemplateRepositoryInterface
                 'review_stage' => (int) $row->stage,
             ];
         })->values();
+    }
+
+    public function minPendingReviewStageForTemplate(string $templateId): ?int
+    {
+        $min = TemplateReviewer::query()
+            ->where('template_id', $templateId)
+            ->where('status', 'pending')
+            ->min('stage');
+
+        return $min !== null ? (int) $min : null;
     }
 
     public function transaction(callable $callback): mixed

--- a/backend/app/Services/TemplatePublishingService.php
+++ b/backend/app/Services/TemplatePublishingService.php
@@ -7,6 +7,7 @@ namespace App\Services;
 use Maya\Messaging\Events\BroadcastNotificationCreated;
 use App\Events\TemplateStateChanged;
 use App\Models\Template;
+use App\Models\TemplateReviewer;
 use App\Repositories\Contracts\DocumentRepositoryInterface;
 use App\Repositories\Contracts\EntityVersionRepositoryInterface;
 use App\Repositories\Contracts\TemplateRepositoryInterface;
@@ -78,18 +79,7 @@ class TemplatePublishingService
 
             $reviewer = $template->reviewers()->where('user_id', $actorId)->first();
 
-            if ($reviewer && $template->review_mode === 'sequential') {
-                $pendingPreviousStage = $template->reviewers()
-                    ->where('stage', '<', $reviewer->stage)
-                    ->where('status', '!=', 'approved')
-                    ->exists();
-
-                if ($pendingPreviousStage) {
-                    throw ValidationException::withMessages([
-                        'stage' => ['Debes esperar a que los revisores de etapas anteriores aprueben primero.'],
-                    ]);
-                }
-            }
+            $this->assertSequentialReviewerMayPublish($template, $reviewer);
 
             $template->load([
                 'blocks' => fn ($q) => $q->orderBy('sort_order'),
@@ -322,5 +312,26 @@ class TemplatePublishingService
 
             return $updated;
         });
+    }
+
+    /**
+     * En revisión secuencial, solo publica el revisor de la etapa pendiente activa.
+     */
+    private function assertSequentialReviewerMayPublish(Template $template, ?TemplateReviewer $reviewer): void
+    {
+        if ($reviewer === null || $template->review_mode !== 'sequential') {
+            return;
+        }
+
+        $minStage = $this->templateRepository->minPendingReviewStageForTemplate($template->id);
+        if ($minStage === null) {
+            return;
+        }
+
+        if ((int) $reviewer->stage !== $minStage) {
+            throw ValidationException::withMessages([
+                'stage' => ['Debes esperar a que los revisores de etapas anteriores aprueben primero.'],
+            ]);
+        }
     }
 }

--- a/backend/app/Services/TemplateReviewService.php
+++ b/backend/app/Services/TemplateReviewService.php
@@ -63,8 +63,6 @@ class TemplateReviewService
                 $headVersion->update(['change_set' => $cycles]);
             }
 
-            $template->reviewers()->update(['status' => 'pending']);
-
             $hasEditableBlock = $template->blocks->contains(
                 fn ($b) => in_array((string) $b->block_state, ['editable', 'modifiable'], true)
             );
@@ -148,6 +146,8 @@ class TemplateReviewService
 
     /**
      * Rechaza la revisión de la plantilla.
+     *
+     * En modo secuencial solo puede actuar el revisor de la etapa pendiente activa.
      */
     public function rejectReview(string $templateId, string $actorId): Template
     {
@@ -173,6 +173,8 @@ class TemplateReviewService
                     'status' => ['No puedes rechazar una plantilla que ya has aprobado.'],
                 ]);
             }
+
+            $this->assertSequentialReviewAllowsActing($template, $reviewer);
 
             $template->reviewers()
                 ->where('user_id', $actorId)
@@ -237,18 +239,7 @@ class TemplateReviewService
                 ]);
             }
 
-            if ($template->review_mode === 'sequential') {
-                $pendingPreviousStage = $template->reviewers()
-                    ->where('stage', '<', $reviewer->stage)
-                    ->where('status', '!=', 'approved')
-                    ->exists();
-
-                if ($pendingPreviousStage) {
-                    throw ValidationException::withMessages([
-                        'stage' => ['Debes esperar a que los revisores de etapas anteriores aprueben primero.'],
-                    ]);
-                }
-            }
+            $this->assertSequentialReviewAllowsActing($template, $reviewer);
 
             $template->reviewers()
                 ->where('user_id', $actorId)
@@ -273,6 +264,27 @@ class TemplateReviewService
 
             return $fresh ?? $template;
         });
+    }
+
+    /**
+     * En revisión secuencial, solo actúa el revisor cuya etapa no tiene pendientes anteriores.
+     */
+    private function assertSequentialReviewAllowsActing(Template $template, TemplateReviewer $reviewer): void
+    {
+        if ($template->review_mode !== 'sequential') {
+            return;
+        }
+
+        $minStage = $this->templateRepository->minPendingReviewStageForTemplate($template->id);
+        if ($minStage === null) {
+            return;
+        }
+
+        if ((int) $reviewer->stage !== $minStage) {
+            throw ValidationException::withMessages([
+                'stage' => ['Debes esperar a que los revisores de etapas anteriores aprueben primero.'],
+            ]);
+        }
     }
 
     private function notifyTemplateValidationRequested(Template $template): void

--- a/backend/tests/Feature/TemplateReviewServiceEdgeCasesApiTest.php
+++ b/backend/tests/Feature/TemplateReviewServiceEdgeCasesApiTest.php
@@ -30,6 +30,7 @@ use Tests\TestCase;
  *   - submitForReview: repeated submit updates blocks_submission_history
  *   - rejectReview: template not in_review but reviewer is assigned → 422 (service guards)
  *   - rejectReview: reviewer already approved → 422
+ *   - rejectReview: sequential mode, previous stage not yet approved → 422
  *   - approveReview: template not in_review but reviewer is assigned → 422
  *   - approveReview: reviewer already approved → 422
  *   - approveReview: sequential mode, previous stage not yet approved → 422
@@ -334,6 +335,52 @@ class TemplateReviewServiceEdgeCasesApiTest extends TestCase
         $this->postJson("/api/v1/templates/{$templateId}/reject-review", [], $headersReviewer)
             ->assertUnprocessable()
             ->assertJsonPath('errors.status.0', fn ($v) => str_contains($v, 'aprobado'));
+    }
+
+    public function test_reject_review_returns_422_in_sequential_mode_when_previous_stage_not_approved(): void
+    {
+        $ownerId     = (string) Str::uuid();
+        $reviewer1Id = (string) Str::uuid();
+        $reviewer2Id = (string) Str::uuid();
+
+        auth()->forgetUser();
+        $this->assignUserPermissions($ownerId, ['template.show']);
+        $this->assignUserPermissions($reviewer1Id, ['template.show', 'template.review']);
+        $this->assignUserPermissions($reviewer2Id, ['template.show', 'template.review']);
+
+        [$privatePem, $publicPem] = $this->generateRsaKeyPairForTests();
+
+        $this->mock(JwksServiceInterface::class)
+            ->shouldReceive('getPublicKey')
+            ->andReturn($publicPem);
+
+        $tokenOwner     = $this->buildJwtForSub($privatePem, $publicPem, 'kid-o-'.substr($ownerId, 0, 8), $ownerId, 'test-issuer', 'test-audience');
+        $tokenReviewer2 = $this->buildJwtForSub($privatePem, $publicPem, 'kid-r2-'.substr($reviewer2Id, 0, 8), $reviewer2Id, 'test-issuer', 'test-audience');
+
+        $headersOwner     = ['Authorization' => 'Bearer '.$tokenOwner];
+        $headersReviewer2 = ['Authorization' => 'Bearer '.$tokenReviewer2];
+
+        $templateId = (string) Str::uuid();
+        Template::query()->forceCreate([
+            'id'               => $templateId,
+            'name'             => 'Sequential Template Reject',
+            'description'      => null,
+            'visibility_level' => TemplateVisibilityLevel::Personal->value,
+            'created_by'       => $ownerId,
+            'status'           => 'draft',
+            'review_stages'    => 0,
+            'review_mode'      => 'sequential',
+        ]);
+
+        $this->addEditableBlock($templateId);
+        $this->addReviewer($templateId, $reviewer1Id, stage: 1);
+        $this->addReviewer($templateId, $reviewer2Id, stage: 2);
+
+        $this->postJson("/api/v1/templates/{$templateId}/submit-review", [], $headersOwner)->assertOk();
+
+        $this->postJson("/api/v1/templates/{$templateId}/reject-review", [], $headersReviewer2)
+            ->assertUnprocessable()
+            ->assertJsonPath('errors.stage.0', fn ($v) => str_contains($v, 'etapas anteriores'));
     }
 
     // ─── approveReview — error paths ──────────────────────────────────────────


### PR DESCRIPTION
1. Notificaciones solo al enviar a revisión:
   - Eliminadas notificaciones al sincronizar revisores de plantilla o pool de validadores de documento.
   - Los avisos *.validation_requested se envían en submitForReview / submitToReview.
   
2. Notificaciones y modos alineados:
   - ReviewValidationNotificationRecipients: en ordenada solo la etapa mínima; en libre todos los pendientes.
   - Resolución del modo desde plantilla live (no desde snapshot anclado fantasma).
   
3. Modos independientes plantilla / documento:
   - review_mode → validación de plantilla
   - document_review_mode → validación de documentos (fallback a review_mode)
   - Propagado en snapshots, DTOs, API, wizard de plantilla y documento.

4. Stage en validadores de documento:
   - Columna stage en template_document_reviewers (migración base).
   - Sync, publish, clone/restore, seeders y creación de document_reviews con etapa explícita.
   - Fallback legacy para snapshots sin stage.

5. Robustez del flujo de revisión de documentos:
   - Congelación de review_mode en cabecera del documento mientras está in_review.
   - Bandeja de validación usa modo efectivo (COALESCE cabecera documento + plantilla).
   - Sin re-notificación en modo libre tras aprobaciones parciales (plantilla y documento).

6. Paridad plantilla en rechazo secuencial:
   - rejectReview exige etapa activa (como aprobar y como documentos).
   - minPendingReviewStageForTemplate en repositorio; reutilizado en TemplateReviewService y TemplatePublishingService.
   - Eliminado reset prematuro de revisores en submitForReview (evita side effects si falla validación).