### PR TITLE
fix:document'd editable blocks load default

### DIFF
--- a/backend/app/Services/DocumentBlockService.php
+++ b/backend/app/Services/DocumentBlockService.php
@@ -177,7 +177,7 @@ class DocumentBlockService
             $this->appendModifiableBlockVersionSnapshotsIfNeeded($document, $block, $definition, $dto);
 
             $isFilled = $isStructuralFill
-                ? ($dto->content !== null && $dto->content !== [])
+                ? ($dto->content !== null)
                 : $this->isContentFilled($dto->content);
             if (! $isStructuralFill && $state === 'editable') {
                 $default = $definition['default_content'] ?? null;

--- a/frontend/src/features/documents/components/DocumentWizard.tsx
+++ b/frontend/src/features/documents/components/DocumentWizard.tsx
@@ -1066,7 +1066,7 @@ export function DocumentWizard({ documentId, templateId, mode = 'edit', sourceDo
     );
     if (!block) return;
 
-    const editorBaseline = normalizeBlockContentForEditor(block.content);
+    const editorBaseline = normalizeBlockContentForEditor(activeBlock.content);
     applyLocalContent(editorBaseline);
     // Misma base que muestra el editor (content persistido o default_content de plantilla).
     lastSavedContentRef.current = editorBaseline;
@@ -2436,7 +2436,7 @@ export function DocumentWizard({ documentId, templateId, mode = 'edit', sourceDo
                               key={activeBlockKey ?? 'none'}
                             >
                               <BlockNoteEditorPanel
-                                initialContent={normalizeBlockContentForEditor(activeBlock.content)}
+                                initialContent={normalizeBlockContentForEditor(activeBlock.content ?? activeBlock.default_content)}
                                 editable
                                 isDark={isDark}
                                 onChange={handleDocumentContentChange}


### PR DESCRIPTION
fix document's editable block in develop2
It was not loading default content on editor due:
1-Block.content is null when document is created, instead it should use default_content in editor. Therefore now -> block.content ?? block.default_content
2-Backend was not allowing to save empty arrays if you try it, it loaded last saved data. Now -> allows save empty array but red dot does not allow to continue 
if (empty || content === default_content)