### PR TITLE
Feature/eliminar procesos plantillas documentos

### DIFF
--- a/backend/app/DTOs/Processes/ProcessDeletionPreviewDto.php
+++ b/backend/app/DTOs/Processes/ProcessDeletionPreviewDto.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTOs\Processes;
+
+/**
+ * Conteo de dependientes afectados por el borrado de un proceso.
+ * Vista de valor que devuelve el Service al Controller para confirmar la acción.
+ */
+final class ProcessDeletionPreviewDto
+{
+    public function __construct(
+        public readonly int $templatesCount,
+        public readonly int $documentsCount,
+        public readonly int $subprocessCount,
+    ) {}
+
+    /**
+     * @param  array{templates_count: int, documents_count: int, subprocess_count: int}  $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            templatesCount: (int) ($data['templates_count'] ?? 0),
+            documentsCount: (int) ($data['documents_count'] ?? 0),
+            subprocessCount: (int) ($data['subprocess_count'] ?? 0),
+        );
+    }
+
+    /**
+     * @return array{templates_count: int, documents_count: int, subprocess_count: int}
+     */
+    public function toArray(): array
+    {
+        return [
+            'templates_count' => $this->templatesCount,
+            'documents_count' => $this->documentsCount,
+            'subprocess_count' => $this->subprocessCount,
+        ];
+    }
+}

--- a/backend/app/Http/Controllers/Api/ProcessController.php
+++ b/backend/app/Http/Controllers/Api/ProcessController.php
@@ -10,6 +10,7 @@ use App\Http\Requests\Processes\IndexProcessRequest;
 use App\Http\Requests\Processes\ShowProcessRequest;
 use App\Http\Requests\Processes\StoreProcessRequest;
 use App\Http\Requests\Processes\UpdateProcessRequest;
+use App\Http\Resources\ProcessDeletionPreviewResource;
 use App\Http\Resources\ProcessResource;
 use App\Services\Contracts\ProcessServiceInterface;
 use Illuminate\Http\JsonResponse;
@@ -44,6 +45,11 @@ class ProcessController extends Controller
     public function update(UpdateProcessRequest $request, string $process): ProcessResource
     {
         return new ProcessResource($this->processService->update($process, $request->toDto()));
+    }
+
+    public function deletionPreview(DestroyProcessRequest $request, string $process): ProcessDeletionPreviewResource
+    {
+        return new ProcessDeletionPreviewResource($this->processService->deletionPreview($process));
     }
 
     public function destroy(DestroyProcessRequest $request, string $process): Response

--- a/backend/app/Http/Resources/ProcessDeletionPreviewResource.php
+++ b/backend/app/Http/Resources/ProcessDeletionPreviewResource.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use App\DTOs\Processes\ProcessDeletionPreviewDto;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @property ProcessDeletionPreviewDto $resource
+ */
+class ProcessDeletionPreviewResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        /** @var ProcessDeletionPreviewDto $dto */
+        $dto = $this->resource;
+
+        return [
+            'templates_count' => $dto->templatesCount,
+            'documents_count' => $dto->documentsCount,
+            'subprocess_count' => $dto->subprocessCount,
+        ];
+    }
+}

--- a/backend/app/Models/Process.php
+++ b/backend/app/Models/Process.php
@@ -9,10 +9,13 @@ use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 #[ObservedBy(ProcessObserver::class)]
 class Process extends Model
 {
+    use SoftDeletes;
+
     protected $table = 'processes';
 
     public $incrementing = false;

--- a/backend/app/Observers/ProcessObserver.php
+++ b/backend/app/Observers/ProcessObserver.php
@@ -23,7 +23,7 @@ final class ProcessObserver extends AbstractAuditableModelObserver
     /** @return list<string> */
     protected function auditTemporalKeys(): array
     {
-        return ['created_at', 'updated_at'];
+        return ['created_at', 'updated_at', 'deleted_at'];
     }
 
     protected function resolveAuditUserId(Model $model): string

--- a/backend/app/Repositories/Contracts/ProcessRepositoryInterface.php
+++ b/backend/app/Repositories/Contracts/ProcessRepositoryInterface.php
@@ -32,7 +32,12 @@ interface ProcessRepositoryInterface
 
     public function delete(string $id): void;
 
-    public function hasDependents(string $processId): bool;
+    public function hasSubprocesses(string $processId): bool;
+
+    /**
+     * @return array{templates_count: int, documents_count: int, subprocess_count: int}
+     */
+    public function deletionCounts(string $processId): array;
 
     /**
      * @param  array{search?: string, parent_id?: string}  $filters

--- a/backend/app/Repositories/Eloquent/ProcessRepository.php
+++ b/backend/app/Repositories/Eloquent/ProcessRepository.php
@@ -6,11 +6,14 @@ namespace App\Repositories\Eloquent;
 
 use App\DTOs\Processes\CreateProcessDto;
 use App\DTOs\Processes\UpdateProcessDto;
+use App\Models\Document;
 use App\Models\Process;
+use App\Models\Template;
 use App\Repositories\Contracts\ProcessRepositoryInterface;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Pagination\LengthAwarePaginator as ConcretePaginator;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 
 class ProcessRepository implements ProcessRepositoryInterface
@@ -85,21 +88,74 @@ class ProcessRepository implements ProcessRepositoryInterface
         return $this->toRow($process);
     }
 
+    /**
+     * Soft-delete del proceso y, en cascada, de sus plantillas y documentos.
+     *
+     * No se borran las filas hijas de cada plantilla/documento (bloques, versiones,
+     * comentarios, etc.): quedan accesibles solo a través del padre soft-deleted,
+     * que es la semántica habitual de soft delete en el proyecto.
+     */
     public function delete(string $id): void
     {
-        Process::destroy($id);
+        DB::transaction(function () use ($id): void {
+            $this->templatesQueryForProcess($id)
+                ->get()
+                ->each(fn (Template $template) => $template->delete());
+
+            $this->documentsQueryForProcess($id)
+                ->get()
+                ->each(fn (Document $document) => $document->delete());
+
+            Process::query()->whereKey($id)->first()?->delete();
+        });
     }
 
-    public function hasDependents(string $processId): bool
+    public function hasSubprocesses(string $processId): bool
     {
         return Process::query()
-            ->whereKey($processId)
-            ->where(function ($q) {
-                $q->whereHas('children')
-                    ->orWhereHas('templates')
-                    ->orWhereHas('documents');
-            })
+            ->where('process_parent_id', $processId)
             ->exists();
+    }
+
+    /**
+     * Conteo de dependientes afectados por el borrado, sobre TODAS las filas
+     * (sin scopes de visibilidad por usuario), porque el borrado las afecta a todas.
+     *
+     * @return array{templates_count: int, documents_count: int, subprocess_count: int}
+     */
+    public function deletionCounts(string $processId): array
+    {
+        return [
+            'templates_count' => $this->templatesQueryForProcess($processId)->count(),
+            'documents_count' => $this->documentsQueryForProcess($processId)->count(),
+            'subprocess_count' => Process::query()
+                ->where('process_parent_id', $processId)
+                ->count(),
+        ];
+    }
+
+    /**
+     * Plantillas del proceso sin los scopes de visibilidad/join de cabezal
+     * (mantiene el scope de soft delete para excluir las ya eliminadas).
+     *
+     * @return \Illuminate\Database\Eloquent\Builder<Template>
+     */
+    private function templatesQueryForProcess(string $processId)
+    {
+        return Template::withoutGlobalScopes(['join_head_entity_version', 'user_access'])
+            ->where('process_id', $processId);
+    }
+
+    /**
+     * Documentos del proceso sin los scopes de visibilidad/join de cabezal
+     * (mantiene el scope de soft delete para excluir los ya eliminados).
+     *
+     * @return \Illuminate\Database\Eloquent\Builder<Document>
+     */
+    private function documentsQueryForProcess(string $processId)
+    {
+        return Document::withoutGlobalScopes(['join_head_document_entity_version', 'user_access'])
+            ->where('process_id', $processId);
     }
 
     /**

--- a/backend/app/Services/Contracts/ProcessServiceInterface.php
+++ b/backend/app/Services/Contracts/ProcessServiceInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Services\Contracts;
 
 use App\DTOs\Processes\CreateProcessDto;
+use App\DTOs\Processes\ProcessDeletionPreviewDto;
 use App\DTOs\Processes\UpdateProcessDto;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 
@@ -31,6 +32,11 @@ interface ProcessServiceInterface
     public function update(string $id, UpdateProcessDto $dto): array;
 
     public function delete(string $id): void;
+
+    /**
+     * Conteo de dependientes afectados por el borrado del proceso.
+     */
+    public function deletionPreview(string $id): ProcessDeletionPreviewDto;
 
     /**
      * @param  array{search?: string, parent_id?: string}  $filters

--- a/backend/app/Services/ProcessService.php
+++ b/backend/app/Services/ProcessService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Services;
 
 use App\DTOs\Processes\CreateProcessDto;
+use App\DTOs\Processes\ProcessDeletionPreviewDto;
 use App\DTOs\Processes\UpdateProcessDto;
 use App\Models\Process;
 use App\Repositories\Contracts\ProcessRepositoryInterface;
@@ -69,12 +70,19 @@ class ProcessService implements ProcessServiceInterface
     {
         $this->findOrFail($id);
 
-        if ($this->repository->hasDependents($id)) {
+        if ($this->repository->hasSubprocesses($id)) {
             throw new ConflictHttpException(
-                'No se puede eliminar un proceso con subprocesos, plantillas o documentos asociados.',
+                'No se puede eliminar un proceso con subprocesos. Elimina o reubica primero sus subprocesos.',
             );
         }
 
         $this->repository->delete($id);
+    }
+
+    public function deletionPreview(string $id): ProcessDeletionPreviewDto
+    {
+        $this->findOrFail($id);
+
+        return ProcessDeletionPreviewDto::fromArray($this->repository->deletionCounts($id));
     }
 }

--- a/backend/database/migrations/0001_00_00_000001_000002_create_processes_table.php
+++ b/backend/database/migrations/0001_00_00_000001_000002_create_processes_table.php
@@ -20,6 +20,7 @@ return new class extends Migration
             $table->string('icon', 40)->nullable();
             $table->string('color', 7)->nullable();
             $table->timestamps();
+            $table->softDeletes();
 
             $table->index('process_parent_id');
         });

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -75,6 +75,7 @@ Route::prefix('v1')->group(function () {
         Route::post('/processes', [ProcessController::class, 'store']);
         Route::get('/processes/{process}', [ProcessController::class, 'show'])->whereUuid('process');
         Route::match(['put', 'patch'], '/processes/{process}', [ProcessController::class, 'update'])->whereUuid('process');
+        Route::get('/processes/{process}/deletion-preview', [ProcessController::class, 'deletionPreview'])->whereUuid('process');
         Route::delete('/processes/{process}', [ProcessController::class, 'destroy'])->whereUuid('process');
 
         // Media — subida de imágenes para bloques BlockNote

--- a/backend/tests/Feature/Api/ProcessCrudBusinessTest.php
+++ b/backend/tests/Feature/Api/ProcessCrudBusinessTest.php
@@ -49,6 +49,37 @@ function insertProcess(string $code = 'PX01', ?string $parentId = null): string
     return $id;
 }
 
+/**
+ * Inserta una plantilla mínima (sin cabezal) anclada al proceso. Suficiente para
+ * verificar conteo y cascada de soft delete sin construir el snapshot completo.
+ */
+function insertTemplate(string $processId): string
+{
+    $id = (string) Str::uuid();
+    DB::table('templates')->insert([
+        'id' => $id,
+        'process_id' => $processId,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    return $id;
+}
+
+function insertDocument(string $processId, string $templateId): string
+{
+    $id = (string) Str::uuid();
+    DB::table('documents')->insert([
+        'id' => $id,
+        'process_id' => $processId,
+        'template_id' => $templateId,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    return $id;
+}
+
 // ─── store (POST) ─────────────────────────────────────────────────────────────
 
 it('store returns 201 with the created process', function () {
@@ -174,12 +205,46 @@ it('destroy returns 404 for non-existent process', function () {
     $this->deleteJson('/api/v1/processes/'.Str::uuid())->assertNotFound();
 });
 
-it('destroy returns 204 for a process with no dependents', function () {
+it('destroy soft-deletes a process with no dependents', function () {
     $id = insertProcess('PDEL01');
 
     $this->deleteJson("/api/v1/processes/{$id}")->assertNoContent();
 
-    $this->assertDatabaseMissing('processes', ['id' => $id]);
+    $this->assertSoftDeleted('processes', ['id' => $id]);
+});
+
+it('destroy cascades soft-delete to the process templates and documents', function () {
+    $processId = insertProcess('PCASC01');
+    $templateId = insertTemplate($processId);
+    $documentId = insertDocument($processId, $templateId);
+
+    $this->deleteJson("/api/v1/processes/{$processId}")->assertNoContent();
+
+    $this->assertSoftDeleted('processes', ['id' => $processId]);
+    $this->assertSoftDeleted('templates', ['id' => $templateId]);
+    $this->assertSoftDeleted('documents', ['id' => $documentId]);
+});
+
+it('deletion-preview returns the count of affected dependents', function () {
+    $processId = insertProcess('PPREV01');
+    $templateId = insertTemplate($processId);
+    insertTemplate($processId);
+    insertDocument($processId, $templateId);
+
+    $this->getJson("/api/v1/processes/{$processId}/deletion-preview")
+        ->assertOk()
+        ->assertJsonPath('data.templates_count', 2)
+        ->assertJsonPath('data.documents_count', 1)
+        ->assertJsonPath('data.subprocess_count', 0);
+});
+
+it('deletion-preview counts subprocesses', function () {
+    $parentId = insertProcess('PPREV_PARENT');
+    insertProcess('PPREV_CHILD', $parentId);
+
+    $this->getJson("/api/v1/processes/{$parentId}/deletion-preview")
+        ->assertOk()
+        ->assertJsonPath('data.subprocess_count', 1);
 });
 
 it('destroy returns 409 when process has child processes', function () {

--- a/backend/tests/Feature/Api/ProcessPermissionsTest.php
+++ b/backend/tests/Feature/Api/ProcessPermissionsTest.php
@@ -136,3 +136,19 @@ it('allows process delete with process.delete when no dependents', function () {
 
     $this->deleteJson("/api/v1/processes/{$id}")->assertNoContent();
 });
+
+it('denies deletion-preview without process.delete', function () {
+    grantProcessPermission('process.show');
+    $id = insertTestProcess('PX09');
+
+    $this->getJson("/api/v1/processes/{$id}/deletion-preview")->assertForbidden();
+});
+
+it('allows deletion-preview with process.delete', function () {
+    grantProcessPermission('process.delete');
+    $id = insertTestProcess('PX10');
+
+    $this->getJson("/api/v1/processes/{$id}/deletion-preview")
+        ->assertOk()
+        ->assertJsonStructure(['data' => ['templates_count', 'documents_count', 'subprocess_count']]);
+});

--- a/frontend/src/api/processes.ts
+++ b/frontend/src/api/processes.ts
@@ -1,4 +1,4 @@
-import type { Process } from '../types/processes';
+import type { Process, ProcessDeletionPreview } from '../types/processes';
 import { apiFetchJson, apiGetJson } from './http';
 
 /** GET /api/v1/processes — catálogo de procesos disponibles. */
@@ -29,6 +29,13 @@ export async function createProcess(payload: ProcessPayload): Promise<{ data: Pr
 /** PATCH /api/v1/processes/:id */
 export async function updateProcess(id: string, payload: ProcessPayload): Promise<{ data: Process }> {
   return apiFetchJson<{ data: Process }>(`processes/${id}`, { method: 'PATCH', body: payload });
+}
+
+/** GET /api/v1/processes/:id/deletion-preview — conteo de dependientes afectados. */
+export async function fetchProcessDeletionPreview(
+  id: string,
+): Promise<{ data: ProcessDeletionPreview }> {
+  return apiGetJson<{ data: ProcessDeletionPreview }>(`processes/${id}/deletion-preview`);
 }
 
 /** DELETE /api/v1/processes/:id */

--- a/frontend/src/features/processes/pages/ProcessShowPage.tsx
+++ b/frontend/src/features/processes/pages/ProcessShowPage.tsx
@@ -8,7 +8,13 @@ import { Alert, Button, ConfirmDialog, PageTitle, useConfirm } from '@ceedcv-may
 import { useUserProfile } from '../../user-profile';
 import { useProcessesQuery } from '../../../hooks/useProcesses';
 import { DMS_PERMISSIONS } from '../../../permissions';
-import { fetchProcess, createProcess, deleteProcess, updateProcess } from '../../../api/processes';
+import {
+  fetchProcess,
+  createProcess,
+  deleteProcess,
+  fetchProcessDeletionPreview,
+  updateProcess,
+} from '../../../api/processes';
 import { ColorBadge } from '../components/ColorBadge';
 import { getProcessIcon, PROCESS_ICON_SLUGS } from '../../../components/layout/processIcons';
 import { formatError } from '../utils/formatError';
@@ -41,7 +47,16 @@ export function ProcessShowPage() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const { hasPermission } = useUserProfile();
-  const { confirmState, confirm, closeConfirm } = useConfirm();
+  const {
+    confirmState: deleteConfirmState,
+    confirm: confirmDelete,
+    closeConfirm: closeDeleteConfirm,
+  } = useConfirm();
+  const {
+    confirmState: impactConfirmState,
+    confirm: confirmImpact,
+    closeConfirm: closeImpactConfirm,
+  } = useConfirm();
 
   const [editing, setEditing] = useState(isCreate);
   const [actionError, setActionError] = useState<string | null>(null);
@@ -133,6 +148,69 @@ export function ProcessShowPage() {
     }
   };
 
+  const plural = (n: number, singular: string, pluralForm: string) =>
+    `${n} ${n === 1 ? singular : pluralForm}`;
+
+  // Paso 1: confirmación genérica. Tras aceptar, se consulta el impacto y se
+  // decide si bloquear (subprocesos), pedir 2.ª confirmación (con dependientes)
+  // o eliminar directamente (sin dependientes).
+  const openDeleteFlow = () => {
+    if (!data) return;
+    confirmDelete({
+      title: 'Eliminar proceso',
+      description: `¿Está seguro de que quiere eliminar "${data.name}" (${data.code})?`,
+      confirmLabel: 'Sí, continuar',
+      variant: 'danger',
+      onConfirm: () => evaluateDeletionImpact(),
+    });
+  };
+
+  const evaluateDeletionImpact = async () => {
+    if (!data) return;
+    try {
+      setActionError(null);
+      const { data: preview } = await fetchProcessDeletionPreview(data.id);
+
+      if (preview.subprocess_count > 0) {
+        confirmImpact({
+          title: 'No se puede eliminar',
+          description: `Este proceso tiene ${plural(
+            preview.subprocess_count,
+            'subproceso',
+            'subprocesos',
+          )}. Elimina o reubica primero sus subprocesos.`,
+          confirmLabel: 'Entendido',
+          variant: 'primary',
+          onConfirm: () => {},
+        });
+        return;
+      }
+
+      if (preview.templates_count > 0 || preview.documents_count > 0) {
+        confirmImpact({
+          title: 'Confirmar eliminación',
+          description: `Al borrar este proceso borrarás ${plural(
+            preview.templates_count,
+            'plantilla',
+            'plantillas',
+          )} y ${plural(
+            preview.documents_count,
+            'documento',
+            'documentos',
+          )}. ¿Estás seguro?`,
+          confirmLabel: 'Eliminar definitivamente',
+          variant: 'danger',
+          onConfirm: () => handleDelete(),
+        });
+        return;
+      }
+
+      await handleDelete();
+    } catch (e) {
+      setActionError(formatError(e));
+    }
+  };
+
   const handleCancelEdit = () => {
     if (isCreate) {
       navigate('/admin/procesos');
@@ -198,15 +276,7 @@ export function ProcessShowPage() {
                     type="button"
                     variant="danger"
                     size="sm"
-                    onClick={() =>
-                      confirm({
-                        title: 'Eliminar proceso',
-                        description: `¿Eliminar "${data.name}" (${data.code})? Esta acción no se puede deshacer.`,
-                        confirmLabel: 'Eliminar',
-                        variant: 'danger',
-                        onConfirm: () => void handleDelete(),
-                      })
-                    }
+                    onClick={openDeleteFlow}
                   >
                     Eliminar
                   </Button>
@@ -474,7 +544,8 @@ export function ProcessShowPage() {
         </>
       )}
 
-      <ConfirmDialog {...confirmState} onCancel={closeConfirm} />
+      <ConfirmDialog {...deleteConfirmState} onCancel={closeDeleteConfirm} />
+      <ConfirmDialog {...impactConfirmState} onCancel={closeImpactConfirm} />
     </div>
   );
 }

--- a/frontend/src/types/processes.ts
+++ b/frontend/src/types/processes.ts
@@ -18,3 +18,10 @@ export type Process = {
   description: string | null;
   process_parent_id: string | null;
 };
+
+/** Conteo de dependientes afectados al eliminar un proceso. */
+export type ProcessDeletionPreview = {
+  templates_count: number;
+  documents_count: number;
+  subprocess_count: number;
+};


### PR DESCRIPTION
Se rehace el borrado de procesos/subprocesos en el DMS para permitir eliminar procesos que contienen plantillas y documentos (antes lo bloqueaba), aplicando soft delete en cascada y una confirmación en dos pasos en la interfaz.
- El proceso pasa a ser soft-deletable; al eliminarlo se hace soft delete en cascada de sus plantillas y documentos.
- Solo se bloquea el borrado si el proceso tiene subprocesos (hay que eliminarlos o reubicarlos primero).
- Nuevo endpoint `GET /processes/{process}/deletion-preview` que devuelve el número de plantillas, documentos y subprocesos afectados.
- En la UI, al pulsar "Eliminar" se muestra un primer cartel de confirmación y, si hay plantillas/documentos, un segundo cartel con el conteo; si hay subprocesos se informa del bloqueo.


Requiere recrear el esquema del DMS porque se modificó la migración existente.